### PR TITLE
Fix release-build blank screen on launch (v0.4.6)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,15 +10,30 @@ import 'widget/widget_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  // iOS: register the CoreBluetooth-restoration wake handler. On a background
-  // relaunch this runs too, so a band-triggered wake reaches runHeadlessSync.
-  await IosBleRestore.init();
-  await WidgetService.init();
-  await NotificationService.instance.init(); // sets up the notif plugin + channel
+
+  // Optional startup services. A failure in any one of these must NEVER block the
+  // first frame — they are awaited before runApp, so an unguarded throw (e.g. the
+  // flutter_local_notifications `invalid_icon` crash) leaves the app stuck on the
+  // native launch screen (blank/icon). Guard each so the UI always boots.
+  // iOS: registers the CoreBluetooth-restoration wake handler (no-op on Android).
+  await _safeInit('IosBleRestore', IosBleRestore.init);
+  await _safeInit('WidgetService', WidgetService.init);
+  await _safeInit('NotificationService', NotificationService.instance.init);
 
   // Resolve appearance (persisted choice + OS brightness) BEFORE the first frame
   // so login/signup already paint in the right mode (Ember on Paper / Char).
-  final theme = await ThemeController.bootstrap();
+  // Fall back to a system-brightness controller if persistence fails.
+  ThemeController theme;
+  try {
+    theme = await ThemeController.bootstrap();
+  } catch (e, st) {
+    debugPrint('[main] ThemeController.bootstrap failed, using default: $e\n$st');
+    theme = ThemeController.seed(
+      AppThemeChoice.system,
+      WidgetsBinding.instance.platformDispatcher.platformBrightness,
+    );
+  }
+
   runApp(
     MultiProvider(
       providers: [
@@ -28,4 +43,14 @@ Future<void> main() async {
       child: const OpenStrapApp(),
     ),
   );
+}
+
+/// Run an optional startup init, swallowing (but logging) any failure so it can
+/// never prevent runApp from being reached.
+Future<void> _safeInit(String label, Future<void> Function() init) async {
+  try {
+    await init();
+  } catch (e, st) {
+    debugPrint('[main] $label init failed (continuing without it): $e\n$st');
+  }
 }

--- a/lib/notify/notification_service.dart
+++ b/lib/notify/notification_service.dart
@@ -52,8 +52,12 @@ class NotificationService {
   /// Set up the plugin + the device-alerts channel. Idempotent. Does NOT prompt.
   Future<void> init() async {
     if (_inited) return;
+    // Use the real launcher mipmap — the project renamed it to `launcher_icon`
+    // (see AndroidManifest android:icon), so the Flutter-default `ic_launcher`
+    // no longer resolves and made initialize() throw `invalid_icon` in release,
+    // which (being awaited before runApp) blanked the whole app on launch.
     const AndroidInitializationSettings android =
-        AndroidInitializationSettings('@mipmap/ic_launcher');
+        AndroidInitializationSettings('@mipmap/launcher_icon');
     // We prompt explicitly later (after pairing), not at plugin init.
     const DarwinInitializationSettings darwin = DarwinInitializationSettings(
       requestAlertPermission: false,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openstrap_edge
 description: "OpenStrap — open-source WHOOP 4.0 companion. BLE drain → raw-first local store → cloud sync."
 publish_to: 'none'
-version: 0.4.5+10
+version: 0.4.6+11
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
## Problem
The release APK (from CI) booted to a blank/black screen or launch-icon only; debug worked. Release logcat showed:

```
PlatformException(invalid_icon, The resource @mipmap/ic_launcher could not be found …)
  at AndroidFlutterLocalNotificationsPlugin.initialize
  at NotificationService.init (notification_service.dart)
  at main (main.dart:17)
```

`flutter_local_notifications` was initialized with `@mipmap/ic_launcher`, but the launcher icon was renamed to `launcher_icon` (see `AndroidManifest`). On API 26+ that resource fails to resolve → `initialize()` throws. Because it's `await`ed in `main()` **before `runApp()`**, the throw aborted startup → app stuck on the native launch screen (release-only; debug masked it via resource resolution).

## Fix
- **notification_service**: init with `@mipmap/launcher_icon` (the resource that actually exists).
- **main()**: guard the optional startup inits (`IosBleRestore`, `WidgetService`, `NotificationService`) in `_safeInit`, and fall back to a system-brightness `ThemeController` if bootstrap fails — so `runApp()` is always reached and no startup-service failure can ever blank the app again.

## Verified
`flutter build apk --release --dart-define-from-file=.env` boots to the coral spinner → `_Gate`. `flutter analyze` clean.

Version bumped 0.4.5+10 → **0.4.6+11**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)