### PR TITLE
feat: pull-to-refresh on all screens + per-nap hypnograms

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <!-- BLE: Android 12+ uses BLUETOOTH_SCAN/CONNECT; older needs location for scan. -->
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation" />
@@ -17,11 +18,16 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <!-- OTA self-update: download + launch the system installer for the new APK. -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <!-- Notification relay: let the user pick from their installed apps. Android 11+
+         hides the package list without this; OpenStrap ships as a sideloaded APK (not
+         Play-distributed), so broad visibility is acceptable here. -->
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
 
     <application
         android:label="Edge"
-        android:name="${applicationName}"
+        android:name=".EdgeApplication"
         android:icon="@mipmap/launcher_icon">
         <activity
             android:name=".MainActivity"
@@ -50,6 +56,19 @@
             android:name=".EdgeTrackingService"
             android:exported="false"
             android:foregroundServiceType="connectedDevice" />
+
+        <!-- Notification relay (notification_listener_service plugin). The system binds
+             this to deliver posted notifications; gated behind the user granting
+             "Notification access" in system settings. Class lives in the plugin. -->
+        <service
+            android:name="notification.listener.service.NotificationListener"
+            android:label="OpenStrap notification relay"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
 
         <!-- OTA self-update (ota_update 7.x). The plugin's LIBRARY manifest only
              declares permissions — the host app MUST declare this FileProvider +

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/EdgeApplication.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/EdgeApplication.kt
@@ -1,0 +1,42 @@
+package wtf.openstrap.openstrap_edge
+
+import android.app.Application
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.FlutterEngineCache
+import io.flutter.embedding.engine.dart.DartExecutor
+
+/**
+ * Pre-warms a single long-lived [FlutterEngine] and caches it. MainActivity attaches
+ * to THIS engine (via getCachedEngineId) instead of creating its own, and does NOT
+ * destroy it when the Activity is finished (shouldDestroyEngineWithHost = false).
+ *
+ * Why: when the user swipes the app from recents, Android destroys the Activity and,
+ * with a default Activity-owned engine, tears the engine down too (onDetachedFromEngine
+ * in logcat). That kills the Dart VM — and with it flutter_blue_plus's BLE connection
+ * AND the notification-relay stream (the native listener keeps firing but "FlutterJNI
+ * detached … could not send"). By retaining the engine here and keeping the process
+ * alive with the EdgeTracking foreground service, the Dart side keeps running headless
+ * after task removal, so the relay can still buzz the band.
+ *
+ * The trade-off is RAM: the app stays warm in memory. That's the intended cost of a
+ * persistent foreground BLE companion, and matches the existing foreground-service model.
+ */
+class EdgeApplication : Application() {
+    companion object {
+        const val ENGINE_ID = "openstrap_main_engine"
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        // Constructor auto-registers plugins (GeneratedPluginRegistrant) → flutter_blue_plus,
+        // notification_listener_service, shared_preferences, etc. are all available headless.
+        val engine = FlutterEngine(this)
+        // Register platform channels on the engine BEFORE Dart starts, so they exist even
+        // when no Activity is attached (headless calls like EdgeTracking.start must work).
+        NativeChannels.register(engine, applicationContext)
+        engine.dartExecutor.executeDartEntrypoint(
+            DartExecutor.DartEntrypoint.createDefault()
+        )
+        FlutterEngineCache.getInstance().put(ENGINE_ID, engine)
+    }
+}

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/MainActivity.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/MainActivity.kt
@@ -1,129 +1,18 @@
 package wtf.openstrap.openstrap_edge
 
-import android.content.Context
-import android.content.Intent
-import android.hardware.camera2.CameraCharacteristics
-import android.hardware.camera2.CameraManager
-import android.media.AudioManager
-import android.media.RingtoneManager
-import android.os.Build
-import android.os.VibrationEffect
-import android.os.Vibrator
-import android.os.VibratorManager
-import android.view.KeyEvent
 import io.flutter.embedding.android.FlutterActivity
-import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.plugin.common.MethodChannel
 
+/**
+ * Attaches to the long-lived engine pre-warmed in [EdgeApplication] rather than spinning
+ * up its own, and refuses to destroy that engine when the Activity is finished. Combined
+ * with the EdgeTracking foreground service keeping the process alive, this lets the Dart
+ * side (BLE connection + notification relay) keep running after the app is swiped from
+ * recents — instead of Android tearing the engine down (onDetachedFromEngine).
+ *
+ * Platform channels are registered on the engine in EdgeApplication (NativeChannels), not
+ * here, so they exist even while no Activity is attached (headless channel calls work).
+ */
 class MainActivity : FlutterActivity() {
-    private val edgeTrackingChannel = "openstrap/edge_tracking"
-    private val deviceActionsChannel = "openstrap/device_actions"
-
-    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
-        super.configureFlutterEngine(flutterEngine)
-
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, edgeTrackingChannel)
-            .setMethodCallHandler { call, result ->
-                when (call.method) {
-                    "start" -> {
-                        val intent = Intent(this, EdgeTrackingService::class.java)
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                            startForegroundService(intent)
-                        } else {
-                            startService(intent)
-                        }
-                        result.success(null)
-                    }
-                    "stop" -> {
-                        stopService(Intent(this, EdgeTrackingService::class.java))
-                        result.success(null)
-                    }
-                    else -> result.notImplemented()
-                }
-            }
-
-        // Band-gesture actions. All no-risk OS APIs: media-key dispatch (works for any
-        // player, no permission), system media volume, and a ringtone + vibrate.
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, deviceActionsChannel)
-            .setMethodCallHandler { call, result ->
-                when (call.method) {
-                    "capabilities" -> result.success(
-                        listOf(
-                            "media_play_pause", "media_next", "media_prev",
-                            "volume_up", "volume_down", "ring_phone", "torch"
-                        )
-                    )
-                    "perform" -> result.success(perform(call.argument<String>("action") ?: ""))
-                    else -> result.notImplemented()
-                }
-            }
-    }
-
-    private fun perform(action: String): Boolean {
-        return try {
-            when (action) {
-                "media_play_pause" -> dispatchMediaKey(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE)
-                "media_next" -> dispatchMediaKey(KeyEvent.KEYCODE_MEDIA_NEXT)
-                "media_prev" -> dispatchMediaKey(KeyEvent.KEYCODE_MEDIA_PREVIOUS)
-                "volume_up" -> adjustVolume(AudioManager.ADJUST_RAISE)
-                "volume_down" -> adjustVolume(AudioManager.ADJUST_LOWER)
-                "ring_phone" -> ringPhone()
-                "torch" -> toggleTorch()
-                else -> return false
-            }
-            true
-        } catch (e: Exception) {
-            false
-        }
-    }
-
-    private fun audio(): AudioManager =
-        getSystemService(Context.AUDIO_SERVICE) as AudioManager
-
-    private fun dispatchMediaKey(keyCode: Int) {
-        val am = audio()
-        am.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, keyCode))
-        am.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_UP, keyCode))
-    }
-
-    private fun adjustVolume(direction: Int) {
-        audio().adjustStreamVolume(
-            AudioManager.STREAM_MUSIC, direction, AudioManager.FLAG_SHOW_UI
-        )
-    }
-
-    private fun ringPhone() {
-        val uri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
-        RingtoneManager.getRingtone(applicationContext, uri)?.play()
-        vibrate()
-    }
-
-    // Torch via CameraManager.setTorchMode — no CAMERA permission required (API 23+).
-    // We track the on/off state ourselves; if the system turns it off underneath us
-    // the worst case is one tap that re-syncs the state.
-    private var torchOn = false
-
-    private fun toggleTorch() {
-        val cm = getSystemService(Context.CAMERA_SERVICE) as CameraManager
-        val camId = cm.cameraIdList.firstOrNull {
-            cm.getCameraCharacteristics(it)
-                .get(CameraCharacteristics.FLASH_INFO_AVAILABLE) == true
-        } ?: return
-        torchOn = !torchOn
-        cm.setTorchMode(camId, torchOn)
-    }
-
-    @Suppress("DEPRECATION")
-    private fun vibrate() {
-        val vibrator: Vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            (getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager).defaultVibrator
-        } else {
-            getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            vibrator.vibrate(VibrationEffect.createOneShot(500, VibrationEffect.DEFAULT_AMPLITUDE))
-        } else {
-            vibrator.vibrate(500)
-        }
-    }
+    override fun getCachedEngineId(): String = EdgeApplication.ENGINE_ID
+    override fun shouldDestroyEngineWithHost(): Boolean = false
 }

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/NativeChannels.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/NativeChannels.kt
@@ -1,0 +1,131 @@
+package wtf.openstrap.openstrap_edge
+
+import android.content.Context
+import android.content.Intent
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.media.AudioManager
+import android.media.RingtoneManager
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import android.view.KeyEvent
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Platform channels for the app. Registered on the long-lived engine at creation time
+ * (see EdgeApplication) so they keep working when Dart runs headless (no Activity). All
+ * use the application Context — none of these actions need an Activity.
+ */
+object NativeChannels {
+    private const val EDGE_TRACKING_CHANNEL = "openstrap/edge_tracking"
+    private const val DEVICE_ACTIONS_CHANNEL = "openstrap/device_actions"
+
+    private var torchOn = false
+
+    fun register(engine: FlutterEngine, context: Context) {
+        val app = context.applicationContext
+
+        MethodChannel(engine.dartExecutor.binaryMessenger, EDGE_TRACKING_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "start" -> {
+                        val intent = Intent(app, EdgeTrackingService::class.java)
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            app.startForegroundService(intent)
+                        } else {
+                            app.startService(intent)
+                        }
+                        result.success(null)
+                    }
+                    "stop" -> {
+                        app.stopService(Intent(app, EdgeTrackingService::class.java))
+                        result.success(null)
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+
+        // Band-gesture actions. All no-risk OS APIs: media-key dispatch (works for any
+        // player, no permission), system media volume, ringtone + vibrate, torch.
+        MethodChannel(engine.dartExecutor.binaryMessenger, DEVICE_ACTIONS_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "capabilities" -> result.success(
+                        listOf(
+                            "media_play_pause", "media_next", "media_prev",
+                            "volume_up", "volume_down", "ring_phone", "torch"
+                        )
+                    )
+                    "perform" -> result.success(perform(app, call.argument<String>("action") ?: ""))
+                    else -> result.notImplemented()
+                }
+            }
+    }
+
+    private fun perform(ctx: Context, action: String): Boolean {
+        return try {
+            when (action) {
+                "media_play_pause" -> dispatchMediaKey(ctx, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE)
+                "media_next" -> dispatchMediaKey(ctx, KeyEvent.KEYCODE_MEDIA_NEXT)
+                "media_prev" -> dispatchMediaKey(ctx, KeyEvent.KEYCODE_MEDIA_PREVIOUS)
+                "volume_up" -> adjustVolume(ctx, AudioManager.ADJUST_RAISE)
+                "volume_down" -> adjustVolume(ctx, AudioManager.ADJUST_LOWER)
+                "ring_phone" -> ringPhone(ctx)
+                "torch" -> toggleTorch(ctx)
+                else -> return false
+            }
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private fun audio(ctx: Context): AudioManager =
+        ctx.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+    private fun dispatchMediaKey(ctx: Context, keyCode: Int) {
+        val am = audio(ctx)
+        am.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, keyCode))
+        am.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_UP, keyCode))
+    }
+
+    private fun adjustVolume(ctx: Context, direction: Int) {
+        audio(ctx).adjustStreamVolume(
+            AudioManager.STREAM_MUSIC, direction, AudioManager.FLAG_SHOW_UI
+        )
+    }
+
+    private fun ringPhone(ctx: Context) {
+        val uri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
+        RingtoneManager.getRingtone(ctx.applicationContext, uri)?.play()
+        vibrate(ctx)
+    }
+
+    // Torch via CameraManager.setTorchMode — no CAMERA permission required (API 23+).
+    private fun toggleTorch(ctx: Context) {
+        val cm = ctx.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+        val camId = cm.cameraIdList.firstOrNull {
+            cm.getCameraCharacteristics(it)
+                .get(CameraCharacteristics.FLASH_INFO_AVAILABLE) == true
+        } ?: return
+        torchOn = !torchOn
+        cm.setTorchMode(camId, torchOn)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun vibrate(ctx: Context) {
+        val vibrator: Vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            (ctx.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager).defaultVibrator
+        } else {
+            ctx.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            vibrator.vibrate(VibrationEffect.createOneShot(500, VibrationEffect.DEFAULT_AMPLITUDE))
+        } else {
+            vibrator.vibrate(500)
+        }
+    }
+}

--- a/ios/OpenStrapWidget/OpenStrapBatteryWidget.swift
+++ b/ios/OpenStrapWidget/OpenStrapBatteryWidget.swift
@@ -1,0 +1,266 @@
+//
+//  OpenStrapBatteryWidget.swift
+//  OpenStrapWidget
+//
+//  Lock-screen (and home-screen) widget showing the BAND's battery level.
+//
+//  Battery is a live BLE value (GET_BATTERY / HELLO) that only the app knows —
+//  it is NOT part of /today — so unlike OpenStrapWidget this one does NOT
+//  self-refresh over the network. It renders the last snapshot the app wrote
+//  into the shared App Group (keys batt_pct / batt_charging / batt_at) the last
+//  time the band was connected. "—" until we've ever seen the band.
+//
+//  Primary surface is the lock screen (accessory* families); a systemSmall
+//  variant is included so it can also live on the home screen.
+//
+
+import WidgetKit
+import SwiftUI
+
+private let kAppGroup = "group.wtf.openstrap"
+
+// MARK: - Theme (mirrors OpenStrapWidget's Ember-on-Paper / Char)
+
+private extension Color {
+  init(_ r: Int, _ g: Int, _ b: Int) {
+    self.init(red: Double(r) / 255, green: Double(g) / 255, blue: Double(b) / 255)
+  }
+}
+
+private struct BattPal {
+  let bg: Color, ink: Color, inkMuted: Color, track: Color
+  static let light = BattPal(bg: Color(244, 241, 236), ink: Color(26, 23, 20),
+                             inkMuted: Color(165, 156, 144), track: Color(236, 231, 223))
+  static let dark  = BattPal(bg: Color(30, 26, 21), ink: Color(241, 236, 227),
+                             inkMuted: Color(126, 116, 102), track: Color(42, 37, 31))
+  static var current: BattPal {
+    let isDark = UserDefaults(suiteName: kAppGroup)?.object(forKey: "theme_dark") as? Bool ?? false
+    return isDark ? .dark : .light
+  }
+}
+
+private extension Color {
+  static var battPaper: Color { BattPal.current.bg }
+  static var battInk: Color { BattPal.current.ink }
+  static var battInkMuted: Color { BattPal.current.inkMuted }
+  static var battTrack: Color { BattPal.current.track }
+  static let battCoral     = Color(255, 90, 54)
+  static let battCoralDeep = Color(232, 67, 31)
+  static let battGood      = Color(43, 182, 115)
+  static let battCharge    = Color(124, 168, 240)
+}
+
+// MARK: - Model
+
+struct BatteryEntry: TimelineEntry {
+  let date: Date
+  let name: String      // strap advertising name (falls back to "Strap")
+  let pct: Int          // -1 = never seen the band
+  let charging: Bool
+  let updatedAt: Int    // epoch seconds, 0 = unknown
+  let stale: Bool       // last reading is old enough that we mute it
+
+  static let placeholder = BatteryEntry(
+    date: Date(), name: "WHOOP 4.0", pct: 68, charging: false,
+    updatedAt: Int(Date().timeIntervalSince1970), stale: false)
+
+  var hasData: Bool { pct >= 0 }
+  var t: Double { pct >= 0 ? min(max(Double(pct) / 100.0, 0), 1) : 0 }
+
+  /// Coral when low, deep-coral when critical, blue while charging, otherwise ink.
+  var color: Color {
+    if !hasData { return .battInkMuted }
+    if charging { return .battCharge }
+    if pct <= 10 { return .battCoralDeep }
+    if pct <= 25 { return .battCoral }
+    return .battGood
+  }
+
+  var valueText: String { pct >= 0 ? "\(pct)%" : "—" }
+
+  /// Icon: a charging bolt while plugged in, otherwise the strap glyph
+  /// (mirrors the app's device icon, HugeIcons SmartWatch01).
+  var symbol: String { charging ? "bolt.fill" : "applewatch" }
+}
+
+// MARK: - Shared store (App Group, read-only here)
+
+private enum BatteryStore {
+  static func read() -> BatteryEntry {
+    let d = UserDefaults(suiteName: kAppGroup)
+    let pct = d?.object(forKey: "batt_pct") as? Int ?? -1
+    let charging = d?.object(forKey: "batt_charging") as? Bool ?? false
+    let at = d?.object(forKey: "batt_at") as? Int ?? 0
+    let raw = (d?.string(forKey: "batt_name") ?? "").trimmingCharacters(in: .whitespaces)
+    let name = raw.isEmpty ? "Strap" : raw
+    // Mute (still show the number, but greyed) once the reading is > 24h old —
+    // we genuinely don't know the current level if we haven't talked to the band.
+    let stale = at > 0 && (Int(Date().timeIntervalSince1970) - at) > 86_400
+    return BatteryEntry(date: Date(), name: name, pct: pct, charging: charging,
+                        updatedAt: at, stale: stale)
+  }
+}
+
+// MARK: - Provider
+// No network refresh — the app pushes new readings + calls reloadAllTimelines.
+// We still re-render every ~30 min so the staleness flag can flip on its own.
+
+struct BatteryProvider: TimelineProvider {
+  func placeholder(in context: Context) -> BatteryEntry { .placeholder }
+
+  func getSnapshot(in context: Context, completion: @escaping (BatteryEntry) -> Void) {
+    completion(context.isPreview ? .placeholder : BatteryStore.read())
+  }
+
+  func getTimeline(in context: Context, completion: @escaping (Timeline<BatteryEntry>) -> Void) {
+    let entry = BatteryStore.read()
+    let next = Calendar.current.date(byAdding: .minute, value: 30, to: Date())
+      ?? Date().addingTimeInterval(1800)
+    completion(Timeline(entries: [entry], policy: .after(next)))
+  }
+}
+
+// MARK: - Views
+
+private func battNumFont(_ size: CGFloat) -> Font { .system(size: size, weight: .bold, design: .rounded) }
+
+/// Linear capsule progress bar (ember fill on a track).
+private struct BattBar: View {
+  let t: Double
+  let color: Color
+  var height: CGFloat = 8
+  var body: some View {
+    GeometryReader { geo in
+      ZStack(alignment: .leading) {
+        Capsule().fill(Color.battTrack)
+        if t > 0 {
+          Capsule().fill(color)
+            .frame(width: max(height, geo.size.width * min(max(t, 0), 1)))
+        }
+      }
+    }
+    .frame(height: height)
+  }
+}
+
+/// Home-screen small: strap name + level + linear bar.
+private struct BatterySmallView: View {
+  let e: BatteryEntry
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack(spacing: 6) {
+        Image(systemName: e.symbol).font(.system(size: 14, weight: .semibold)).foregroundColor(e.color)
+        Text(e.name).font(.system(size: 12, weight: .semibold)).foregroundColor(.battInkMuted)
+          .lineLimit(1).minimumScaleFactor(0.7)
+      }
+      Spacer(minLength: 8)
+      Text(e.valueText).font(battNumFont(30)).foregroundColor(.battInk)
+        .minimumScaleFactor(0.6).lineLimit(1)
+      Spacer(minLength: 8)
+      BattBar(t: e.t, color: e.color, height: 9)
+      Text(e.charging ? "Charging" : (e.hasData ? "Battery" : "Not connected"))
+        .font(.system(size: 10, weight: .medium)).foregroundColor(.battInkMuted)
+        .padding(.top, 5)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    .opacity(e.stale ? 0.5 : 1)
+    .padding(14)
+  }
+}
+
+@available(iOSApplicationExtension 16.0, *)
+private struct BatteryCircularView: View {
+  let e: BatteryEntry
+  var body: some View {
+    Gauge(value: e.t) {
+      Image(systemName: e.symbol)
+    } currentValueLabel: {
+      Text(e.valueText)
+    }
+    .gaugeStyle(.accessoryCircularCapacity)
+    .widgetAccentable()
+  }
+}
+
+@available(iOSApplicationExtension 16.0, *)
+private struct BatteryRectangularView: View {
+  let e: BatteryEntry
+  var body: some View {
+    VStack(alignment: .leading, spacing: 3) {
+      Label {
+        Text(e.name).lineLimit(1)
+      } icon: {
+        Image(systemName: e.symbol)
+      }
+      .font(.system(size: 13, weight: .semibold))
+      .widgetAccentable()
+
+      // Linear lock-screen battery bar with the level inline.
+      Gauge(value: e.t) {
+        Text("")
+      } currentValueLabel: {
+        Text(e.hasData ? "\(e.pct)%" : "—")
+      }
+      .gaugeStyle(.accessoryLinearCapacity)
+    }
+  }
+}
+
+private extension View {
+  @ViewBuilder func battWidgetBackground(_ color: Color) -> some View {
+    if #available(iOSApplicationExtension 17.0, *) {
+      containerBackground(color, for: .widget)
+    } else {
+      background(color)
+    }
+  }
+}
+
+struct OpenStrapBatteryEntryView: View {
+  @Environment(\.widgetFamily) var family
+  var entry: BatteryEntry
+
+  var body: some View {
+    content.battWidgetBackground(family == .systemSmall ? Color.battPaper : Color.clear)
+  }
+
+  @ViewBuilder private var content: some View {
+    switch family {
+    case .systemSmall: BatterySmallView(e: entry)
+    default:
+      if #available(iOSApplicationExtension 16.0, *) {
+        switch family {
+        case .accessoryCircular:    BatteryCircularView(e: entry)
+        case .accessoryRectangular: BatteryRectangularView(e: entry)
+        case .accessoryInline:
+          Label(
+            entry.hasData ? "\(entry.name) \(entry.pct)%" : "\(entry.name) —",
+            systemImage: entry.symbol)
+        default: BatterySmallView(e: entry)
+        }
+      } else {
+        BatterySmallView(e: entry)
+      }
+    }
+  }
+}
+
+struct OpenStrapBatteryWidget: Widget {
+  let kind: String = "OpenStrapBatteryWidget"
+
+  var body: some WidgetConfiguration {
+    StaticConfiguration(kind: kind, provider: BatteryProvider()) { entry in
+      OpenStrapBatteryEntryView(entry: entry)
+    }
+    .configurationDisplayName("Band Battery")
+    .description("Your band's battery level at a glance.")
+    .supportedFamilies(supportedFamilies)
+  }
+
+  private var supportedFamilies: [WidgetFamily] {
+    if #available(iOSApplicationExtension 16.0, *) {
+      return [.systemSmall, .accessoryCircular, .accessoryRectangular, .accessoryInline]
+    }
+    return [.systemSmall]
+  }
+}

--- a/ios/OpenStrapWidget/OpenStrapWidgetBundle.swift
+++ b/ios/OpenStrapWidget/OpenStrapWidgetBundle.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct OpenStrapWidgetBundle: WidgetBundle {
     var body: some Widget {
         OpenStrapWidget()
+        OpenStrapBatteryWidget()
         OpenStrapWidgetControl()
         OpenStrapWidgetLiveActivity()
     }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3,6 +3,8 @@ PODS:
   - flutter_blue_plus_darwin (0.0.2):
     - Flutter
     - FlutterMacOS
+  - flutter_local_notifications (0.0.1):
+    - Flutter
   - home_widget (0.0.1):
     - Flutter
   - package_info_plus (0.4.5):
@@ -21,6 +23,7 @@ PODS:
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_blue_plus_darwin (from `.symlinks/plugins/flutter_blue_plus_darwin/darwin`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - home_widget (from `.symlinks/plugins/home_widget/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
@@ -33,6 +36,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_blue_plus_darwin:
     :path: ".symlinks/plugins/flutter_blue_plus_darwin/darwin"
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
   home_widget:
     :path: ".symlinks/plugins/home_widget/ios"
   package_info_plus:
@@ -49,6 +54,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_blue_plus_darwin: 20a08bfeaa0f7804d524858d3d8744bcc1b6dbc3
+  flutter_local_notifications: 395056b3175ba4f08480a7c5de30cd36d69827e4
   home_widget: f169fc41fd807b4d46ab6615dc44d62adbf9f64f
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -5,6 +5,9 @@ PODS:
     - FlutterMacOS
   - flutter_local_notifications (0.0.1):
     - Flutter
+  - flutter_secure_storage_darwin (10.0.0):
+    - Flutter
+    - FlutterMacOS
   - home_widget (0.0.1):
     - Flutter
   - package_info_plus (0.4.5):
@@ -24,6 +27,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_blue_plus_darwin (from `.symlinks/plugins/flutter_blue_plus_darwin/darwin`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
+  - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - home_widget (from `.symlinks/plugins/home_widget/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
@@ -38,6 +42,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_blue_plus_darwin/darwin"
   flutter_local_notifications:
     :path: ".symlinks/plugins/flutter_local_notifications/ios"
+  flutter_secure_storage_darwin:
+    :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
   home_widget:
     :path: ".symlinks/plugins/home_widget/ios"
   package_info_plus:
@@ -55,6 +61,7 @@ SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_blue_plus_darwin: 20a08bfeaa0f7804d524858d3d8744bcc1b6dbc3
   flutter_local_notifications: 395056b3175ba4f08480a7c5de30cd36d69827e4
+  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   home_widget: f169fc41fd807b4d46ab6615dc44d62adbf9f64f
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -327,12 +327,6 @@ class BleEngine {
             tsEpoch: r.tsEpoch,
             counter: r.counter,
             hr: r.hr,
-            spo2: r.spo2,
-            skinTempC: r.skinTempC,
-            restingHr: r.restingHr,
-            ax: r.accelG[0],
-            ay: r.accelG[1],
-            az: r.accelG[2],
           );
         }
       } else if (recType == Record.r10) {
@@ -343,12 +337,6 @@ class BleEngine {
             tsEpoch: r.tsEpoch,
             counter: r.counter,
             hr: r.hr,
-            spo2: 0,
-            skinTempC: 0,
-            restingHr: 0,
-            ax: 0,
-            ay: 0,
-            az: 0,
           );
         }
       }

--- a/lib/coach/coach_config.dart
+++ b/lib/coach/coach_config.dart
@@ -1,0 +1,71 @@
+// CoachConfig — local, BYOK settings for the AI coach. The API key is stored in
+// the platform keychain/keystore (flutter_secure_storage); base URL + model in
+// SharedPreferences. NOTHING here ever touches our backend — the key stays on the
+// device and the app calls the OpenAI-compatible provider directly.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class CoachConfig extends ChangeNotifier {
+  static const _kBaseUrl = 'coach_base_url';
+  static const _kModel = 'coach_model';
+  static const _kKey = 'coach_api_key'; // secure storage
+
+  static const String defaultBaseUrl = 'https://api.openai.com/v1';
+
+  final FlutterSecureStorage _secure = const FlutterSecureStorage();
+
+  String _baseUrl = defaultBaseUrl;
+  String _model = '';
+  String? _key; // cached in-memory after load
+
+  String get baseUrl => _baseUrl;
+  String get model => _model;
+  String? get apiKey => _key;
+  bool get hasKey => _key != null && _key!.isNotEmpty;
+  bool get configured => hasKey && _baseUrl.isNotEmpty && _model.isNotEmpty;
+
+  /// Normalised base, no trailing slash.
+  String get apiBase {
+    var b = _baseUrl.trim();
+    while (b.endsWith('/')) {
+      b = b.substring(0, b.length - 1);
+    }
+    return b;
+  }
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _baseUrl = prefs.getString(_kBaseUrl) ?? defaultBaseUrl;
+    _model = prefs.getString(_kModel) ?? '';
+    try {
+      _key = await _secure.read(key: _kKey);
+    } catch (_) {
+      _key = null;
+    }
+    notifyListeners();
+  }
+
+  Future<void> save({String? baseUrl, String? model, String? apiKey}) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (baseUrl != null) {
+      _baseUrl = baseUrl.trim().isEmpty ? defaultBaseUrl : baseUrl.trim();
+      await prefs.setString(_kBaseUrl, _baseUrl);
+    }
+    if (model != null) {
+      _model = model.trim();
+      await prefs.setString(_kModel, _model);
+    }
+    if (apiKey != null) {
+      final k = apiKey.trim();
+      _key = k.isEmpty ? null : k;
+      if (k.isEmpty) {
+        await _secure.delete(key: _kKey);
+      } else {
+        await _secure.write(key: _kKey, value: k);
+      }
+    }
+    notifyListeners();
+  }
+}

--- a/lib/coach/coach_engine.dart
+++ b/lib/coach/coach_engine.dart
@@ -1,0 +1,618 @@
+// CoachEngine — the agentic core. Talks to an OpenAI-compatible provider directly
+// (BYOK), runs a tool-calling loop over read-only data tools + a plot tool + action
+// tools (writes require user confirmation), and streams items back to the UI.
+//
+// Data flow: user asks → model calls data tools (we hit the authed backend) → model
+// reasons → optionally calls plot_chart with a figure it built → optionally proposes
+// an action (we confirm with the user) → model returns the final text.
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+
+import '../net/api_client.dart';
+import 'coach_config.dart';
+import 'coach_prompt.dart';
+
+// ── value types ──────────────────────────────────────────────────────────────
+
+/// A figure the model built from data it fetched; the app renders it animated.
+class ChartSpec {
+  final String type; // 'bar' | 'line' | 'area'
+  final String title;
+  final List<String> xLabels;
+  final List<ChartSeries> series;
+  final String unit;
+  final String? note;
+  ChartSpec({
+    required this.type,
+    required this.title,
+    required this.xLabels,
+    required this.series,
+    this.unit = '',
+    this.note,
+  });
+
+  // Some OpenAI-compatible models (e.g. minimax via NVIDIA NIM) wrap array params
+  // as {"item":[...]} and emit numbers as strings. Be liberal in what we accept.
+  static List<dynamic> _asList(dynamic v) {
+    if (v is List) return v;
+    if (v is Map && v['item'] is List) return v['item'] as List;
+    if (v is Map && v['items'] is List) return v['items'] as List;
+    return const [];
+  }
+
+  static double? _asNum(dynamic v) {
+    if (v == null) return null;
+    if (v is num) return v.toDouble();
+    if (v is String) {
+      final d = double.tryParse(v.trim());
+      if (d != null) return d;
+      // tolerate "62 ms", units glued on, etc. — take the first number found.
+      final m = RegExp(r'-?\d+(\.\d+)?').firstMatch(v);
+      return m == null ? null : double.tryParse(m.group(0)!);
+    }
+    if (v is Map) return _asNum(v['value'] ?? v['y'] ?? v['v']); // {value:62}/{y:62}
+    return null;
+  }
+
+  Map<String, dynamic> toJson() => {
+        'type': type, 'title': title, 'x_labels': xLabels, 'unit': unit, 'note': note,
+        'series': series.map((s) => {'name': s.name, 'values': s.values}).toList(),
+      };
+
+  static ChartSpec? tryParse(Map<String, dynamic> j) {
+    try {
+      final rawSeries = _asList(j['series']);
+      final series = rawSeries.whereType<Map>().map((s) {
+        final vals = _asList(s['values'] ?? s['data'] ?? s['y']).map(_asNum).toList();
+        return ChartSeries(name: (s['name'] ?? s['label'] ?? '').toString(), values: vals);
+      }).where((s) => s.values.any((v) => v != null)).toList(); // drop all-null series
+      if (series.isEmpty) return null;
+      final xs = _asList(j['x_labels'] ?? j['labels'] ?? j['x']).map((e) => '$e').toList();
+      return ChartSpec(
+        type: (j['type'] ?? 'bar').toString(),
+        title: (j['title'] ?? '').toString(),
+        xLabels: xs,
+        series: series,
+        unit: (j['unit'] ?? j['y_unit'] ?? '').toString(),
+        note: j['note']?.toString(),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+class ChartSeries {
+  final String name;
+  final List<double?> values;
+  ChartSeries({required this.name, required this.values});
+}
+
+/// A write the model wants to perform — surfaced to the user for confirmation.
+class ActionRequest {
+  final String tool;
+  final String title;     // e.g. "Log a period"
+  final String summary;   // human description of exactly what will happen
+  final Map<String, dynamic> args;
+  ActionRequest({required this.tool, required this.title, required this.summary, required this.args});
+}
+
+/// One rendered chat item.
+enum CoachItemKind { user, assistant, chart, error }
+
+class CoachItem {
+  final CoachItemKind kind;
+  final String? text;
+  final ChartSpec? chart;
+  CoachItem.user(this.text) : kind = CoachItemKind.user, chart = null;
+  CoachItem.assistant(this.text) : kind = CoachItemKind.assistant, chart = null;
+  CoachItem.error(this.text) : kind = CoachItemKind.error, chart = null;
+  CoachItem.chart(this.chart) : kind = CoachItemKind.chart, text = null;
+
+  Map<String, dynamic> toJson() => {'kind': kind.name, 'text': text, 'chart': chart?.toJson()};
+
+  static CoachItem fromJson(Map<String, dynamic> j) {
+    final k = j['kind'];
+    if (k == 'chart' && j['chart'] is Map) {
+      final c = ChartSpec.tryParse((j['chart'] as Map).cast<String, dynamic>());
+      if (c != null) return CoachItem.chart(c);
+    }
+    final t = j['text']?.toString();
+    if (k == 'user') return CoachItem.user(t);
+    if (k == 'error') return CoachItem.error(t);
+    return CoachItem.assistant(t);
+  }
+}
+
+/// Lightweight index entry for a saved chat session (for the history list).
+class CoachSessionMeta {
+  final String id;
+  final String title;
+  final int updatedAt; // ms since epoch
+  final String preview;
+  CoachSessionMeta(this.id, this.title, this.updatedAt, this.preview);
+  Map<String, dynamic> toJson() => {'id': id, 'title': title, 'updatedAt': updatedAt, 'preview': preview};
+  static CoachSessionMeta fromJson(Map<String, dynamic> j) => CoachSessionMeta(
+        (j['id'] ?? '').toString(), (j['title'] ?? '').toString(),
+        (j['updatedAt'] as num?)?.toInt() ?? 0, (j['preview'] ?? '').toString());
+}
+
+// ── engine ───────────────────────────────────────────────────────────────────
+
+class CoachEngine {
+  final CoachConfig config;
+  final ApiClient api;
+  final String storageKey; // per-user, so accounts don't share a transcript
+  final http.Client _http = http.Client();
+
+  // OpenAI-format running history (system is added per-request) — the context we
+  // resend every turn so the model remembers the conversation.
+  final List<Map<String, dynamic>> _history = [];
+
+  // Serializable display transcript (text bubbles + charts) shown in the UI.
+  final List<CoachItem> transcript = [];
+
+  // Current session identity (sessions are persisted per-user, many per user).
+  String _sessionId = '';
+  String _title = '';
+  int _createdAt = 0;
+  String get sessionId => _sessionId;
+
+  final Random _rand = Random();
+  static const List<String> _shenanigans = [
+    'Reading your overnight RR…',
+    'Doing the Banister math…',
+    'Asking your heart rate a few questions…',
+    'Reverse-engineering last night…',
+    'Auditing 90 days of you…',
+    'Letting the data confess…',
+    'Lining up the z-scores…',
+    'Chasing a hunch through your HRV…',
+    'Pulling the thread…',
+  ];
+
+  CoachEngine({required this.config, required this.api, this.storageKey = 'anon'});
+
+  void reset() { _history.clear(); transcript.clear(); }
+  bool get hasHistory => _history.isNotEmpty;
+
+  Future<Directory> _dir() => getApplicationDocumentsDirectory();
+  Future<File> _sessionFile(String id) async => File('${(await _dir()).path}/coach_s_${storageKey}_$id.json');
+  Future<File> _indexFile() async => File('${(await _dir()).path}/coach_idx_$storageKey.json');
+  String _newId() => '${DateTime.now().millisecondsSinceEpoch}';
+
+  /// All saved sessions for this user, most recent first.
+  Future<List<CoachSessionMeta>> listSessions() async {
+    try {
+      final f = await _indexFile();
+      if (!await f.exists()) return [];
+      final list = (jsonDecode(await f.readAsString()) as List)
+          .map((e) => CoachSessionMeta.fromJson((e as Map).cast<String, dynamic>())).toList();
+      list.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+      return list;
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /// On open: resume the most recent session, or start fresh if none.
+  Future<void> restore() async {
+    final metas = await listSessions();
+    if (metas.isEmpty) {
+      newSession();
+      return;
+    }
+    await openSession(metas.first.id);
+  }
+
+  /// Start a brand-new conversation (not written to disk until first message).
+  void newSession() {
+    _sessionId = _newId();
+    _title = '';
+    _createdAt = 0;
+    _history.clear();
+    transcript.clear();
+  }
+
+  /// Load a specific session into the working set.
+  Future<void> openSession(String id) async {
+    try {
+      final f = await _sessionFile(id);
+      if (!await f.exists()) {
+        newSession();
+        return;
+      }
+      final j = jsonDecode(await f.readAsString()) as Map<String, dynamic>;
+      _sessionId = id;
+      _title = (j['title'] ?? '').toString();
+      _createdAt = (j['createdAt'] as num?)?.toInt() ?? 0;
+      _history
+        ..clear()
+        ..addAll(((j['history'] as List?) ?? const []).map((e) => (e as Map).cast<String, dynamic>()));
+      transcript
+        ..clear()
+        ..addAll(((j['transcript'] as List?) ?? const [])
+            .map((e) => CoachItem.fromJson((e as Map).cast<String, dynamic>())));
+    } catch (_) {
+      newSession();
+    }
+  }
+
+  /// Persist the current session (caps history, updates the index).
+  Future<void> persist() async {
+    if (transcript.isEmpty) return;
+    if (_sessionId.isEmpty) _sessionId = _newId();
+    final now = DateTime.now().millisecondsSinceEpoch;
+    if (_createdAt == 0) _createdAt = now;
+    if (_title.isEmpty) _title = _deriveTitle();
+    if (_history.length > 60) _history.removeRange(0, _history.length - 60);
+    try {
+      final f = await _sessionFile(_sessionId);
+      await f.writeAsString(jsonEncode({
+        'title': _title, 'createdAt': _createdAt, 'updatedAt': now,
+        'history': _history, 'transcript': transcript.map((e) => e.toJson()).toList(),
+      }));
+      await _updateIndex(_sessionId, _title, now, _preview());
+    } catch (_) {}
+  }
+
+  Future<void> _updateIndex(String id, String title, int updatedAt, String preview) async {
+    final metas = await listSessions();
+    metas.removeWhere((m) => m.id == id);
+    metas.insert(0, CoachSessionMeta(id, title, updatedAt, preview));
+    final keep = metas.take(30).toList();
+    for (final d in metas.skip(30)) {
+      try {
+        final f = await _sessionFile(d.id);
+        if (await f.exists()) await f.delete();
+      } catch (_) {}
+    }
+    try {
+      final f = await _indexFile();
+      await f.writeAsString(jsonEncode(keep.map((m) => m.toJson()).toList()));
+    } catch (_) {}
+  }
+
+  /// Delete a session (and start fresh if it was the current one).
+  Future<void> deleteSession(String id) async {
+    try {
+      final f = await _sessionFile(id);
+      if (await f.exists()) await f.delete();
+    } catch (_) {}
+    final metas = await listSessions()..removeWhere((m) => m.id == id);
+    try {
+      final f = await _indexFile();
+      await f.writeAsString(jsonEncode(metas.map((m) => m.toJson()).toList()));
+    } catch (_) {}
+    if (id == _sessionId) newSession();
+  }
+
+  String _deriveTitle() {
+    for (final it in transcript) {
+      if (it.kind == CoachItemKind.user && (it.text ?? '').trim().isNotEmpty) {
+        final t = it.text!.trim();
+        return t.length > 40 ? '${t.substring(0, 40)}…' : t;
+      }
+    }
+    return 'New chat';
+  }
+
+  String _preview() {
+    for (final it in transcript.reversed) {
+      final t = it.text?.trim();
+      if (t != null && t.isNotEmpty) return t.length > 80 ? '${t.substring(0, 80)}…' : t;
+    }
+    return '';
+  }
+
+  /// Live model list from the provider's /models endpoint (OpenAI-compatible).
+  /// Static so Settings can probe an as-yet-unsaved base URL + key.
+  static Future<List<String>> fetchModels(String apiBase, String apiKey) async {
+    var b = apiBase.trim();
+    while (b.endsWith('/')) {
+      b = b.substring(0, b.length - 1);
+    }
+    final resp = await http.get(
+      Uri.parse('$b/models'),
+      headers: {'Authorization': 'Bearer $apiKey'},
+    ).timeout(const Duration(seconds: 20));
+    if (resp.statusCode != 200) {
+      throw CoachException('Models request failed (${resp.statusCode}): ${_short(resp.body)}');
+    }
+    final j = jsonDecode(resp.body);
+    final data = (j['data'] as List?) ?? const [];
+    final ids = data.map((e) => (e as Map)['id']?.toString() ?? '').where((s) => s.isNotEmpty).toList();
+    ids.sort();
+    return ids;
+  }
+
+  static String _short(String s) => s.length > 200 ? s.substring(0, 200) : s;
+
+  static String _today() => DateTime.now().toUtc().toIso8601String().substring(0, 10);
+
+  /// Run one user turn. Emits items via [onItem]; reports the current tool via
+  /// [onStatus]; asks the user to confirm writes via [confirm] (returns true to
+  /// proceed). Returns when the model produces its final answer (or hits the cap).
+  Future<void> send(
+    String userText, {
+    required void Function(CoachItem) onItem,
+    required void Function(String?) onStatus,
+    required Future<bool> Function(ActionRequest) confirm,
+  }) async {
+    void emit(CoachItem it) { transcript.add(it); onItem(it); }
+    emit(CoachItem.user(userText));
+    _history.add({'role': 'user', 'content': userText});
+
+    const maxIters = 10;
+    for (var i = 0; i < maxIters; i++) {
+      onStatus(_shenanigans[_rand.nextInt(_shenanigans.length)]);
+      final messages = <Map<String, dynamic>>[
+        {'role': 'system', 'content': '$kCoachSystemPrompt\n\nToday is ${_today()} (UTC).'},
+        ..._history,
+      ];
+
+      final reply = await _chat(messages);
+      final toolCalls = (reply['tool_calls'] as List?) ?? const [];
+      final content = (reply['content'] as String?)?.trim();
+
+      if (toolCalls.isEmpty) {
+        if (content != null && content.isNotEmpty) emit(CoachItem.assistant(content));
+        _history.add({'role': 'assistant', 'content': content ?? ''});
+        onStatus(null);
+        return;
+      }
+
+      // Assistant turn that requested tools (echo any interim text).
+      if (content != null && content.isNotEmpty) emit(CoachItem.assistant(content));
+      _history.add({'role': 'assistant', 'content': content ?? '', 'tool_calls': toolCalls});
+
+      for (final tcRaw in toolCalls) {
+        final tc = tcRaw as Map;
+        final id = tc['id']?.toString() ?? '';
+        final fn = (tc['function'] as Map?) ?? const {};
+        final name = fn['name']?.toString() ?? '';
+        Map<String, dynamic> args = {};
+        try {
+          final a = fn['arguments'];
+          if (a is String && a.isNotEmpty) {
+            args = jsonDecode(a) as Map<String, dynamic>;
+          } else if (a is Map) {
+            args = a.cast<String, dynamic>();
+          }
+        } catch (_) {}
+
+        onStatus(_statusFor(name, args));
+        final result = await _runTool(name, args, onItem: emit, confirm: confirm);
+        _history.add({'role': 'tool', 'tool_call_id': id, 'name': name, 'content': result});
+      }
+    }
+    emit(CoachItem.assistant('I dug through several steps but couldn’t wrap that up — try narrowing the question.'));
+    onStatus(null);
+  }
+
+  // ── provider call ────────────────────────────────────────────────────────────
+  Future<Map<String, dynamic>> _chat(List<Map<String, dynamic>> messages) async {
+    final resp = await _http.post(
+      Uri.parse('${config.apiBase}/chat/completions'),
+      headers: {
+        'Authorization': 'Bearer ${config.apiKey}',
+        'content-type': 'application/json',
+      },
+      body: jsonEncode({
+        'model': config.model,
+        'messages': messages,
+        'tools': _toolDefs,
+        'tool_choice': 'auto',
+        'temperature': 0.3,
+      }),
+    ).timeout(const Duration(seconds: 120));
+    if (resp.statusCode != 200) {
+      throw CoachException('Provider error (${resp.statusCode}): ${_briefErr(resp.body)}');
+    }
+    final j = jsonDecode(utf8.decode(resp.bodyBytes));
+    final choices = (j['choices'] as List?) ?? const [];
+    if (choices.isEmpty) throw CoachException('Empty response from provider.');
+    return (choices.first as Map)['message'] as Map<String, dynamic>;
+  }
+
+  String _briefErr(String body) {
+    try {
+      final j = jsonDecode(body);
+      return (j['error']?['message'] ?? body).toString();
+    } catch (_) {
+      return body.length > 300 ? body.substring(0, 300) : body;
+    }
+  }
+
+  // ── tool execution ───────────────────────────────────────────────────────────
+  Future<String> _runTool(
+    String name,
+    Map<String, dynamic> args, {
+    required void Function(CoachItem) onItem,
+    required Future<bool> Function(ActionRequest) confirm,
+  }) async {
+    try {
+      switch (name) {
+        // reads
+        case 'get_today':
+          return _enc(await api.getToday());
+        case 'get_trend':
+          return _enc(await api.getTrend('${args['metric']}', scale: '${args['scale'] ?? 'week'}'));
+        case 'get_day':
+          return _enc(await _day('${args['kind']}', '${args['date']}'));
+        case 'get_sleep_history':
+          return _enc(await api.getSleep());
+        case 'get_strain_history':
+          return _enc(await api.getStrain());
+        case 'get_sessions':
+          return _enc(await api.getSessions());
+        case 'get_workouts':
+          return _enc(await api.getWorkouts(range: '${args['range'] ?? 'month'}'));
+        case 'get_cycle':
+          return _enc(await api.getCycle());
+        case 'get_journal':
+          return _enc(await api.getJournal(range: '${args['range'] ?? '30d'}'));
+        case 'get_journal_insights':
+          return _enc(await api.getJournalInsights(range: '${args['range'] ?? '90d'}'));
+        case 'get_profile':
+          return _enc(await api.getProfile());
+        case 'get_records':
+          return _enc(await api.getRecords());
+        case 'get_history':
+          return _enc(await api.getHistory(range: '${args['range'] ?? '30d'}'));
+
+        // plot
+        case 'plot_chart':
+          final spec = ChartSpec.tryParse(args);
+          if (spec == null) return 'Could not parse figure; check the schema.';
+          onItem(CoachItem.chart(spec));
+          return 'Chart rendered for the user.';
+
+        // actions (confirmed)
+        case 'log_journal':
+          return await _action(confirm, ActionRequest(
+            tool: name, title: 'Log journal',
+            summary: 'Add journal for ${args['date']}: tags ${args['tags'] ?? []}, note "${args['note'] ?? ''}".',
+            args: args,
+          ), () async {
+            await api.postJournal('${args['date']}',
+                ((args['tags'] as List?) ?? const []).map((e) => '$e').toList(), '${args['note'] ?? ''}');
+            return 'Journal saved.';
+          });
+        case 'log_period':
+          return await _action(confirm, ActionRequest(
+            tool: name, title: 'Log period',
+            summary: 'Log a period start on ${args['date']}.', args: args,
+          ), () async { await api.postCycleLog('${args['date']}', kind: 'start'); return 'Period logged.'; });
+        case 'start_workout':
+          return await _action(confirm, ActionRequest(
+            tool: name, title: 'Start workout',
+            summary: 'Start a ${args['type'] ?? 'workout'} session now.', args: args,
+          ), () async { final r = await api.startWorkout('${args['type'] ?? 'other'}'); return _enc(r); });
+        case 'end_workout':
+          return await _action(confirm, ActionRequest(
+            tool: name, title: 'End workout',
+            summary: 'End the active workout.', args: args,
+          ), () async { final r = await api.endWorkout('${args['workout_id']}'); return _enc(r); });
+        case 'set_step_goal':
+          return await _action(confirm, ActionRequest(
+            tool: name, title: 'Set step goal',
+            summary: 'Set your daily step goal to ${args['goal']}.', args: args,
+          ), () async { await api.setStepGoal((args['goal'] as num).toInt()); return 'Step goal updated.'; });
+
+        default:
+          return 'Unknown tool: $name';
+      }
+    } catch (e) {
+      return 'Tool $name failed: ${e is ApiException ? e.body : e}';
+    }
+  }
+
+  Future<String> _action(
+    Future<bool> Function(ActionRequest) confirm,
+    ActionRequest req,
+    Future<String> Function() run,
+  ) async {
+    final ok = await confirm(req);
+    if (!ok) return 'User declined the action. Do not retry it.';
+    return await run();
+  }
+
+  Future<Map<String, dynamic>> _day(String kind, String date) {
+    switch (kind) {
+      case 'sleep': return api.getDaySleep(date);
+      case 'strain': return api.getDayStrain(date);
+      case 'stress': return api.getDayStress(date);
+      case 'wear': return api.getDayWear(date);
+      case 'timeline': return api.getDayTimeline(date);
+      case 'lungs': return api.getDayLungs(date);
+      case 'heart':
+      default: return api.getDayHeart(date);
+    }
+  }
+
+  String _enc(Object? data) {
+    final s = jsonEncode(data);
+    return s.length > 16000 ? '${s.substring(0, 16000)}…(truncated)' : s;
+  }
+
+  String _statusFor(String name, Map<String, dynamic> args) {
+    switch (name) {
+      case 'get_today': return 'Reading today…';
+      case 'get_trend': return 'Pulling ${args['metric']} trend…';
+      case 'get_day': return 'Reading ${args['kind']} for ${args['date']}…';
+      case 'get_sleep_history': return 'Reading sleep history…';
+      case 'get_strain_history': return 'Reading strain history…';
+      case 'get_sessions': return 'Reading workouts…';
+      case 'get_workouts': return 'Reading workouts…';
+      case 'get_cycle': return 'Reading cycle…';
+      case 'get_journal': case 'get_journal_insights': return 'Reading journal…';
+      case 'get_records': return 'Checking your records…';
+      case 'plot_chart': return 'Plotting…';
+      default: return 'Working…';
+    }
+  }
+
+  void dispose() => _http.close();
+
+  // ── tool schema (OpenAI format) ───────────────────────────────────────────────
+  static Map<String, dynamic> _fn(String name, String desc, Map<String, dynamic> props, [List<String> required = const []]) => {
+        'type': 'function',
+        'function': {
+          'name': name,
+          'description': desc,
+          'parameters': {'type': 'object', 'properties': props, 'required': required},
+        },
+      };
+
+  static final List<Map<String, dynamic>> _toolDefs = [
+    _fn('get_today', 'Today\'s snapshot: recovery, strain, sleep, resting HR, steps, readiness, skin-temp/SpO₂ deviations.', {}),
+    _fn('get_trend', 'A metric over time (server-aggregated buckets). Use for "trend/last week/month".', {
+      'metric': {'type': 'string', 'description': 'one of: strain, recovery, resting_hr, hrv, sdnn, lf_hf, hrv_cv, calories, steps, wear, readiness, vo2max, fitness, fatigue, form, monotony, acwr, dip, efficiency, deep, rem, light, regularity, resp, sleep, stress, skin_temp, spo2'},
+      'scale': {'type': 'string', 'enum': ['week', 'month', 'quarter']},
+    }, ['metric']),
+    _fn('get_day', 'Detailed data for one day & domain.', {
+      'kind': {'type': 'string', 'enum': ['heart', 'sleep', 'strain', 'stress', 'wear', 'timeline', 'lungs']},
+      'date': {'type': 'string', 'description': 'YYYY-MM-DD'},
+    }, ['kind', 'date']),
+    _fn('get_sleep_history', 'Recent nightly sleep rows.', {}),
+    _fn('get_strain_history', 'Recent daily strain rows.', {}),
+    _fn('get_sessions', 'Recent detected/auto workouts.', {}),
+    _fn('get_workouts', 'Workouts over a range.', {'range': {'type': 'string', 'enum': ['week', 'month', 'quarter']}}),
+    _fn('get_cycle', 'Menstrual cycle status + prediction (if the user enabled tracking).', {}),
+    _fn('get_journal', 'Behavior-tag journal entries.', {'range': {'type': 'string'}}),
+    _fn('get_journal_insights', 'How tags correlate with the user\'s own metrics.', {'range': {'type': 'string'}}),
+    _fn('get_profile', 'Profile: age, sex, height, weight, step goal.', {}),
+    _fn('get_records', 'Personal records & streaks.', {}),
+    _fn('get_history', 'Compact multi-metric history.', {'range': {'type': 'string'}}),
+    _fn('plot_chart', 'Render a chart for the user from data you fetched. Build the figure yourself.', {
+      'type': {'type': 'string', 'enum': ['bar', 'line', 'area']},
+      'title': {'type': 'string'},
+      'x_labels': {'type': 'array', 'items': {'type': 'string'}},
+      'series': {'type': 'array', 'items': {'type': 'object', 'properties': {
+        'name': {'type': 'string'},
+        'values': {'type': 'array', 'items': {'type': ['number', 'null']}},
+      }}},
+      'unit': {'type': 'string'},
+      'note': {'type': 'string'},
+    }, ['type', 'x_labels', 'series']),
+    _fn('log_journal', 'Log a journal entry (asks the user to confirm).', {
+      'date': {'type': 'string'}, 'tags': {'type': 'array', 'items': {'type': 'string'}}, 'note': {'type': 'string'},
+    }, ['date']),
+    _fn('log_period', 'Log a period start (asks the user to confirm).', {'date': {'type': 'string'}}, ['date']),
+    _fn('start_workout', 'Start a live workout (asks the user to confirm).', {'type': {'type': 'string'}}),
+    _fn('end_workout', 'End the active workout (asks the user to confirm).', {'workout_id': {'type': 'string'}}, ['workout_id']),
+    _fn('set_step_goal', 'Set the daily step goal (asks the user to confirm).', {'goal': {'type': 'integer'}}, ['goal']),
+  ];
+}
+
+class CoachException implements Exception {
+  final String message;
+  CoachException(this.message);
+  @override
+  String toString() => message;
+}

--- a/lib/coach/coach_prompt.dart
+++ b/lib/coach/coach_prompt.dart
@@ -1,0 +1,76 @@
+// The coach's system prompt — domain knowledge + STRICT tool + output contract.
+// The coach reasons ONLY over data it fetches with tools; it never invents numbers.
+
+const String kCoachSystemPrompt = '''
+You are the OpenStrap AI Coach — an expert in wearable physiology, training load,
+sleep science, and HRV, embedded in the user's own OpenStrap app (an open-source
+WHOOP-4.0 alternative). You can read EVERY metric in the user's account via tools
+and render charts the app draws natively.
+
+# SCOPE — stay strictly on-topic (most important rule)
+ONLY answer questions about the user's health and fitness: recovery, sleep, HRV,
+heart rate, strain/training, workouts, steps, body metrics, menstrual cycle,
+recovery-focused nutrition/hydration/caffeine, illness signals, and how to read
+their own OpenStrap data and app features.
+
+REFUSE everything else — coding/programming, math homework, general knowledge,
+trivia, writing essays/emails, current events, anything unrelated to the user's
+health. Do NOT write code under any circumstances. When a request is off-topic,
+decline in ONE friendly sentence and steer back, e.g.: "I'm your health & fitness
+coach, so I'll stick to that — ask me about your recovery, sleep, training, or any
+metric in your data." Do not partially comply (no code snippets, no exceptions).
+
+# How OpenStrap measures things (interpret correctly)
+- Resting HR: 5th-percentile sleeping HR. Lower trend = fitter/recovered.
+- Strain: Banister TRIMP, log-squashed to 0–21 (like WHOOP). Daily load.
+- HRV: RMSSD/SDNN/pNN50 from real RR intervals. Higher RMSSD = more recovered.
+- Recovery: Plews ln(RMSSD) z-score vs the user's baseline → 0–100. Needs ~5 nights.
+- Sleep: Cole-Kripke + HR-dip; stages are BETA (wrist ≠ EEG — never claim clinical accuracy).
+- Training load: EWMA ACWR; 0.8–1.3 = sweet spot, >1.5 = spike risk.
+- Illness watch: Mahalanobis of {resting HR↑, RMSSD↓, skin-temp↑}.
+- Skin temp & SpO₂ are RELATIVE indices (Δ vs personal baseline), NOT clinical °C / %.
+- Steps: AN-2554 estimate. Cycle: log-anchored calendar method (only if user enabled it).
+
+# TOOLS — you MUST fetch before you answer. Never state a number you didn't fetch.
+Read tools (call freely, in parallel when useful):
+- get_today() — today's recovery, strain, sleep, resting HR, steps, readiness, skin-temp/SpO₂ Δ.
+- get_trend(metric, scale) — server-bucketed history. scale ∈ week|month|quarter.
+    metric ∈ strain, recovery, resting_hr, hrv, sdnn, lf_hf, hrv_cv, calories, steps, wear,
+    readiness, vo2max, fitness, fatigue, form, monotony, acwr, dip, efficiency, deep, rem,
+    light, regularity, resp, sleep, stress, skin_temp, spo2.
+- get_day(kind, date) — one day, kind ∈ heart|sleep|strain|stress|wear|timeline|lungs; date=YYYY-MM-DD.
+- get_sleep_history(), get_strain_history(), get_sessions(), get_workouts(range).
+- get_cycle() — menstrual cycle (returns enabled:false if the user hasn't opted in; respect that).
+- get_journal(range), get_journal_insights(range) — behavior tags & their correlations.
+- get_profile(), get_records() (PRs/streaks), get_history(range).
+
+Plot tool — call to SHOW data you fetched (the app animates it):
+- plot_chart(type, title, x_labels, series, unit, note)
+    type ∈ bar|line|area. x_labels: string[]. series: [{name, values:number[]}].
+    values MUST be PLAIN NUMBERS (e.g. 62, not "62 ms"), one per x_label, in the same order;
+    use null only for a genuine gap. For trends/comparisons plot the FULL series of points
+    (one per day/bucket) — never collapse a series to a single averaged point. Use line/area for
+    time-series, bar for one value per category. Build the figure from fetched data (you may
+    combine series, e.g. RMSSD vs resting HR).
+
+Action tools — the app ASKS THE USER TO CONFIRM before any write. Only when clearly requested:
+- log_journal(date, tags, note), log_period(date), start_workout(type), end_workout(workout_id),
+  set_step_goal(goal).
+
+# OUTPUT FORMAT (strict — the app renders Markdown)
+- Be CONCISE. Lead with the direct answer in 1–2 sentences, then brief support.
+- For ANY multi-day / time-series / comparison, call plot_chart INSTEAD of a big table.
+  Use a small Markdown table only for ≤4 rows of non-time data.
+- Bold the key numbers. Cite the metric and day/period ("**62 ms** last night vs your **71 ms** baseline").
+- Keep structure light: at most ONE short "##" heading; do NOT use horizontal rules (---) or
+  stacks of headings. Bullets ("- ") are fine.
+- Emoji: use real Unicode sparingly (✅ ⚠️). NEVER colon shortcodes like ":warning:".
+- End with ONE line "Not medical advice." ONLY when you gave health guidance — not every message.
+
+# Honesty (non-negotiable)
+Never fabricate. Missing data → say so and show "—". Respect honest scope (sleep stages = beta;
+skin-temp/SpO₂ relative; HRV needs enough nights). You are not a doctor.
+
+# Style
+Warm, sharp, evidence-based. Answer → why → (optional) chart → one concrete suggestion.
+''';

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -26,17 +26,7 @@ class LocalDb {
       path,
       onCreate: (db, version) async {
         await _createRaw(db);
-        await db.execute('''
-          CREATE TABLE samples (
-            counter INTEGER PRIMARY KEY,
-            ts INTEGER NOT NULL,
-            hr INTEGER,
-            spo2 INTEGER,
-            skin_temp_c REAL,
-            resting_hr INTEGER,
-            ax REAL, ay REAL, az REAL
-          )
-        ''');
+        await _createSamples(db);
         await db.execute('CREATE INDEX idx_samples_ts ON samples(ts)');
         await _createEvents(db);
       },
@@ -50,9 +40,29 @@ class LocalDb {
           await db.execute('DROP TABLE IF EXISTS raw_records');
           await _createRaw(db);
         }
+        if (oldV < 4) {
+          // The old samples table cached decoded sensor fields (spo2/skin_temp) that
+          // (a) were read from MISIDENTIFIED offsets and (b) nothing ever read. The
+          // edge no longer decodes sensors — drop + recreate as a header-only index.
+          await db.execute('DROP TABLE IF EXISTS samples');
+          await _createSamples(db);
+          await db.execute('CREATE INDEX IF NOT EXISTS idx_samples_ts ON samples(ts)');
+        }
       },
-      version: 3,
+      version: 4,
     );
+  }
+
+  // samples — header-only record index (counter, ts, hr). The band is a raw pipe;
+  // sensors are decoded in the cloud from the uploaded raw hex, never on-device.
+  static Future<void> _createSamples(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS samples (
+        counter INTEGER PRIMARY KEY,
+        ts INTEGER NOT NULL,
+        hr INTEGER
+      )
+    ''');
   }
 
   // raw_records — keyed by the full frame hex (unique; dedupes identical

--- a/lib/data/models.dart
+++ b/lib/data/models.dart
@@ -1,26 +1,17 @@
 // Data models shared across the app.
 
-/// A decoded 1 Hz telemetry sample (from a type-24 record). Mirrors the backend
-/// `samples` columns and parse_r24 output.
+/// The HEADER of a 1 Hz record (type-24 / R10): timestamp + counter + HR. The
+/// sensor block is NOT decoded on-device — the band is a raw pipe, the full frame
+/// is uploaded as hex and the cloud owns the sensor decode.
 class Sample {
   final int tsEpoch;
   final int counter;
   final int hr; // 0 = off-wrist (never display as a heart rate)
-  final int spo2;
-  final double skinTempC;
-  final int restingHr;
-  final double ax, ay, az;
 
   Sample({
     required this.tsEpoch,
     required this.counter,
     required this.hr,
-    required this.spo2,
-    required this.skinTempC,
-    required this.restingHr,
-    required this.ax,
-    required this.ay,
-    required this.az,
   });
 
   bool get wristOn => hr > 0;
@@ -29,36 +20,12 @@ class Sample {
         'ts': tsEpoch,
         'counter': counter,
         'hr': hr,
-        'spo2': spo2,
-        'skin_temp_c': skinTempC,
-        'resting_hr': restingHr,
-        'ax': ax,
-        'ay': ay,
-        'az': az,
       };
 
   factory Sample.fromDbMap(Map<String, dynamic> m) => Sample(
         tsEpoch: m['ts'] as int,
         counter: m['counter'] as int,
         hr: m['hr'] as int,
-        spo2: m['spo2'] as int,
-        skinTempC: (m['skin_temp_c'] as num).toDouble(),
-        restingHr: m['resting_hr'] as int,
-        ax: (m['ax'] as num).toDouble(),
-        ay: (m['ay'] as num).toDouble(),
-        az: (m['az'] as num).toDouble(),
-      );
-
-  factory Sample.fromBackendJson(Map<String, dynamic> m) => Sample(
-        tsEpoch: m['ts'] as int,
-        counter: m['counter'] as int,
-        hr: (m['hr'] ?? 0) as int,
-        spo2: (m['spo2'] ?? 0) as int,
-        skinTempC: ((m['skin_temp_c'] ?? 0) as num).toDouble(),
-        restingHr: (m['resting_hr'] ?? 0) as int,
-        ax: ((m['ax'] ?? 0) as num).toDouble(),
-        ay: ((m['ay'] ?? 0) as num).toDouble(),
-        az: ((m['az'] ?? 0) as num).toDouble(),
       );
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,7 +4,9 @@ import 'package:provider/provider.dart';
 import 'app.dart';
 import 'ble/ios_ble_restore.dart';
 import 'notify/notification_service.dart';
+import 'coach/coach_config.dart';
 import 'state/app_state.dart';
+import 'state/units_controller.dart';
 import 'theme/theme_controller.dart';
 import 'widget/widget_service.dart';
 
@@ -34,11 +36,30 @@ Future<void> main() async {
     );
   }
 
+  // Local display-units preference (metric/imperial). Best-effort; defaults to metric.
+  UnitsController units;
+  try {
+    units = await UnitsController.bootstrap();
+  } catch (e, st) {
+    debugPrint('[main] UnitsController.bootstrap failed, using metric: $e\n$st');
+    units = UnitsController.seed(UnitSystem.metric);
+  }
+
+  // Local BYOK AI-coach config (key in keychain). Best-effort load.
+  final coachConfig = CoachConfig();
+  try {
+    await coachConfig.load();
+  } catch (e, st) {
+    debugPrint('[main] CoachConfig.load failed: $e\n$st');
+  }
+
   runApp(
     MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => AppState()),
         ChangeNotifierProvider<ThemeController>.value(value: theme),
+        ChangeNotifierProvider<UnitsController>.value(value: units),
+        ChangeNotifierProvider<CoachConfig>.value(value: coachConfig),
       ],
       child: const OpenStrapApp(),
     ),

--- a/lib/net/api_client.dart
+++ b/lib/net/api_client.dart
@@ -236,6 +236,31 @@ class ApiClient {
   Future<Map<String, dynamic>> getJournalInsights({String range = '90d'}) =>
       _getObj('/journal/insights', {'range': range});
 
+  /// POST /spotcheck — decode collected live RR frames → HRV (RMSSD/SDNN/pNN50/HR).
+  Future<Map<String, dynamic>> spotCheck(List<String> records) async {
+    final resp = await _authed((h) => _client.post(_u('/spotcheck'),
+        headers: h, body: jsonEncode({'records': records})));
+    if (resp.statusCode != 200) throw ApiException(resp.statusCode, resp.body);
+    return _decode(resp.body);
+  }
+
+  // ── menstrual cycle ────────────────────────────────────────────────────────
+  /// GET /cycle → phase + prediction + logs + biometric overlay.
+  Future<Map<String, dynamic>> getCycle() => _getObj('/cycle');
+
+  /// POST /cycle/log — log a period event (kind: start|end|spotting).
+  Future<void> postCycleLog(String date, {String kind = 'start', String? note}) async {
+    final resp = await _authed((h) => _client.post(_u('/cycle/log'),
+        headers: h, body: jsonEncode({'date': date, 'kind': kind, if (note != null) 'note': note})));
+    if (resp.statusCode != 200) throw ApiException(resp.statusCode, resp.body);
+  }
+
+  /// DELETE /cycle/log?date= — remove a logged event.
+  Future<void> deleteCycleLog(String date) async {
+    final resp = await _authed((h) => _client.delete(_u('/cycle/log', {'date': date}), headers: h));
+    if (resp.statusCode != 200) throw ApiException(resp.statusCode, resp.body);
+  }
+
   // ── day drill-down detail (all computed server-side) ───────────────────────
   /// GET /day/strain?date= → cumulative strain curve + zones + HR stats + sessions.
   Future<Map<String, dynamic>> getDayStrain(String date) =>

--- a/lib/notify/notification_relay.dart
+++ b/lib/notify/notification_relay.dart
@@ -1,0 +1,217 @@
+// notification_relay.dart — relay selected phone-app notifications to the strap as
+// a haptic buzz. ANDROID ONLY: it rides Android's NotificationListenerService (the
+// `notification_listener_service` plugin). iOS has no API to observe other apps'
+// notifications, so on iOS this whole feature is inert and the UI never shows it.
+//
+// Flow: user grants "Notification access" + picks apps → we subscribe to the system
+// notification stream → for each NEW notification whose package is on the allow-list,
+// we buzz the band (Cmd.runHapticsPattern, via the injected callback). Same persisted
+// ChangeNotifier idiom as GestureSettings/ThemeController so the settings UI is live.
+
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/services.dart' show MethodChannel;
+import 'package:flutter/widgets.dart';
+import 'package:notification_listener_service/notification_event.dart';
+import 'package:notification_listener_service/notification_listener_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class NotificationRelay extends ChangeNotifier with WidgetsBindingObserver {
+  NotificationRelay({required this.buzz, required this.isConnected});
+
+  // The plugin's own MethodChannel. v1.0.0's Dart API doesn't expose the native
+  // rebind/health handlers, so we invoke them directly to self-heal when Android
+  // unbinds the NotificationListenerService (it does this routinely over time).
+  static const MethodChannel _pluginChannel =
+      MethodChannel('x-slayer/notifications_channel');
+  static const Duration _healEvery = Duration(seconds: 120);
+  Timer? _healTimer;
+
+  /// Fire the strap haptic. Wired by AppState to `engine.buzz()`. Best-effort.
+  final Future<void> Function() buzz;
+
+  /// Whether the band is currently connected (no point buzzing nothing).
+  final bool Function() isConnected;
+
+  static const _kEnabled = 'notif_relay_enabled';
+  static const _kPackages = 'notif_relay_packages';
+
+  /// Only Android can observe other apps' notifications. Everything below is a
+  /// no-op when this is false, and the UI hides the feature entirely.
+  bool get supported => Platform.isAndroid;
+
+  bool _enabled = false;
+  bool get enabled => _enabled;
+
+  bool _granted = false;
+  bool get permissionGranted => _granted;
+
+  final Set<String> _packages = {};
+  Set<String> get packages => _packages;
+  bool isAppEnabled(String pkg) => _packages.contains(pkg);
+  int get appCount => _packages.length;
+
+  /// True only when everything needed to actually buzz is in place.
+  bool get active => supported && _enabled && _granted && _packages.isNotEmpty;
+
+  StreamSubscription<ServiceNotificationEvent>? _sub;
+  // Per-package de-dupe: ignore repeat posts of the same app within this window
+  // (apps re-post the same notification as it updates), plus a global floor so a
+  // burst never machine-guns the strap.
+  final Map<String, int> _lastBuzzMs = {};
+  int _lastAnyBuzzMs = 0;
+  static const _perAppCooldownMs = 4000;
+  static const _globalFloorMs = 800;
+
+  /// Load saved state, refresh permission, and start listening if active. Call
+  /// once at startup. No-op on iOS.
+  Future<void> bootstrap() async {
+    if (!supported) return;
+    final prefs = await SharedPreferences.getInstance();
+    _enabled = prefs.getBool(_kEnabled) ?? false;
+    _packages
+      ..clear()
+      ..addAll(prefs.getStringList(_kPackages) ?? const []);
+    WidgetsBinding.instance.addObserver(this);
+    await refreshPermission();
+    _resync();
+    notifyListeners();
+  }
+
+  // The OS can unbind the listener and kill our stream while we're backgrounded.
+  // On every foreground return, re-check the grant and force the listener back.
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed && supported) {
+      refreshPermission().then((_) {
+        _resync();
+        _heal();
+      });
+    }
+  }
+
+  /// Re-query the OS "Notification access" grant (it can change while we're
+  /// backgrounded — user revokes it in Settings). Returns the current value.
+  Future<bool> refreshPermission() async {
+    if (!supported) return false;
+    try {
+      _granted = await NotificationListenerService.isPermissionGranted();
+    } catch (_) {
+      _granted = false;
+    }
+    notifyListeners();
+    return _granted;
+  }
+
+  /// Open the system Notification-access settings page and return once the user
+  /// comes back. We re-read the real grant rather than trusting the return value.
+  Future<bool> requestPermission() async {
+    if (!supported) return false;
+    try {
+      await NotificationListenerService.requestPermission();
+    } catch (_) {/* user may just back out */}
+    final ok = await refreshPermission();
+    _resync();
+    return ok;
+  }
+
+  Future<void> setEnabled(bool on) async {
+    if (!supported || on == _enabled) return;
+    _enabled = on;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_kEnabled, on);
+    _resync();
+    notifyListeners();
+  }
+
+  Future<void> setAppEnabled(String pkg, bool on) async {
+    if (!supported) return;
+    if (on) {
+      if (!_packages.add(pkg)) return;
+    } else {
+      if (!_packages.remove(pkg)) return;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_kPackages, _packages.toList());
+    _resync();
+    notifyListeners();
+  }
+
+  // Subscribe only when the feature can actually do something; otherwise tear the
+  // stream down so we're not holding a system callback for nothing. Also runs a
+  // periodic heal so a system-unbound listener gets re-armed while we're alive.
+  void _resync() {
+    final shouldListen = supported && _enabled && _granted;
+    if (shouldListen) {
+      _startListening();
+      _healTimer ??= Timer.periodic(_healEvery, (_) => _heal());
+    } else {
+      _sub?.cancel();
+      _sub = null;
+      _healTimer?.cancel();
+      _healTimer = null;
+    }
+  }
+
+  void _startListening() {
+    if (_sub != null) return;
+    try {
+      _sub = NotificationListenerService.notificationsStream.listen(
+        _onNotification,
+        // If the stream errors or closes, drop it and let the next _resync/heal
+        // re-arm — a dead subscription must never silently stay dead.
+        onError: (_) {
+          _sub?.cancel();
+          _sub = null;
+        },
+        onDone: () {
+          _sub = null;
+        },
+        cancelOnError: true,
+      );
+    } catch (_) {/* stream unavailable — stay inert */}
+  }
+
+  // Ask the native side whether the listener is still bound; if not, force a
+  // rebind + reconnect via the plugin's (Dart-unexposed) handlers. All best-effort
+  // — older plugin builds or pre-API-24 devices simply no-op.
+  Future<void> _heal() async {
+    if (!active) return;
+    _startListening(); // re-arm the Dart stream if it died
+    try {
+      final connected =
+          await _pluginChannel.invokeMethod<bool>('isServiceConnected') ?? true;
+      if (!connected) {
+        try { await _pluginChannel.invokeMethod('forceRequestRebind'); } catch (_) {}
+        try { await _pluginChannel.invokeMethod('reconnectService'); } catch (_) {}
+      }
+    } catch (_) {/* handler absent on this plugin build — ignore */}
+  }
+
+  void _onNotification(ServiceNotificationEvent e) {
+    // Only fresh, user-facing posts: skip removals and persistent/ongoing ones
+    // (media players, foreground-service notifications) — those aren't "a ping".
+    if (e.hasRemoved || e.onGoing) return;
+    final pkg = e.packageName;
+    if (pkg.isEmpty || !_packages.contains(pkg)) return;
+    if (!isConnected()) return;
+
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final lastForPkg = _lastBuzzMs[pkg] ?? 0;
+    if (now - lastForPkg < _perAppCooldownMs) return;
+    if (now - _lastAnyBuzzMs < _globalFloorMs) return;
+    _lastBuzzMs[pkg] = now;
+    _lastAnyBuzzMs = now;
+    // Fire-and-forget; never let a BLE hiccup throw into the system callback.
+    unawaited(buzz().catchError((_) {}));
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _healTimer?.cancel();
+    _sub?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/protocol/records.dart
+++ b/lib/protocol/records.dart
@@ -47,32 +47,28 @@ Uint8List hexToBytes(String hex) {
 }
 
 // ── 5.5 The type-24 record (the historical substrate), 1 Hz ──────────────────
+// EDGE DECODES HEADER ONLY. The band is a raw sensor pipe: the full frame is
+// stored + uploaded as hex (raw_records) and the CLOUD owns the sensor decode
+// (openstrap-protocol/ts/records.ts → spo2/temp/ppg/ambient/HRV). We extract just
+// the header here for sync bookkeeping (timestamp span, idempotency counter, HR).
+// Do NOT re-add the sensor block on-device — it's never read and the cloud is the
+// system of record.
 class R24 {
   final int tsEpoch; // u32 @[7:11] seconds — AUTHORITATIVE
   final int tsSubsec; // u16 @[11:13] — AUTHORITATIVE
   final int counter; // u32 @[3:7] — AUTHORITATIVE (idempotency key)
   final int hr; // u8 @[17] bpm — AUTHORITATIVE; 0 = no reading (off-wrist)
-  final int spo2; // u8 @[72] % — EMPIRICAL
-  final double skinTempC; // [70]/4 °C — EMPIRICAL
-  final int restingHr; // u8 @[88] — EMPIRICAL (held baseline)
-  final List<double> accelG; // float32 ×3 @[36:48] g — EMPIRICAL
-  final String rawTail; // [13:] hex — app-opaque (relayed raw to cloud)
 
   R24({
     required this.tsEpoch,
     required this.tsSubsec,
     required this.counter,
     required this.hr,
-    required this.spo2,
-    required this.skinTempC,
-    required this.restingHr,
-    required this.accelG,
-    required this.rawTail,
   });
 }
 
-/// Decode a type-24 record. `inner` starts at the packet_type byte (offset 0).
-/// Returns null if too short (guard `< 89`).
+/// Decode the HEADER of a type-24 record (`inner` starts at the packet_type byte).
+/// Returns null if too short. Sensors live in the raw hex; the cloud decodes them.
 R24? parseR24(Uint8List inner) {
   if (inner.length < 89) return null;
   return R24(
@@ -80,15 +76,6 @@ R24? parseR24(Uint8List inner) {
     tsSubsec: u16(inner, 11),
     counter: u32(inner, 3),
     hr: inner[17],
-    spo2: inner[72],
-    skinTempC: _round(inner[70] / 4.0, 2),
-    restingHr: inner[88],
-    accelG: [
-      _round(f32(inner, 36), 4),
-      _round(f32(inner, 40), 4),
-      _round(f32(inner, 44), 4),
-    ],
-    rawTail: _hex(Uint8List.sublistView(inner, 13)),
   );
 }
 
@@ -370,7 +357,8 @@ Decoded _decodeDataRecord(Uint8List inner) {
       return Decoded('realtime_hr', {'rec_type': recType, 'hr': r.hr, 'wearing': true});
     }
   }
-  // Big record by type byte. We only field-decode R24 (the substrate).
+  // R24: header only on-device (ts/counter/hr). The full frame is uploaded as raw
+  // hex and the cloud decodes the sensor block.
   if (recType == Record.r24) {
     final r = parseR24(inner);
     if (r != null) {
@@ -379,11 +367,6 @@ Decoded _decodeDataRecord(Uint8List inner) {
         'ts_subsec': r.tsSubsec,
         'counter': r.counter,
         'hr': r.hr,
-        'spo2': r.spo2,
-        'skin_temp_c': r.skinTempC,
-        'resting_hr': r.restingHr,
-        'accel_g': r.accelG,
-        'raw_tail': r.rawTail,
       });
     }
   }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -341,6 +341,11 @@ class AppState extends ChangeNotifier {
   }
 
   Future<void> _onRecord(Sample? sample, RawRecord raw) async {
+    // Spot-check: tap the live RR-bearing frames (0x28 compact HR, 0x2B R10) into
+    // the in-memory scan buffer. Cheap-bounded; cleared at each scan start.
+    if (spotActive && (raw.packetType == 0x28 || raw.packetType == 0x2B)) {
+      if (_spotFrames.length < 8000) _spotFrames.add(raw.hex);
+    }
     await LocalDb.insertRecord(raw, sample);
   }
 
@@ -630,6 +635,83 @@ class AppState extends ChangeNotifier {
     if (!await FlutterBluePlus.isSupported) return false;
     final state = await FlutterBluePlus.adapterState.first;
     return state == BluetoothAdapterState.on;
+  }
+
+  // ── live HRV spot-check ──────────────────────────────────────────────────────
+  // User taps "spot check": we enable wrist-gated optical + realtime records,
+  // collect live frames for [spotDuration]s, then POST them to /spotcheck which
+  // decodes RR + computes HRV server-side. Ephemeral — nothing is stored.
+  static const int spotDuration = 60;
+  bool spotActive = false;
+  int spotRemaining = 0;             // seconds left in the current scan
+  Map<String, dynamic>? spotResult;  // last result {rmssd, sdnn, mean_hr, n_beats, ok}
+  String? spotError;
+  final List<String> _spotFrames = [];
+  Timer? _spotTimer;
+  bool _spotEnabledStreams = false;  // did WE turn streams on (so we turn them off)
+
+  /// Begin a 60s live HRV reading. Requires a connected band.
+  Future<void> startSpotCheck() async {
+    if (spotActive) return;
+    if (!isConnected) { spotError = 'Connect your band first.'; notifyListeners(); return; }
+    spotActive = true;
+    spotError = null;
+    spotResult = null;
+    spotRemaining = spotDuration;
+    _spotFrames.clear();
+    notifyListeners();
+    try {
+      // If a workout is already streaming, reuse it; else turn streams on ourselves.
+      if (activeWorkout == null) { await engine.enableLiveStreams(); _spotEnabledStreams = true; }
+    } catch (_) {/* best-effort; we still collect whatever arrives */}
+    _spotTimer?.cancel();
+    _spotTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      spotRemaining -= 1;
+      if (spotRemaining <= 0) { unawaited(_finishSpotCheck()); } else { notifyListeners(); }
+    });
+  }
+
+  /// Abort an in-progress scan without computing.
+  void cancelSpotCheck() {
+    if (!spotActive) return;
+    _spotTimer?.cancel();
+    _spotTimer = null;
+    spotActive = false;
+    spotRemaining = 0;
+    _stopSpotStreams();
+    notifyListeners();
+  }
+
+  Future<void> _finishSpotCheck() async {
+    _spotTimer?.cancel();
+    _spotTimer = null;
+    spotRemaining = 0;
+    _stopSpotStreams();
+    final frames = List<String>.from(_spotFrames);
+    notifyListeners();
+    try {
+      final res = api == null || frames.isEmpty
+          ? null
+          : await api!.spotCheck(frames);
+      spotResult = res;
+      if (res == null) {
+        spotError = 'No reading captured — keep the band snug and still.';
+      } else if (res['ok'] != true) {
+        spotError = 'Not enough clean beats — try again, sitting still.';
+      }
+    } catch (e) {
+      spotError = 'Spot check failed: ${e is ApiException ? e.body : e}';
+    } finally {
+      spotActive = false;
+      notifyListeners();
+    }
+  }
+
+  void _stopSpotStreams() {
+    if (_spotEnabledStreams && activeWorkout == null) {
+      unawaited(engine.disableLiveStreams());
+    }
+    _spotEnabledStreams = false;
   }
 
   // ── live session coach ───────────────────────────────────────────────────────

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -58,6 +58,12 @@ class AppState extends ChangeNotifier {
   bool _keepAlive = false;
   bool _reconnecting = false;
   String _prevConn = 'disconnected';
+  // Last battery snapshot pushed to the Band Battery widget — so we only reload
+  // the widget when pct/charging actually change (the engine-state hook fires
+  // ~1 Hz on live HR). -2 = never pushed.
+  int _widgetBattPct = -2;
+  bool? _widgetBattCharging;
+  String? _widgetBattName;
   bool initialized = false;
 
   /// True while the app is backgrounded. On iOS we KEEP the BLE connection alive in
@@ -343,6 +349,17 @@ class AppState extends ChangeNotifier {
   void _onEngineState(DeviceState s) {
     // Battery-low / charging OS notifications (edge-triggered + de-duped inside).
     _deviceAlerts.onDeviceState(batteryPct: s.batteryPct, charging: s.charging);
+    // Keep the lock-screen Band Battery widget current — only when it changed.
+    final battPct = s.batteryPct?.round() ?? -1;
+    if (battPct != _widgetBattPct ||
+        s.charging != _widgetBattCharging ||
+        s.strapName != _widgetBattName) {
+      _widgetBattPct = battPct;
+      _widgetBattCharging = s.charging;
+      _widgetBattName = s.strapName;
+      unawaited(WidgetService.pushBattery(
+          s.batteryPct == null ? null : battPct, s.charging, s.strapName));
+    }
     if (_prevConn != 'disconnected' && s.connection == 'disconnected') {
       if (_keepAlive && isPaired && !_reconnecting) {
         _log('Connection dropped — reconnecting…');

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -26,6 +26,7 @@ import '../data/models.dart';
 import '../net/api_client.dart';
 import '../live/live_activity.dart';
 import '../notify/device_alerts.dart';
+import '../notify/notification_relay.dart';
 import '../notify/notification_service.dart';
 import '../sync/config.dart';
 import '../sync/edge_tracking.dart';
@@ -49,6 +50,13 @@ class AppState extends ChangeNotifier {
   /// Band-gesture → action mapping (double-tap, etc.). Exposed for the settings UI.
   final GestureSettings gestureSettings = GestureSettings();
   late final GestureDispatcher _gestureDispatcher;
+
+  /// Relay selected phone-app notifications to the strap as a buzz (Android only).
+  /// Exposed for the settings UI; buzzes via the live BLE engine when connected.
+  late final NotificationRelay notificationRelay = NotificationRelay(
+    buzz: () => engine.buzz(),
+    isConnected: () => engine.isConnected,
+  );
   Sample? lastSynced;
   Map<String, int> dbCounts = {'raw': 0, 'pending': 0};
   final List<String> logLines = [];
@@ -195,6 +203,8 @@ class AppState extends ChangeNotifier {
     // Band-gesture mapping: load the saved action + query native capabilities so the
     // settings UI knows what this platform supports. Best-effort, non-blocking.
     unawaited(gestureSettings.bootstrap());
+    // Notification relay (Android only; inert + invisible elsewhere). Best-effort.
+    unawaited(notificationRelay.bootstrap());
     initialized = true;
     notifyListeners();
     // App status (OTA pointer + admin alert banner) — best-effort, non-blocking.

--- a/lib/state/units_controller.dart
+++ b/lib/state/units_controller.dart
@@ -1,0 +1,87 @@
+// Units controller — a LOCAL display preference (metric / imperial). The backend
+// always stores and returns metric (kg, cm); this only changes how values are
+// shown and how edit fields are parsed. Persisted on-device via SharedPreferences,
+// mirroring ThemeController. Nothing here ever touches the server.
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum UnitSystem { metric, imperial }
+
+extension UnitSystemLabel on UnitSystem {
+  String get label => this == UnitSystem.imperial ? 'Imperial' : 'Metric';
+}
+
+class UnitsController extends ChangeNotifier {
+  static const String _kUnits = 'units_system'; // 'metric' | 'imperial'
+  static const double _kgPerLb = 0.45359237;
+  static const double _cmPerIn = 2.54;
+
+  UnitSystem _system;
+  UnitsController._(this._system);
+
+  factory UnitsController.seed(UnitSystem s) => UnitsController._(s);
+
+  static Future<UnitsController> bootstrap() async {
+    final prefs = await SharedPreferences.getInstance();
+    return UnitsController._(_parse(prefs.getString(_kUnits)));
+  }
+
+  static UnitSystem _parse(String? s) =>
+      s == 'imperial' ? UnitSystem.imperial : UnitSystem.metric;
+
+  UnitSystem get system => _system;
+  bool get isImperial => _system == UnitSystem.imperial;
+
+  Future<void> setSystem(UnitSystem s) async {
+    if (_system == s) return;
+    _system = s;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kUnits, s.name);
+  }
+
+  // ── display (input is always metric, as stored) ────────────────────────────
+  String _trim(num v) =>
+      v == v.roundToDouble() ? v.round().toString() : v.toStringAsFixed(1);
+
+  /// "70 kg" / "154 lb" / "—".
+  String weight(num? kg) {
+    if (kg == null) return '—';
+    return isImperial ? '${(kg / _kgPerLb).round()} lb' : '${_trim(kg)} kg';
+  }
+
+  /// "180 cm" / "5′11″" / "—".
+  String height(num? cm) {
+    if (cm == null) return '—';
+    if (!isImperial) return '${_trim(cm)} cm';
+    final totalIn = (cm / _cmPerIn).round();
+    return "${totalIn ~/ 12}′${totalIn % 12}″";
+  }
+
+  // ── edit-field helpers (display ↔ metric for storage) ──────────────────────
+  String get weightLabel => isImperial ? 'Weight (lb)' : 'Weight (kg)';
+  String get heightLabel => isImperial ? 'Height (in)' : 'Height (cm)';
+
+  /// Pre-fill value for the weight field in the user's units.
+  String weightField(num? kg) =>
+      kg == null ? '' : (isImperial ? (kg / _kgPerLb).round().toString() : _trim(kg));
+
+  /// Pre-fill value for the height field in the user's units (total inches).
+  String heightField(num? cm) =>
+      cm == null ? '' : (isImperial ? (cm / _cmPerIn).round().toString() : _trim(cm));
+
+  /// Parse a weight field (display units) → kg for storage.
+  double? weightToKg(String text) {
+    final v = double.tryParse(text.trim());
+    if (v == null) return null;
+    return isImperial ? v * _kgPerLb : v;
+  }
+
+  /// Parse a height field (display units = total inches when imperial) → cm.
+  double? heightToCm(String text) {
+    final v = double.tryParse(text.trim());
+    if (v == null) return null;
+    return isImperial ? v * _cmPerIn : v;
+  }
+}

--- a/lib/ui/coach/ai_coach_screen.dart
+++ b/lib/ui/coach/ai_coach_screen.dart
@@ -1,0 +1,372 @@
+// The AI Coach chat (BYOK, agentic). Runs CoachEngine, renders interleaved text +
+// animated charts, and surfaces write-actions for explicit confirmation. Distinct
+// from the rule-based CoachScreen (deterministic plan).
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+
+import '../../coach/coach_config.dart';
+import '../../coach/coach_engine.dart';
+import '../../state/app_state.dart';
+import '../../theme/theme.dart';
+import '../../theme/tokens.dart';
+import '../kit/kit.dart';
+import 'coach_chart.dart';
+import 'coach_settings_screen.dart';
+
+class AiCoachScreen extends StatefulWidget {
+  const AiCoachScreen({super.key});
+  @override
+  State<AiCoachScreen> createState() => _AiCoachScreenState();
+}
+
+class _AiCoachScreenState extends State<AiCoachScreen> {
+  CoachEngine? _engine;
+  final List<CoachItem> _items = [];
+  final _input = TextEditingController();
+  final _scroll = ScrollController();
+  bool _busy = false;
+  String? _status;
+
+  static const _starters = [
+    'How recovered am I today, and why?',
+    'Show my HRV trend this month',
+    'Compare my resting HR vs HRV over 2 weeks',
+    'How has my sleep been this week?',
+    'What should my training look like today?',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _initEngine();
+  }
+
+  Future<void> _initEngine() async {
+    final app = context.read<AppState>();
+    final cfg = context.read<CoachConfig>();
+    final api = app.api;
+    if (api == null) return;
+    final uid = (app.user?['id'] ?? 'anon').toString();
+    final engine = CoachEngine(config: cfg, api: api, storageKey: uid);
+    await engine.restore();
+    if (!mounted) return;
+    setState(() {
+      _engine = engine;
+      _items
+        ..clear()
+        ..addAll(engine.transcript);
+    });
+    _scrollDown();
+  }
+
+  @override
+  void dispose() {
+    _input.dispose();
+    _scroll.dispose();
+    _engine?.dispose();
+    super.dispose();
+  }
+
+  Future<void> _send(String text) async {
+    final t = text.trim();
+    if (t.isEmpty || _busy) return;
+    final engine = _engine;
+    if (engine == null) return;
+    _input.clear();
+    setState(() => _busy = true);
+    try {
+      await engine.send(
+        t,
+        onItem: (it) { setState(() => _items.add(it)); _scrollDown(); },
+        onStatus: (s) => setState(() => _status = s),
+        confirm: _confirm,
+      );
+    } catch (e) {
+      setState(() => _items.add(CoachItem.error(
+          e is CoachException ? e.message : 'Something went wrong: $e')));
+    } finally {
+      if (mounted) setState(() { _busy = false; _status = null; });
+      await engine.persist(); // survive reopen
+      _scrollDown();
+    }
+  }
+
+  void _newChat() {
+    _engine?.newSession();
+    setState(() => _items.clear());
+  }
+
+  void _openSession(String id) async {
+    await _engine?.openSession(id);
+    if (mounted) {
+      setState(() => _items
+        ..clear()
+        ..addAll(_engine?.transcript ?? const []));
+      _scrollDown();
+    }
+  }
+
+  Future<void> _openSessions() async {
+    final engine = _engine;
+    if (engine == null) return;
+    await showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: AppColors.surface,
+      showDragHandle: true,
+      isScrollControlled: true,
+      builder: (sheetCtx) => StatefulBuilder(
+        builder: (sheetCtx, setSheet) => FutureBuilder<List<CoachSessionMeta>>(
+          future: engine.listSessions(),
+          builder: (_, snap) {
+            final sessions = snap.data ?? const <CoachSessionMeta>[];
+            return DraggableScrollableSheet(
+              expand: false,
+              initialChildSize: 0.6,
+              maxChildSize: 0.9,
+              builder: (_, controller) => ListView(
+                controller: controller,
+                padding: const EdgeInsets.symmetric(horizontal: Sp.screen),
+                children: [
+                  Row(children: [
+                    Text('Chat history', style: AppText.h2),
+                    const Spacer(),
+                    TextButton.icon(
+                      onPressed: () { Navigator.pop(sheetCtx); _newChat(); },
+                      icon: AppIcon(Ic.plus, size: 16, color: AppColors.coral),
+                      label: Text('New chat', style: AppText.label.copyWith(color: AppColors.coral)),
+                    ),
+                  ]),
+                  const SizedBox(height: Sp.x3),
+                  if (snap.connectionState == ConnectionState.waiting)
+                    const Padding(padding: EdgeInsets.all(Sp.x6), child: Center(child: CircularProgressIndicator()))
+                  else if (sessions.isEmpty)
+                    Padding(padding: const EdgeInsets.all(Sp.x4),
+                        child: Text('No past chats yet.', style: AppText.captionMuted))
+                  else
+                    for (final s in sessions)
+                      ProCard(
+                        onTap: () { Navigator.pop(sheetCtx); _openSession(s.id); },
+                        child: Row(children: [
+                          Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+                            Text(s.title.isEmpty ? 'Untitled chat' : s.title,
+                                style: AppText.label, maxLines: 1, overflow: TextOverflow.ellipsis),
+                            if (s.preview.isNotEmpty) ...[
+                              const SizedBox(height: 2),
+                              Text(s.preview, style: AppText.captionMuted, maxLines: 1, overflow: TextOverflow.ellipsis),
+                            ],
+                            const SizedBox(height: 2),
+                            Text(_relTime(s.updatedAt), style: AppText.captionMuted),
+                          ])),
+                          IconButton(
+                            icon: AppIcon(Ic.trash, size: 16, color: AppColors.inkMuted),
+                            onPressed: () async {
+                              final wasCurrent = s.id == engine.sessionId;
+                              await engine.deleteSession(s.id);
+                              setSheet(() {});
+                              // deleting the open chat resets it to a fresh one
+                              if (wasCurrent && mounted) setState(() => _items.clear());
+                            },
+                          ),
+                        ]),
+                      ),
+                  const SizedBox(height: 40),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  static String _relTime(int ms) {
+    final d = DateTime.now().difference(DateTime.fromMillisecondsSinceEpoch(ms));
+    if (d.inMinutes < 1) return 'just now';
+    if (d.inMinutes < 60) return '${d.inMinutes}m ago';
+    if (d.inHours < 24) return '${d.inHours}h ago';
+    return '${d.inDays}d ago';
+  }
+
+  Future<bool> _confirm(ActionRequest req) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppColors.surface,
+        title: Text(req.title, style: AppText.title),
+        content: Text(req.summary, style: AppText.body),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          FilledButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Confirm')),
+        ],
+      ),
+    );
+    return ok ?? false;
+  }
+
+  void _scrollDown() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scroll.hasClients) {
+        _scroll.animateTo(_scroll.position.maxScrollExtent,
+            duration: const Duration(milliseconds: 250), curve: Curves.easeOut);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cfg = context.watch<CoachConfig>();
+    final signedIn = context.select<AppState, bool>((s) => s.api != null);
+
+    return Scaffold(
+      backgroundColor: AppColors.bg,
+      body: SafeArea(
+        child: Column(children: [
+          _topBar(cfg),
+          Expanded(
+            child: !cfg.configured
+                ? _setupPrompt()
+                : !signedIn
+                    ? _centered('Sign in to use the coach.')
+                    : _items.isEmpty
+                        ? _starterView()
+                        : _transcript(),
+          ),
+          if (_status != null) _statusBar(),
+          if (cfg.configured && signedIn) _composer(),
+        ]),
+      ),
+    );
+  }
+
+  Widget _topBar(CoachConfig cfg) => Padding(
+        padding: const EdgeInsets.fromLTRB(Sp.screen, Sp.x4, Sp.screen, Sp.x2),
+        child: Row(children: [
+          RoundIconButton(Ic.arrowLeft, onTap: () => Navigator.of(context).pop()),
+          const SizedBox(width: Sp.x3),
+          Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+            Text('AI Coach', style: AppText.h1),
+            Text(cfg.configured ? cfg.model : 'Not configured', style: AppText.caption),
+          ])),
+          RoundIconButton(Ic.history, onTap: _openSessions),
+          const SizedBox(width: Sp.x2),
+          RoundIconButton(Ic.plus, onTap: _newChat),
+          const SizedBox(width: Sp.x2),
+          RoundIconButton(Ic.settings, onTap: () => Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const CoachSettingsScreen()))),
+        ]),
+      );
+
+  Widget _setupPrompt() => Center(child: Padding(
+        padding: const EdgeInsets.all(Sp.x6),
+        child: Column(mainAxisSize: MainAxisSize.min, children: [
+          AppIcon(Ic.ai, size: 40, color: AppColors.coral),
+          const SizedBox(height: Sp.x4),
+          Text('Bring your own AI', style: AppText.h2),
+          const SizedBox(height: Sp.x3),
+          Text('Use any OpenAI-compatible provider with your own API key. Your key '
+              'stays on this device and talks to the provider directly — it never '
+              'touches OpenStrap servers.',
+              textAlign: TextAlign.center, style: AppText.bodySoft),
+          const SizedBox(height: Sp.x5),
+          FilledButton(
+            onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const CoachSettingsScreen())),
+            child: const Text('Set up your AI coach'),
+          ),
+        ]),
+      ));
+
+  Widget _starterView() => ListView(
+        padding: const EdgeInsets.all(Sp.screen),
+        children: [
+          const SizedBox(height: Sp.x4),
+          Text('Ask me anything about your health', style: AppText.h2),
+          const SizedBox(height: Sp.x2),
+          Text('I can read every metric in your account and chart it.', style: AppText.captionMuted),
+          const SizedBox(height: Sp.x5),
+          for (final s in _starters)
+            Padding(
+              padding: const EdgeInsets.only(bottom: Sp.x3),
+              child: ProCard(onTap: () => _send(s), child: Row(children: [
+                Expanded(child: Text(s, style: AppText.body)),
+                AppIcon(Ic.arrowRight, size: 16, color: AppColors.inkMuted),
+              ])),
+            ),
+        ],
+      );
+
+  Widget _transcript() => ListView.builder(
+        controller: _scroll,
+        padding: const EdgeInsets.all(Sp.screen),
+        itemCount: _items.length,
+        itemBuilder: (_, i) => _bubble(_items[i]),
+      );
+
+  Widget _bubble(CoachItem it) {
+    switch (it.kind) {
+      case CoachItemKind.user:
+        return Align(
+          alignment: Alignment.centerRight,
+          child: Container(
+            margin: const EdgeInsets.only(bottom: Sp.x3, left: 40),
+            padding: const EdgeInsets.symmetric(horizontal: Sp.x4, vertical: Sp.x3),
+            decoration: BoxDecoration(color: AppColors.coralSoft, borderRadius: BorderRadius.circular(R.card)),
+            child: Text(it.text ?? '', style: AppText.body.copyWith(color: AppColors.coralInk)),
+          ),
+        );
+      case CoachItemKind.assistant:
+        return Padding(
+          padding: const EdgeInsets.only(bottom: Sp.x4, right: 8),
+          child: GptMarkdown(it.text ?? '', style: AppText.body),
+        );
+      case CoachItemKind.chart:
+        return Padding(
+          padding: const EdgeInsets.only(bottom: Sp.x4),
+          child: CoachChart(spec: it.chart!),
+        );
+      case CoachItemKind.error:
+        return Padding(
+          padding: const EdgeInsets.only(bottom: Sp.x4),
+          child: ProCard(child: Row(children: [
+            AppIcon(Ic.info, size: 16, color: AppColors.warn),
+            const SizedBox(width: Sp.x3),
+            Expanded(child: Text(it.text ?? '', style: AppText.captionMuted)),
+          ])),
+        );
+    }
+  }
+
+  Widget _statusBar() => Padding(
+        padding: const EdgeInsets.symmetric(horizontal: Sp.screen, vertical: Sp.x2),
+        child: Row(children: [
+          const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2)),
+          const SizedBox(width: Sp.x3),
+          Text(_status ?? '', style: AppText.captionMuted),
+        ]),
+      );
+
+  Widget _composer() => Padding(
+        padding: EdgeInsets.fromLTRB(Sp.screen, Sp.x2, Sp.screen,
+            Sp.x3 + MediaQuery.of(context).viewInsets.bottom),
+        child: Row(children: [
+          Expanded(child: TextField(
+            controller: _input,
+            minLines: 1, maxLines: 4,
+            textInputAction: TextInputAction.send,
+            onSubmitted: _busy ? null : _send,
+            decoration: const InputDecoration(hintText: 'Ask about your health…'),
+          )),
+          const SizedBox(width: Sp.x3),
+          FilledButton(
+            onPressed: _busy ? null : () => _send(_input.text),
+            child: const AppIcon(Ic.arrowRight, size: 18, color: Colors.white),
+          ),
+        ]),
+      );
+
+  Widget _centered(String msg) => Center(child: Padding(
+      padding: const EdgeInsets.all(Sp.x6),
+      child: Text(msg, textAlign: TextAlign.center, style: AppText.bodySoft)));
+}

--- a/lib/ui/coach/coach_chart.dart
+++ b/lib/ui/coach/coach_chart.dart
@@ -1,0 +1,182 @@
+// Renders a ChartSpec (built by the coach from real data) as an ANIMATED native
+// chart, using the app's look. Bars reuse LabeledBars; line/area use an animated
+// multi-series painter. Honest: it only ever plots the numbers the model passed.
+
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+
+import '../../coach/coach_engine.dart';
+import '../../theme/theme.dart';
+import '../../theme/tokens.dart';
+import '../kit/kit.dart';
+import '../kit/charts.dart';
+
+class CoachChart extends StatelessWidget {
+  final ChartSpec spec;
+  const CoachChart({super.key, required this.spec});
+
+  List<Color> get _colors => [
+        AppColors.coral,
+        AppColors.good,
+        AppColors.loadDetraining,
+        AppColors.warn,
+        AppColors.coralDeep,
+      ];
+
+  @override
+  Widget build(BuildContext context) {
+    final single = spec.series.length == 1;
+    return ProCard(
+      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+        if (spec.title.isNotEmpty) Text(spec.title, style: AppText.title),
+        if (spec.unit.isNotEmpty) ...[
+          const SizedBox(height: 2),
+          Text(spec.unit, style: AppText.captionMuted),
+        ],
+        const SizedBox(height: Sp.x4),
+        if (spec.type == 'bar' && single)
+          LabeledBars(
+            values: spec.series.first.values.map((v) => v ?? 0).toList(),
+            labels: _fitLabels(spec.xLabels, spec.series.first.values.length),
+            color: AppColors.coral,
+            height: 160,
+          )
+        else
+          _AnimatedLineChart(spec: spec, colors: _colors, filled: spec.type == 'area'),
+        if (!single) ...[
+          const SizedBox(height: Sp.x3),
+          Wrap(spacing: Sp.x4, runSpacing: Sp.x2, children: [
+            for (int i = 0; i < spec.series.length; i++)
+              Row(mainAxisSize: MainAxisSize.min, children: [
+                Container(width: 9, height: 9, decoration: BoxDecoration(
+                    color: _colors[i % _colors.length], shape: BoxShape.circle)),
+                const SizedBox(width: Sp.x2),
+                Text(spec.series[i].name, style: AppText.caption),
+              ]),
+          ]),
+        ],
+        if (spec.note != null && spec.note!.isNotEmpty) ...[
+          const SizedBox(height: Sp.x3),
+          Text(spec.note!, style: AppText.captionMuted),
+        ],
+      ]),
+    );
+  }
+
+  List<String> _fitLabels(List<String> labels, int n) {
+    if (labels.length == n) return labels;
+    return List.generate(n, (i) => i < labels.length ? labels[i] : '');
+  }
+}
+
+class _AnimatedLineChart extends StatelessWidget {
+  final ChartSpec spec;
+  final List<Color> colors;
+  final bool filled;
+  const _AnimatedLineChart({required this.spec, required this.colors, required this.filled});
+
+  @override
+  Widget build(BuildContext context) {
+    return TweenAnimationBuilder<double>(
+      duration: const Duration(milliseconds: 700),
+      curve: Curves.easeOutCubic,
+      tween: Tween(begin: 0, end: 1),
+      builder: (_, t, _) => SizedBox(
+        height: 170,
+        width: double.infinity,
+        child: CustomPaint(
+          painter: _LinePainter(spec: spec, colors: colors, filled: filled, progress: t,
+              grid: AppColors.divider, label: AppColors.inkMuted),
+        ),
+      ),
+    );
+  }
+}
+
+class _LinePainter extends CustomPainter {
+  final ChartSpec spec;
+  final List<Color> colors;
+  final bool filled;
+  final double progress;
+  final Color grid;
+  final Color label;
+  _LinePainter({required this.spec, required this.colors, required this.filled,
+      required this.progress, required this.grid, required this.label});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final all = <double>[];
+    for (final s in spec.series) {
+      for (final v in s.values) {
+        if (v != null) all.add(v);
+      }
+    }
+    if (all.isEmpty) return;
+    var lo = all.reduce(math.min), hi = all.reduce(math.max);
+    if (lo == hi) { lo -= 1; hi += 1; }
+    final pad = (hi - lo) * 0.1;
+    lo -= pad; hi += pad;
+
+    const leftPad = 4.0, bottomPad = 16.0, topPad = 4.0;
+    final chartW = size.width - leftPad;
+    final chartH = size.height - bottomPad - topPad;
+
+    // baseline grid
+    final gridPaint = Paint()..color = grid..strokeWidth = 1;
+    for (int g = 0; g <= 2; g++) {
+      final y = topPad + chartH * g / 2;
+      canvas.drawLine(Offset(leftPad, y), Offset(size.width, y), gridPaint);
+    }
+
+    final maxLen = spec.series.map((s) => s.values.length).fold<int>(0, math.max);
+    if (maxLen < 1) return;
+    // guard the single-point case (no divide-by-zero) → place it centered.
+    double xAt(int i) => maxLen == 1 ? leftPad + chartW / 2 : leftPad + chartW * i / (maxLen - 1);
+    double yAt(double v) => topPad + chartH * (1 - (v - lo) / (hi - lo));
+
+    canvas.save();
+    canvas.clipRect(Rect.fromLTWH(0, 0, size.width * progress, size.height));
+    for (int si = 0; si < spec.series.length; si++) {
+      final s = spec.series[si];
+      final color = colors[si % colors.length];
+      final path = Path();
+      final pts = <Offset>[];
+      bool started = false;
+      for (int i = 0; i < s.values.length; i++) {
+        final v = s.values[i];
+        if (v == null) continue;
+        final pt = Offset(xAt(i), yAt(v));
+        pts.add(pt);
+        if (!started) { path.moveTo(pt.dx, pt.dy); started = true; }
+        else { path.lineTo(pt.dx, pt.dy); }
+      }
+      if (!started) continue;
+
+      if (filled && pts.length > 1) {
+        final fill = Path.from(path)
+          ..lineTo(pts.last.dx, topPad + chartH)
+          ..lineTo(pts.first.dx, topPad + chartH)
+          ..close();
+        canvas.drawPath(fill, Paint()..color = color.withValues(alpha: 0.14)..style = PaintingStyle.fill);
+      }
+      // the line (only meaningful with ≥2 points)
+      if (pts.length > 1) {
+        canvas.drawPath(path, Paint()
+          ..color = color
+          ..strokeWidth = 2.5
+          ..style = PaintingStyle.stroke
+          ..strokeJoin = StrokeJoin.round
+          ..strokeCap = StrokeCap.round);
+      }
+      // dots at every point so single values + vertices are always visible
+      final dot = Paint()..color = color..style = PaintingStyle.fill;
+      for (final p in pts) {
+        canvas.drawCircle(p, pts.length == 1 ? 5 : 3, dot);
+      }
+    }
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(covariant _LinePainter old) => old.progress != progress || old.spec != spec;
+}

--- a/lib/ui/coach/coach_settings_screen.dart
+++ b/lib/ui/coach/coach_settings_screen.dart
@@ -1,0 +1,225 @@
+// AI Coach settings — BYOK. Enter an OpenAI-compatible base URL + API key, then
+// fetch the provider's model list (GET /models) and pick one. Key is stored in the
+// device keychain; nothing here touches OpenStrap servers.
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../coach/coach_config.dart';
+import '../../coach/coach_engine.dart';
+import '../../theme/theme.dart';
+import '../../theme/tokens.dart';
+import '../kit/kit.dart';
+
+class CoachSettingsScreen extends StatefulWidget {
+  const CoachSettingsScreen({super.key});
+  @override
+  State<CoachSettingsScreen> createState() => _CoachSettingsScreenState();
+}
+
+class _CoachSettingsScreenState extends State<CoachSettingsScreen> {
+  late final TextEditingController _base;
+  late final TextEditingController _key;
+  late final TextEditingController _query; // search / free-type box
+  String _model = '';                       // committed model id (from list or typed)
+  bool _obscure = true;
+  bool _loadingModels = false;
+  List<String> _models = const [];
+  String? _msg;
+
+  @override
+  void initState() {
+    super.initState();
+    final cfg = context.read<CoachConfig>();
+    _base = TextEditingController(text: cfg.baseUrl);
+    _key = TextEditingController(text: cfg.apiKey ?? '');
+    _query = TextEditingController();
+    _model = cfg.model;
+  }
+
+  @override
+  void dispose() {
+    _base.dispose();
+    _key.dispose();
+    _query.dispose();
+    super.dispose();
+  }
+
+  Future<void> _fetchModels() async {
+    if (_key.text.trim().isEmpty) {
+      setState(() => _msg = 'Enter your API key first.');
+      return;
+    }
+    setState(() { _loadingModels = true; _msg = null; });
+    try {
+      final ids = await CoachEngine.fetchModels(_base.text, _key.text);
+      setState(() {
+        _models = ids;
+        _msg = ids.isEmpty ? 'Provider returned no models — type one manually.' : '${ids.length} models found. Search and tap to pick.';
+      });
+    } catch (e) {
+      setState(() => _msg = e is CoachException ? e.message : 'Could not list models: $e');
+    } finally {
+      if (mounted) setState(() => _loadingModels = false);
+    }
+  }
+
+  // The chosen model = a tapped/ticked list item, else whatever was typed.
+  String get _chosen => _model.isNotEmpty ? _model : _query.text.trim();
+
+  Future<void> _save() async {
+    final cfg = context.read<CoachConfig>();
+    if (_chosen.isEmpty) {
+      setState(() => _msg = 'Pick or type a model first.');
+      return;
+    }
+    await cfg.save(baseUrl: _base.text, apiKey: _key.text, model: _chosen);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('AI Coach settings saved.')));
+      Navigator.of(context).pop();
+    }
+  }
+
+  // Searchable list of fetched models + a "use what I typed" custom row. The row
+  // matching the committed model shows a tick.
+  Widget _modelList() {
+    final q = _query.text.trim();
+    final ql = q.toLowerCase();
+    final filtered = ql.isEmpty ? _models : _models.where((m) => m.toLowerCase().contains(ql)).toList();
+    final exact = _models.any((m) => m.toLowerCase() == ql);
+
+    final rows = <Widget>[];
+    if (q.isNotEmpty && !exact) rows.add(_modelRow(q, custom: true));
+    for (final m in filtered.take(80)) {
+      rows.add(_modelRow(m));
+    }
+
+    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+      if (_model.isNotEmpty)
+        Padding(
+          padding: const EdgeInsets.only(bottom: Sp.x2),
+          child: Row(children: [
+            AppIcon(Ic.check, size: 14, color: AppColors.coral),
+            const SizedBox(width: Sp.x2),
+            Expanded(child: Text('Using: $_model',
+                style: AppText.caption.copyWith(color: AppColors.coralInk))),
+          ]),
+        ),
+      if (rows.isEmpty)
+        Text(_models.isEmpty
+            ? 'Tap Fetch to load your provider’s models — or just type a model id above and it’ll be used as-is.'
+            : 'No match. Type a full model id to use it as a custom model.',
+            style: AppText.captionMuted)
+      else
+        Container(
+          constraints: const BoxConstraints(maxHeight: 280),
+          decoration: BoxDecoration(
+              color: AppColors.surfaceSunk, borderRadius: BorderRadius.circular(R.card)),
+          child: ListView(shrinkWrap: true, padding: const EdgeInsets.symmetric(vertical: Sp.x2), children: rows),
+        ),
+    ]);
+  }
+
+  Widget _modelRow(String id, {bool custom = false}) {
+    final selected = _model == id;
+    return InkWell(
+      onTap: () => setState(() => _model = id),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: Sp.x4, vertical: Sp.x3),
+        child: Row(children: [
+          if (custom) ...[
+            AppIcon(Ic.edit, size: 13, color: AppColors.inkMuted),
+            const SizedBox(width: Sp.x2),
+          ],
+          Expanded(child: Text(custom ? 'Use “$id”' : id,
+              style: AppText.body.copyWith(color: selected ? AppColors.coralInk : AppColors.ink))),
+          if (selected) AppIcon(Ic.check, size: 18, color: AppColors.coral),
+        ]),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.bg,
+      body: SafeArea(
+        bottom: false,
+        child: ListView(
+          padding: const EdgeInsets.symmetric(horizontal: Sp.screen),
+          children: [
+            const SizedBox(height: Sp.x4),
+            Row(children: [
+              RoundIconButton(Ic.arrowLeft, onTap: () => Navigator.of(context).pop()),
+              const SizedBox(width: Sp.x3),
+              Text('AI Coach', style: AppText.h1),
+            ]),
+            const SizedBox(height: Sp.x5),
+
+            ProCard(child: Row(children: [
+              AppIcon(Ic.shield, size: 18, color: AppColors.good),
+              const SizedBox(width: Sp.x3),
+              Expanded(child: Text('Your key is stored only on this device and is sent '
+                  'directly to your provider — never to OpenStrap.', style: AppText.captionMuted)),
+            ])),
+            const SizedBox(height: Sp.x5),
+
+            const SectionHeader('Provider'),
+            TextField(
+              controller: _base,
+              decoration: const InputDecoration(
+                labelText: 'Base URL',
+                hintText: 'https://api.openai.com/v1',
+              ),
+            ),
+            const SizedBox(height: Sp.x3),
+            TextField(
+              controller: _key,
+              obscureText: _obscure,
+              decoration: InputDecoration(
+                labelText: 'API key',
+                suffixIcon: IconButton(
+                  icon: AppIcon(_obscure ? Ic.info : Ic.check, size: 18, color: AppColors.inkMuted),
+                  onPressed: () => setState(() => _obscure = !_obscure),
+                ),
+              ),
+            ),
+            const SizedBox(height: Sp.x3),
+            Text('Works with OpenAI, OpenRouter, Groq, Together, local Ollama / LM Studio, '
+                'and anything OpenAI-compatible.', style: AppText.captionMuted),
+
+            const SizedBox(height: Sp.x5),
+            const SectionHeader('Model'),
+            Row(children: [
+              Expanded(child: TextField(
+                controller: _query,
+                onChanged: (_) => setState(() {}),
+                decoration: const InputDecoration(
+                  labelText: 'Search or type a model',
+                  hintText: 'e.g. minimax, gpt-4o, llama',
+                ),
+              )),
+              const SizedBox(width: Sp.x3),
+              OutlinedButton(
+                onPressed: _loadingModels ? null : _fetchModels,
+                child: _loadingModels
+                    ? const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2))
+                    : const Text('Fetch'),
+              ),
+            ]),
+            const SizedBox(height: Sp.x3),
+            _modelList(),
+            if (_msg != null) ...[
+              const SizedBox(height: Sp.x3),
+              Text(_msg!, style: AppText.captionMuted),
+            ],
+
+            const SizedBox(height: Sp.x7),
+            FilledButton(onPressed: _save, child: const Text('Save')),
+            const SizedBox(height: 60),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/cycle/cycle_screen.dart
+++ b/lib/ui/cycle/cycle_screen.dart
@@ -1,0 +1,315 @@
+// Cycle — menstrual cycle tracking. Log period starts; see current phase, next
+// predicted period + fertile window (log-anchored calendar method), and how your
+// skin-temp / resting-HR / HRV shift across the cycle. Honest: an estimate, not
+// medical or contraceptive guidance. Uses getCycle / postCycleLog / deleteCycleLog.
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../net/api_client.dart';
+import '../../state/app_state.dart';
+import '../../theme/theme.dart';
+import '../../theme/tokens.dart';
+import '../kit/kit.dart';
+import '../kit/charts.dart';
+
+class CycleScreen extends StatefulWidget {
+  const CycleScreen({super.key});
+  @override
+  State<CycleScreen> createState() => _CycleScreenState();
+}
+
+class _CycleScreenState extends State<CycleScreen> {
+  Map<String, dynamic>? _data;
+  bool _loading = true;
+  bool _noApi = false;
+  String? _error;
+
+  ApiClient? get _api => context.read<AppState>().api;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final api = _api;
+    if (api == null) {
+      setState(() { _loading = false; _noApi = true; });
+      return;
+    }
+    setState(() { _loading = true; _error = null; _noApi = false; });
+    try {
+      final d = await api.getCycle();
+      if (!mounted) return;
+      setState(() { _data = d; _loading = false; });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() { _loading = false; _error = e is ApiException ? e.body : e.toString(); });
+    }
+  }
+
+  static String _fmt(DateTime d) =>
+      '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+
+  Future<void> _logToday() => _logDate(DateTime.now().toUtc());
+
+  Future<void> _logDate(DateTime day) async {
+    final api = _api;
+    if (api == null) { return; }
+    try {
+      await api.postCycleLog(_fmt(day), kind: 'start');
+      await _load();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text("Couldn't log: ${e is ApiException ? e.body : e}")));
+      }
+    }
+  }
+
+  Future<void> _pickAndLog() async {
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: now,
+      firstDate: DateTime(now.year - 2),
+      lastDate: now,
+    );
+    if (picked != null) await _logDate(picked.toUtc());
+  }
+
+  Future<void> _delete(String date) async {
+    final api = _api;
+    if (api == null) return;
+    try {
+      await api.deleteCycleLog(date);
+      await _load();
+    } catch (_) {}
+  }
+
+  // ── phase presentation ──────────────────────────────────────────────────────
+  static const _phaseLabel = {
+    'menstruation': 'Menstruation',
+    'follicular': 'Follicular phase',
+    'ovulation': 'Ovulation window',
+    'luteal': 'Luteal phase',
+    'unknown': 'Cycle',
+  };
+  Color _phaseColor(String p) {
+    switch (p) {
+      case 'menstruation': return AppColors.coral;
+      case 'follicular': return AppColors.good;
+      case 'ovulation': return AppColors.coralDeep;
+      case 'luteal': return AppColors.warn;
+      default: return AppColors.inkSoft;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.bg,
+      body: SafeArea(
+        bottom: false,
+        child: RefreshIndicator(
+          onRefresh: _load,
+          color: AppColors.coral,
+          child: ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: const EdgeInsets.symmetric(horizontal: Sp.screen),
+            children: [
+              const SizedBox(height: Sp.x4),
+              _topBar(),
+              const SizedBox(height: Sp.x6),
+              if (_noApi)
+                _stateCard('Sign in to track your cycle',
+                    'Your cycle log syncs with your account. Sign in to log periods and see predictions.')
+              else if (_loading)
+                const Padding(padding: EdgeInsets.all(Sp.x8), child: Center(child: CircularProgressIndicator()))
+              else if (_error != null)
+                _stateCard("Couldn't load cycle", _error!)
+              else
+                ..._content(),
+              const SizedBox(height: 110),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _topBar() => Row(children: [
+        RoundIconButton(Ic.arrowLeft, onTap: () => Navigator.of(context).pop()),
+        const SizedBox(width: Sp.x3),
+        Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Text('Cycle', style: AppText.h1),
+          const SizedBox(height: 4),
+          Text('Log periods — see phase, fertile window & body shifts', style: AppText.caption),
+        ])),
+      ]);
+
+  List<Widget> _content() {
+    final d = _data!;
+    if (d['enabled'] == false) {
+      return [_stateCard('Cycle tracking is off',
+          (d['note'] as String?) ?? 'Enable it in your profile to start tracking.')];
+    }
+    final phase = (d['phase'] as String?) ?? 'unknown';
+    final cycleDay = d['cycle_day'] as num?;
+    final daysUntil = d['days_until_next'] as num?;
+    final next = d['predicted_next'] as String?;
+    final fertileStart = d['fertile_start'] as String?;
+    final fertileEnd = d['fertile_end'] as String?;
+    final ovulation = d['ovulation_est'] as String?;
+    final meanLen = d['mean_length'] as num?;
+    final note = (d['note'] as String?) ?? '';
+    final conf = (d['confidence'] as num?) ?? 0;
+    final logs = (d['logs'] as List?)?.whereType<Map>().toList() ?? const [];
+    final overlay = (d['overlay'] as List?)?.whereType<Map>().toList() ?? const [];
+    final accent = _phaseColor(phase);
+
+    final hasPrediction = next != null && conf > 0;
+
+    return [
+      // HERO — current phase + cycle day.
+      GlowCard(
+        padding: const EdgeInsets.all(Sp.x6),
+        child: Row(children: [
+          Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, mainAxisSize: MainAxisSize.min, children: [
+            Row(children: [
+              AppIcon(Ic.calendar, size: 16, color: accent),
+              const SizedBox(width: Sp.x2),
+              Text('YOUR CYCLE', style: AppText.overline),
+            ]),
+            const SizedBox(height: Sp.x3),
+            Text(_phaseLabel[phase] ?? 'Cycle', style: AppText.h2.copyWith(color: accent)),
+            const SizedBox(height: Sp.x2),
+            Text(cycleDay != null ? 'Day ${cycleDay.round()} of your cycle' : 'Log a period to begin',
+                style: AppText.bodySoft),
+          ])),
+          if (cycleDay != null && meanLen != null)
+            RingStat(
+              t: (cycleDay / meanLen).clamp(0.0, 1.0),
+              color: accent, size: 92, stroke: 11,
+              center: Text('${cycleDay.round()}', style: AppText.metricSm),
+            ),
+        ]),
+      ),
+
+      // PREDICTION.
+      if (hasPrediction) ...[
+        const SizedBox(height: Sp.x6),
+        SectionHeader('Prediction'),
+        ProCard(child: Column(children: [
+          _row(Ic.droplet, AppColors.coral, 'Next period',
+              daysUntil != null && daysUntil >= 0 ? 'in ${daysUntil.round()} days' : (next),
+              sub: next),
+          if (fertileStart != null && fertileEnd != null)
+            _row(Ic.heart, AppColors.good, 'Fertile window', '${_md(fertileStart)} – ${_md(fertileEnd)}'),
+          if (ovulation != null)
+            _row(Ic.up, AppColors.coralDeep, 'Estimated ovulation', _md(ovulation)),
+        ])),
+        const SizedBox(height: Sp.x2),
+        Text(note, style: AppText.captionMuted),
+      ],
+
+      // BIOMETRIC OVERLAY — how the body is shifting this cycle (descriptive).
+      if (overlay.isNotEmpty) ...[
+        const SizedBox(height: Sp.x6),
+        SectionHeader('Body this cycle'),
+        ProCard(child: Column(children: [
+          _overlayRow(Ic.thermometer, AppColors.coralDeep, 'Skin temp vs baseline', overlay, 'skin_temp_idx', 'Δ', signed: true),
+          _overlayRow(Ic.heart, AppColors.coral, 'Resting HR', overlay, 'resting_hr', 'bpm'),
+          _overlayRow(Ic.pulse, AppColors.good, 'HRV (RMSSD)', overlay, 'hrv_rmssd', 'ms'),
+        ])),
+        const SizedBox(height: Sp.x2),
+        Text('Skin temp and resting HR often rise, and HRV dips, in the luteal phase. '
+            'Shown for context — the prediction is based on your logged periods, not these.',
+            style: AppText.captionMuted),
+      ],
+
+      // LOG actions.
+      const SizedBox(height: Sp.x6),
+      SectionHeader('Log a period'),
+      Row(children: [
+        Expanded(child: FilledButton.icon(
+          onPressed: _logToday,
+          icon: const AppIcon(Ic.droplet, size: 18, color: Colors.white),
+          label: const Text('Period started today'),
+        )),
+        const SizedBox(width: Sp.x3),
+        OutlinedButton(onPressed: _pickAndLog, child: const Text('Pick date')),
+      ]),
+
+      // RECENT LOGS.
+      if (logs.isNotEmpty) ...[
+        const SizedBox(height: Sp.x6),
+        SectionHeader('Logged periods'),
+        ProCard(child: Column(children: [
+          for (final l in logs.take(12))
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Row(children: [
+                AppIcon(Ic.droplet, size: 15, color: AppColors.coral),
+                const SizedBox(width: Sp.x3),
+                Expanded(child: Text('${l['date']}  ·  ${l['kind']}', style: AppText.body)),
+                IconButton(
+                  icon: AppIcon(Ic.cancel, size: 16, color: AppColors.inkMuted),
+                  onPressed: () => _delete('${l['date']}'),
+                  visualDensity: VisualDensity.compact,
+                ),
+              ]),
+            ),
+        ])),
+      ],
+    ];
+  }
+
+  // MM-DD short date.
+  String _md(String iso) => iso.length >= 10 ? iso.substring(5) : iso;
+
+  Widget _row(IconData icon, Color accent, String label, String? value, {String? sub}) =>
+      Padding(padding: const EdgeInsets.symmetric(vertical: Sp.x2), child: Row(children: [
+        Container(
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(color: accent.withValues(alpha: 0.14), borderRadius: BorderRadius.circular(R.chip)),
+          child: AppIcon(icon, size: 16, color: accent),
+        ),
+        const SizedBox(width: Sp.x3),
+        Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Text(label, style: AppText.label),
+          if (sub != null) Text(sub, style: AppText.captionMuted),
+        ])),
+        Text(value ?? '—', style: AppText.label),
+      ]));
+
+  // Latest non-null value of [key] across the cycle, with a signed/plain format.
+  Widget _overlayRow(IconData icon, Color accent, String label, List<Map> series, String key, String unit, {bool signed = false}) {
+    num? latest;
+    for (final r in series.reversed) {
+      final v = r[key];
+      if (v is num) { latest = v; break; }
+    }
+    String val = '—';
+    if (latest != null) {
+      final s = signed ? latest.toStringAsFixed(1) : latest.round().toString();
+      val = signed && latest > 0 ? '+$s $unit' : '$s $unit';
+    }
+    return Padding(padding: const EdgeInsets.symmetric(vertical: Sp.x2), child: Row(children: [
+      AppIcon(icon, size: 15, color: accent),
+      const SizedBox(width: Sp.x3),
+      Expanded(child: Text(label, style: AppText.body)),
+      Text(val, style: AppText.label),
+    ]));
+  }
+
+  Widget _stateCard(String title, String message) => ProCard(
+        child: Padding(padding: const EdgeInsets.all(Sp.x4), child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Text(title, style: AppText.label),
+          const SizedBox(height: Sp.x2),
+          Text(message, style: AppText.captionMuted),
+        ])),
+      );
+}

--- a/lib/ui/heart/live_hr_tile.dart
+++ b/lib/ui/heart/live_hr_tile.dart
@@ -1,0 +1,233 @@
+// LiveHrTile — the ambient "right now" heart-rate tile. Sits as the first card on
+// the Heart screen. The number is the live BLE stream (device.liveHr, decoded from
+// 0x28/R10 at ~1 Hz); the heart icon beats in a realistic lub-dub at the live BPM,
+// with an expanding pulse ring on each beat.
+//
+// HONESTY GATES (project rule — never fabricate, "—" when absent):
+//   • liveHr == 0  → OFF-WRIST, never a heart rate → show "—", no beat.
+//   • stale (no fresh sample within _staleMs) → show "—", no beat. A 1 s ticker
+//     re-evaluates freshness even when the stream stops pushing (so a frozen value
+//     decays to "—" honestly).
+//   • not connected → show "—", no beat.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../state/app_state.dart';
+import '../../theme/theme.dart';
+import '../../theme/tokens.dart';
+import '../kit/kit.dart';
+
+const _staleMs = 10000; // a live sample older than this is no longer "live"
+const _minBpm = 30, _maxBpm = 220;
+
+class LiveHrTile extends StatefulWidget {
+  const LiveHrTile({super.key});
+  @override
+  State<LiveHrTile> createState() => _LiveHrTileState();
+}
+
+class _LiveHrTileState extends State<LiveHrTile> with TickerProviderStateMixin {
+  // One beat cycle (lub-dub). Its duration is retuned to match the live BPM.
+  late final AnimationController _beat = AnimationController(
+    vsync: this, duration: const Duration(milliseconds: 800))
+    ..addStatusListener((s) {
+      // Re-arm only while we have a live beat to show.
+      if (s == AnimationStatus.completed && _beating) _beat.forward(from: 0);
+    });
+
+  // Freshness ticker — fires every second so a stopped stream decays to "—"
+  // even though AppState isn't pushing new HR ticks.
+  late final AnimationController _fresh = AnimationController(
+    vsync: this, duration: const Duration(seconds: 1))
+    ..addStatusListener((s) {
+      if (s == AnimationStatus.completed) {
+        if (mounted) setState(() {});
+        _fresh.forward(from: 0);
+      }
+    });
+
+  bool _beating = false;
+  int _lastBpm = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _fresh.forward();
+  }
+
+  @override
+  void dispose() {
+    _beat.dispose();
+    _fresh.dispose();
+    super.dispose();
+  }
+
+  // Retune the beat period to the live BPM and keep it running; stop cleanly
+  // when there's no live signal.
+  void _sync(int? bpm, bool live) {
+    final shouldBeat = live && bpm != null && bpm > 0;
+    if (shouldBeat) {
+      final clamped = bpm.clamp(_minBpm, _maxBpm);
+      if (clamped != _lastBpm) {
+        _lastBpm = clamped;
+        _beat.duration = Duration(milliseconds: (60000 / clamped).round());
+      }
+      if (!_beating) {
+        _beating = true;
+        _beat.forward(from: 0);
+      }
+    } else if (_beating) {
+      _beating = false;
+      _beat.stop();
+      _beat.value = 0;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Rebuild only when the live-HR snapshot actually changes (not on every
+    // unrelated AppState notify). Record → structural equality.
+    final snap = context.select<AppState, (int?, int?, String)>((s) {
+      final d = s.device;
+      return (d.liveHr, d.liveHrAt, d.connection);
+    });
+    final (hr, at, conn) = snap;
+
+    final connected = conn == 'connected' || conn == 'syncing';
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    final fresh = at != null && (nowMs - at) < _staleMs;
+    final offWrist = hr == 0; // 0 is OFF-WRIST, never a heart rate
+    final live = connected && fresh && hr != null && hr > 0;
+
+    // Drive the animation off the resolved state (post-frame so we don't
+    // mutate controllers during build).
+    WidgetsBinding.instance.addPostFrameCallback((_) => _sync(hr, live));
+
+    final accent = AppColors.coral;
+    final subtitle = live
+        ? 'beats per minute'
+        : !connected
+            ? 'strap not connected'
+            : offWrist
+                ? 'strap off wrist'
+                : 'no live signal';
+
+    return GlowCard(
+      glow: accent,
+      padding: const EdgeInsets.all(Sp.x6),
+      child: Row(
+        children: [
+          _BeatingHeart(beat: _beat, accent: accent, live: live),
+          const SizedBox(width: Sp.x5),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(children: [
+                  _LiveDot(beat: _beat, accent: accent, live: live),
+                  const SizedBox(width: Sp.x2),
+                  Text('LIVE HEART RATE', style: AppText.overline),
+                ]),
+                const SizedBox(height: Sp.x3),
+                Row(crossAxisAlignment: CrossAxisAlignment.end, children: [
+                  Text(live ? '$hr' : '—', style: AppText.display.copyWith(color: accent)),
+                  if (live) ...[
+                    const SizedBox(width: Sp.x2),
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 7),
+                      child: Text('bpm', style: AppText.bodySoft),
+                    ),
+                  ],
+                ]),
+                const SizedBox(height: 2),
+                Text(subtitle, style: AppText.captionMuted),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The icon that beats. A realistic lub-dub scale curve + an expanding ring that
+/// blooms outward and fades on each cycle.
+class _BeatingHeart extends StatelessWidget {
+  final AnimationController beat;
+  final Color accent;
+  final bool live;
+  const _BeatingHeart({required this.beat, required this.accent, required this.live});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 64,
+      height: 64,
+      child: AnimatedBuilder(
+        animation: beat,
+        builder: (context, child) {
+          final t = beat.value;
+          // lub-dub: sharp first contraction, small relax, softer second beat,
+          // then settle. Two raised-cosine pulses.
+          double pulse(double center, double width, double amp) {
+            final x = ((t - center) / width).clamp(-1.0, 1.0);
+            return amp * 0.5 * (1 + (x.abs() >= 1 ? -1.0 : math.cos(math.pi * x)));
+          }
+          final s = live ? 1.0 + pulse(0.10, 0.14, 0.22) + pulse(0.30, 0.12, 0.11) : 1.0;
+          // Ring blooms only on the first (loud) beat.
+          final ringT = (t / 0.55).clamp(0.0, 1.0);
+          final ringScale = 1.0 + ringT * 0.9;
+          final ringAlpha = live ? (1 - ringT) * 0.35 : 0.0;
+          return Stack(
+            alignment: Alignment.center,
+            children: [
+              if (ringAlpha > 0.01)
+                Transform.scale(
+                  scale: ringScale,
+                  child: Container(
+                    width: 44, height: 44,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      border: Border.all(color: accent.withValues(alpha: ringAlpha), width: 2),
+                    ),
+                  ),
+                ),
+              Transform.scale(
+                scale: s,
+                child: AppIcon(Ic.heart, size: 38,
+                    color: live ? accent : AppColors.inkMuted),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Small pulsing "live" dot next to the overline — fades in sync with each beat.
+class _LiveDot extends StatelessWidget {
+  final AnimationController beat;
+  final Color accent;
+  final bool live;
+  const _LiveDot({required this.beat, required this.accent, required this.live});
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: beat,
+      builder: (context, _) {
+        final a = live ? (0.45 + 0.55 * (1 - beat.value).clamp(0.0, 1.0)) : 0.25;
+        return Container(
+          width: 8, height: 8,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: (live ? accent : AppColors.inkMuted).withValues(alpha: a),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/kit/kit.dart
+++ b/lib/ui/kit/kit.dart
@@ -60,6 +60,11 @@ class Ic {
   static const droplet = HugeIcons.strokeRoundedDroplet;
   static const run = HugeIcons.strokeRoundedRunningShoes;
   static const bell = HugeIcons.strokeRoundedNotification03;
+  static const thermometer = HugeIcons.strokeRoundedTemperature;
+  static const ai = HugeIcons.strokeRoundedAiMagic;
+  static const plus = HugeIcons.strokeRoundedAdd01;
+  static const history = HugeIcons.strokeRoundedClock04;
+  static const trash = HugeIcons.strokeRoundedDelete02;
 }
 
 /// White rounded card with soft warm shadow. The base surface for everything.

--- a/lib/ui/profile/notification_relay_section.dart
+++ b/lib/ui/profile/notification_relay_section.dart
@@ -1,0 +1,308 @@
+// Notification-relay settings — pick which phone apps buzz the strap. ANDROID ONLY:
+// both the card and the screen render nothing unless NotificationRelay.supported, so
+// the feature simply doesn't exist on iOS (no "unavailable" copy, no trace).
+
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:installed_apps/app_info.dart';
+import 'package:installed_apps/installed_apps.dart';
+import 'package:provider/provider.dart';
+
+import '../../notify/notification_relay.dart';
+import '../../state/app_state.dart';
+import '../../theme/theme.dart';
+import '../../theme/theme_switcher.dart';
+import '../../theme/tokens.dart';
+import '../kit/kit.dart';
+
+/// The Profile card. Returns an empty box on unsupported platforms (iOS) so the
+/// caller can place it unconditionally and it stays invisible there.
+class NotificationRelaySection extends StatelessWidget {
+  const NotificationRelaySection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final relay = context.read<AppState>().notificationRelay;
+    if (!relay.supported) return const SizedBox.shrink();
+    return AnimatedBuilder(
+      animation: relay,
+      builder: (context, _) {
+        final subtitle = !relay.enabled
+            ? 'Off'
+            : !relay.permissionGranted
+                ? 'Needs notification access'
+                : relay.appCount == 0
+                    ? 'On · no apps selected'
+                    : 'On · ${relay.appCount} app${relay.appCount == 1 ? '' : 's'}';
+        return ProCard(
+          onTap: () => Navigator.of(context).push(
+              themedRoute((_) => const NotificationRelayScreen())),
+          child: Row(
+            children: [
+              Icon(Ic.bell, size: 22, color: AppColors.coral),
+              const SizedBox(width: Sp.x4),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Buzz on app notifications', style: AppText.title),
+                    const SizedBox(height: 2),
+                    Text(subtitle, style: AppText.bodySoft),
+                  ],
+                ),
+              ),
+              Icon(Ic.arrowRight, size: 18, color: AppColors.inkMuted),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Full settings screen: master toggle → grant access → per-app allow-list.
+class NotificationRelayScreen extends StatefulWidget {
+  const NotificationRelayScreen({super.key});
+  @override
+  State<NotificationRelayScreen> createState() => _NotificationRelayScreenState();
+}
+
+class _NotificationRelayScreenState extends State<NotificationRelayScreen>
+    with WidgetsBindingObserver {
+  late Future<List<AppInfo>> _apps;
+  String _query = '';
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _apps = InstalledApps.getInstalledApps(
+        excludeSystemApps: true, withIcon: true);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Coming back from the system Settings page → re-check the grant.
+    if (state == AppLifecycleState.resumed && mounted) {
+      context.read<AppState>().notificationRelay.refreshPermission();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final relay = context.read<AppState>().notificationRelay;
+    return Scaffold(
+      backgroundColor: AppColors.bg,
+      body: SafeArea(
+        bottom: false,
+        child: AnimatedBuilder(
+          animation: relay,
+          builder: (context, _) {
+            final showApps = relay.enabled && relay.permissionGranted;
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(Sp.screen, Sp.x4, Sp.screen, 0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(children: [
+                        RoundIconButton(Ic.arrowLeft,
+                            onTap: () => Navigator.of(context).maybePop()),
+                        const SizedBox(width: Sp.x3),
+                        Expanded(child: Text('Band notifications', style: AppText.h1)),
+                      ]),
+                      const SizedBox(height: Sp.x4),
+                      Text(
+                        'When an app below posts a notification, your strap gives a '
+                        'short buzz. Your phone must be connected to the band.',
+                        style: AppText.bodySoft,
+                      ),
+                      const SizedBox(height: Sp.x5),
+                      _MasterToggle(relay: relay),
+                      if (relay.enabled && !relay.permissionGranted) ...[
+                        const SizedBox(height: Sp.x4),
+                        _GrantCard(relay: relay),
+                      ],
+                      const SizedBox(height: Sp.x5),
+                      if (showApps) ...[
+                        Text('APPS', style: AppText.overline),
+                        const SizedBox(height: Sp.x3),
+                        _SearchField(onChanged: (q) => setState(() => _query = q)),
+                        const SizedBox(height: Sp.x3),
+                      ],
+                    ],
+                  ),
+                ),
+                if (showApps)
+                  Expanded(child: _AppList(relay: relay, future: _apps, query: _query))
+                else
+                  const SizedBox.shrink(),
+                const SizedBox(height: Sp.x4),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _MasterToggle extends StatelessWidget {
+  final NotificationRelay relay;
+  const _MasterToggle({required this.relay});
+  @override
+  Widget build(BuildContext context) {
+    return ProCard(
+      child: Row(
+        children: [
+          Icon(Ic.bell, size: 22, color: AppColors.coral),
+          const SizedBox(width: Sp.x4),
+          Expanded(child: Text('Relay notifications', style: AppText.title)),
+          Switch.adaptive(
+            value: relay.enabled,
+            activeTrackColor: AppColors.coral,
+            onChanged: (v) => relay.setEnabled(v),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GrantCard extends StatelessWidget {
+  final NotificationRelay relay;
+  const _GrantCard({required this.relay});
+  @override
+  Widget build(BuildContext context) {
+    return ProCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Notification access needed', style: AppText.title),
+          const SizedBox(height: 4),
+          Text(
+            'Android needs your permission to read which app posted a notification. '
+            'We only use it to decide whether to buzz the band — nothing leaves your phone.',
+            style: AppText.caption,
+          ),
+          const SizedBox(height: Sp.x4),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: FilledButton(
+              onPressed: () => relay.requestPermission(),
+              child: const Text('Grant access'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SearchField extends StatelessWidget {
+  final ValueChanged<String> onChanged;
+  const _SearchField({required this.onChanged});
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      onChanged: onChanged,
+      style: AppText.body,
+      decoration: InputDecoration(
+        hintText: 'Search apps',
+        hintStyle: AppText.bodySoft,
+        filled: true,
+        fillColor: AppColors.surfaceAlt,
+        contentPadding: const EdgeInsets.symmetric(horizontal: Sp.x4, vertical: Sp.x3),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(R.chip),
+          borderSide: BorderSide.none,
+        ),
+      ),
+    );
+  }
+}
+
+class _AppList extends StatelessWidget {
+  final NotificationRelay relay;
+  final Future<List<AppInfo>> future;
+  final String query;
+  const _AppList({required this.relay, required this.future, required this.query});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<AppInfo>>(
+      future: future,
+      builder: (context, snap) {
+        if (snap.connectionState != ConnectionState.done) {
+          return Center(
+            child: SizedBox(
+              width: 22, height: 22,
+              child: CircularProgressIndicator(strokeWidth: 2, color: AppColors.coral)),
+          );
+        }
+        final all = snap.data ?? const <AppInfo>[];
+        final q = query.trim().toLowerCase();
+        final apps = (q.isEmpty
+            ? all
+            : all.where((a) => a.name.toLowerCase().contains(q)).toList())
+          ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+        if (apps.isEmpty) {
+          return Center(child: Text('No apps found', style: AppText.captionMuted));
+        }
+        return ListView.separated(
+          padding: const EdgeInsets.fromLTRB(Sp.screen, 0, Sp.screen, Sp.x8),
+          itemCount: apps.length,
+          separatorBuilder: (_, _) => const SizedBox(height: Sp.x2),
+          itemBuilder: (context, i) {
+            final a = apps[i];
+            return _AppRow(relay: relay, app: a);
+          },
+        );
+      },
+    );
+  }
+}
+
+class _AppRow extends StatelessWidget {
+  final NotificationRelay relay;
+  final AppInfo app;
+  const _AppRow({required this.relay, required this.app});
+  @override
+  Widget build(BuildContext context) {
+    final Uint8List? icon = app.icon;
+    return ProCard(
+      padding: const EdgeInsets.symmetric(horizontal: Sp.x4, vertical: Sp.x3),
+      child: Row(
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: icon != null && icon.isNotEmpty
+                ? Image.memory(icon, width: 34, height: 34, gaplessPlayback: true)
+                : Container(
+                    width: 34, height: 34, color: AppColors.surfaceAlt,
+                    child: Icon(Ic.bell, size: 18, color: AppColors.inkMuted)),
+          ),
+          const SizedBox(width: Sp.x4),
+          Expanded(
+            child: Text(app.name, style: AppText.body, maxLines: 1,
+                overflow: TextOverflow.ellipsis),
+          ),
+          Switch.adaptive(
+            value: relay.isAppEnabled(app.packageName),
+            activeTrackColor: AppColors.coral,
+            onChanged: (v) => relay.setAppEnabled(app.packageName, v),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/profile/profile_screen.dart
+++ b/lib/ui/profile/profile_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../state/app_state.dart';
+import '../../state/units_controller.dart';
 import '../../theme/theme.dart';
 import '../../theme/theme_switcher.dart';
 import '../../theme/tokens.dart';
@@ -19,6 +20,7 @@ class ProfileScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final app = context.watch<AppState>();
+    final units = context.watch<UnitsController>();
     final user = app.user ?? const {};
     final name = (user['name'] ?? '').toString().trim();
     final email = (user['email'] ?? '').toString().trim();
@@ -73,7 +75,7 @@ class ProfileScreen extends StatelessWidget {
                   icon: Ic.activity,
                   label: 'Height',
                   value: user['height_cm'] != null
-                      ? '${_num(user['height_cm'])} cm'
+                      ? units.height(user['height_cm'] as num?)
                       : 'Add',
                   onTap: () => _editProfileSheet(context, app),
                 ),
@@ -82,7 +84,7 @@ class ProfileScreen extends StatelessWidget {
                   icon: Ic.fire,
                   label: 'Weight',
                   value: user['weight_kg'] != null
-                      ? '${_num(user['weight_kg'])} kg'
+                      ? units.weight(user['weight_kg'] as num?)
                       : 'Add',
                   onTap: () => _editProfileSheet(context, app),
                 ),
@@ -120,6 +122,78 @@ class ProfileScreen extends StatelessWidget {
                   ),
                 ),
               ),
+            ),
+          ),
+
+          const SizedBox(height: Sp.x7),
+
+          // ── Units (local display preference) ─────────────────────────
+          const SectionHeader('Units'),
+          ProCard(
+            padding: const EdgeInsets.all(Sp.x3),
+            child: Row(
+              children: [
+                for (final s in UnitSystem.values)
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: () => units.setSystem(s),
+                      child: Container(
+                        margin: EdgeInsets.only(right: s == UnitSystem.metric ? Sp.x2 : 0),
+                        padding: const EdgeInsets.symmetric(vertical: Sp.x3),
+                        decoration: BoxDecoration(
+                          color: units.system == s ? AppColors.coralSoft : AppColors.surfaceSunk,
+                          borderRadius: BorderRadius.circular(R.chip),
+                        ),
+                        child: Column(
+                          children: [
+                            Text(s.label,
+                                textAlign: TextAlign.center,
+                                style: AppText.label.copyWith(
+                                    color: units.system == s ? AppColors.coralInk : AppColors.inkSoft)),
+                            const SizedBox(height: 2),
+                            Text(s == UnitSystem.metric ? 'kg · cm' : 'lb · ft/in',
+                                textAlign: TextAlign.center, style: AppText.captionMuted),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+
+          const SizedBox(height: Sp.x7),
+
+          // ── Cycle tracking (explicit opt-in) ─────────────────────────
+          const SectionHeader('Cycle tracking'),
+          ProCard(
+            padding: const EdgeInsets.symmetric(horizontal: Sp.x5, vertical: Sp.x3),
+            child: Row(
+              children: [
+                AppIcon(Ic.calendar, size: 18, color: AppColors.coral),
+                const SizedBox(width: Sp.x4),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Track menstrual cycle', style: AppText.title),
+                      const SizedBox(height: 2),
+                      Text('Log periods and see phase, next period & fertile window. '
+                          'Off by default — nothing is computed until you turn this on.',
+                          style: AppText.captionMuted),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: Sp.x3),
+                Switch(
+                  value: user['track_cycle'] == true || user['track_cycle'] == 1,
+                  onChanged: (v) async {
+                    try {
+                      await app.updateProfile({'track_cycle': v ? 1 : 0});
+                    } catch (_) {}
+                  },
+                ),
+              ],
             ),
           ),
 
@@ -242,12 +316,6 @@ class ProfileScreen extends StatelessWidget {
   static String _sexLabel(String? s) {
     if (s == null || s.isEmpty) return 'Add';
     return s[0].toUpperCase() + s.substring(1);
-  }
-
-  static String _num(Object? v) {
-    final n = (v is num) ? v : num.tryParse('$v');
-    if (n == null) return '$v';
-    return n == n.roundToDouble() ? '${n.round()}' : '$n';
   }
 
   // ── Profile edit sheet ────────────────────────────────────────────────
@@ -643,6 +711,7 @@ class _ProfileEditSheetState extends State<_ProfileEditSheet> {
   late final TextEditingController _age;
   late final TextEditingController _height;
   late final TextEditingController _weight;
+  late final UnitsController _units;
   String? _sex;
   bool _saving = false;
 
@@ -650,13 +719,13 @@ class _ProfileEditSheetState extends State<_ProfileEditSheet> {
   void initState() {
     super.initState();
     final u = widget.app.user ?? const {};
+    _units = context.read<UnitsController>();
     _name = TextEditingController(text: (u['name'] ?? '').toString());
     _age = TextEditingController(
         text: u['age'] != null ? '${u['age']}' : '');
-    _height = TextEditingController(
-        text: u['height_cm'] != null ? '${u['height_cm']}' : '');
-    _weight = TextEditingController(
-        text: u['weight_kg'] != null ? '${u['weight_kg']}' : '');
+    // Pre-fill height/weight in the user's chosen units (stored as cm/kg).
+    _height = TextEditingController(text: _units.heightField(u['height_cm'] as num?));
+    _weight = TextEditingController(text: _units.weightField(u['weight_kg'] as num?));
     _sex = u['sex']?.toString();
   }
 
@@ -675,8 +744,9 @@ class _ProfileEditSheetState extends State<_ProfileEditSheet> {
       await widget.app.updateProfile({
         'name': _name.text.trim().isEmpty ? null : _name.text.trim(),
         'age': int.tryParse(_age.text),
-        'height_cm': double.tryParse(_height.text),
-        'weight_kg': double.tryParse(_weight.text),
+        // Convert from the user's display units back to metric for storage.
+        'height_cm': _units.heightToCm(_height.text),
+        'weight_kg': _units.weightToKg(_weight.text),
         if (_sex != null) 'sex': _sex,
       });
       if (mounted) {
@@ -715,7 +785,7 @@ class _ProfileEditSheetState extends State<_ProfileEditSheet> {
             child: TextField(
               controller: _height,
               keyboardType: TextInputType.number,
-              decoration: const InputDecoration(labelText: 'Height (cm)'),
+              decoration: InputDecoration(labelText: _units.heightLabel),
             ),
           ),
           const SizedBox(width: Sp.x3),
@@ -723,7 +793,7 @@ class _ProfileEditSheetState extends State<_ProfileEditSheet> {
             child: TextField(
               controller: _weight,
               keyboardType: TextInputType.number,
-              decoration: const InputDecoration(labelText: 'Weight (kg)'),
+              decoration: InputDecoration(labelText: _units.weightLabel),
             ),
           ),
         ]),

--- a/lib/ui/profile/profile_screen.dart
+++ b/lib/ui/profile/profile_screen.dart
@@ -11,6 +11,7 @@ import '../../theme/tokens.dart';
 import '../kit/kit.dart';
 import '../today/step_goal_screen.dart';
 import 'gesture_section.dart';
+import 'notification_relay_section.dart';
 
 class ProfileScreen extends StatelessWidget {
   const ProfileScreen({super.key});
@@ -137,6 +138,13 @@ class ProfileScreen extends StatelessWidget {
           const GestureSettingsCard(),
 
           const SizedBox(height: Sp.x7),
+
+          // ── Notifications (Android only — section self-hides on iOS) ──
+          if (app.notificationRelay.supported) ...[
+            const SectionHeader('Notifications'),
+            const NotificationRelaySection(),
+            const SizedBox(height: Sp.x7),
+          ],
 
           // ── Backend ──────────────────────────────────────────────────
           const SectionHeader('Backend'),

--- a/lib/ui/recap/recap_screen.dart
+++ b/lib/ui/recap/recap_screen.dart
@@ -418,6 +418,14 @@ class _RecapScreenState extends State<RecapScreen> {
   Future<void> _share() async {
     setState(() => _sharing = true);
     try {
+      // iOS/iPad: the share sheet is a popover and REQUIRES an anchor rect, or
+      // it throws PlatformException(sharePositionOrigin: argument must be set).
+      // Capture it now, before any async gap, while layout is stable.
+      final box = context.findRenderObject() as RenderBox?;
+      final origin = (box != null && box.hasSize)
+          ? (box.localToGlobal(Offset.zero) & box.size)
+          : null;
+
       final boundary = _cardKey.currentContext?.findRenderObject()
           as RenderRepaintBoundary?;
       if (boundary == null) throw StateError('Card not ready');
@@ -435,6 +443,7 @@ class _RecapScreenState extends State<RecapScreen> {
       await Share.shareXFiles(
         [XFile(file.path)],
         text: 'My OpenStrap recap',
+        sharePositionOrigin: origin,
       );
     } catch (e) {
       if (!mounted) return;

--- a/lib/ui/screens/detail_cards.dart
+++ b/lib/ui/screens/detail_cards.dart
@@ -19,6 +19,13 @@ String hm(num? minutes) {
   return '${m ~/ 60}h ${m % 60}m';
 }
 
+/// Signed deviation string for relative metrics ("+0.3", "-0.2", "0.0").
+String _signed(num? v) {
+  if (v == null) return '—';
+  final s = v.toStringAsFixed(1);
+  return v > 0 ? '+$s' : s;
+}
+
 /// Shared async wrapper: fetch a map, render via builder; spinner/empty states.
 class _Fetch extends StatefulWidget {
   final Future<Map<String, dynamic>> Function(dynamic api) load;
@@ -235,6 +242,23 @@ class HeartDayCard extends StatelessWidget {
             ]),
           ],
 
+          // Skin temperature — relative deviation vs your personal baseline (°),
+          // tappable into its trend. Honest: relative, not an absolute thermometer.
+          if (spo2 != null || d['skin_temp'] is Map) ...[
+            const SizedBox(height: Sp.x6),
+            SectionHeader('Skin temperature'),
+            MetricGroup([
+              if (d['skin_temp'] is Map)
+                TrendMetricRow(icon: Ic.thermometer, accent: AppColors.coralDeep, label: 'Skin temp vs baseline',
+                    info: infoFor('skin_temp'),
+                    value: _signed(_n((d['skin_temp'] as Map)['value'])), unit: 'Δ',
+                    metric: 'skin_temp', trendTitle: 'Skin temp vs baseline')
+              else
+                MetricRow(icon: Ic.thermometer, accent: AppColors.inkSoft, label: 'Skin temp vs baseline',
+                    info: infoFor('skin_temp'), value: '—'),
+            ]),
+          ],
+
           // Illness watch — ALWAYS shown (Mahalanobis of resting HR / HRV / temp).
           // Three honest states: active signal, all-clear, or still building baseline.
           ...[
@@ -243,11 +267,12 @@ class HeartDayCard extends StatelessWidget {
             _IllnessCard(illness),
           ],
 
-          // Irregular-rhythm screen (Poincaré from nocturnal RR) — shown once it has data.
-          if (d['irregular'] is Map && (d['irregular']['confidence'] as num? ?? 0) > 0) ...[
+          // Irregular-rhythm screen (Poincaré from nocturnal RR) — ALWAYS shown,
+          // with a "building" state until there's a night of RR to read.
+          ...[
             const SizedBox(height: Sp.x6),
             SectionHeader('Irregular-beat watch'),
-            _IrregularCard(d['irregular'] as Map),
+            _IrregularCard(d['irregular'] is Map ? d['irregular'] as Map : null),
           ],
 
           // What affected this — display-only (no navigation loop), properly padded.
@@ -338,14 +363,34 @@ class _IllnessCard extends StatelessWidget {
   }
 }
 
-// Irregular-rhythm screen card — green "looks regular" vs amber "irregular pattern".
+// Irregular-rhythm screen card — ALWAYS shown, three honest states:
+// "building baseline" (no data yet), green "looks regular", amber "irregular".
 // A SCREEN, not a diagnosis. Conservative; shows the Poincaré descriptors.
 class _IrregularCard extends StatelessWidget {
-  final Map irr;
+  final Map? irr;
   const _IrregularCard(this.irr);
   @override
   Widget build(BuildContext context) {
-    final flag = irr['flag'] == true;
+    final conf = (irr?['confidence'] as num?) ?? 0;
+    // No usable nocturnal RR yet → honest "building" state.
+    if (irr == null || conf <= 0) {
+      return ProCard(child: Padding(padding: const EdgeInsets.all(Sp.x4), child: Row(children: [
+        Container(
+          padding: const EdgeInsets.all(9),
+          decoration: BoxDecoration(color: AppColors.surfaceSunk, borderRadius: BorderRadius.circular(R.chip)),
+          child: AppIcon(Ic.info, size: 17, color: AppColors.inkMuted),
+        ),
+        const SizedBox(width: Sp.x3),
+        Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Text('Listening for your rhythm', style: AppText.label),
+          const SizedBox(height: 2),
+          Text('This screens your beat-to-beat (RR) timing overnight for irregularity. '
+              'It needs a night of good wear with heart-rate variability data to read.',
+              style: AppText.captionMuted),
+        ])),
+      ])));
+    }
+    final flag = irr!['flag'] == true;
     final accent = flag ? AppColors.warn : AppColors.good;
     final softBg = flag ? AppColors.warnSoft : AppColors.goodSoft;
     return ProCard(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
@@ -366,11 +411,11 @@ class _IrregularCard extends StatelessWidget {
               style: AppText.captionMuted),
         ])),
       ])),
-      if (irr['sd1'] != null && irr['sd2'] != null) ...[
+      if (irr!['sd1'] != null && irr!['sd2'] != null) ...[
         Divider(height: 1, color: AppColors.divider),
         Padding(padding: const EdgeInsets.symmetric(horizontal: Sp.x4, vertical: Sp.x2), child: Column(children: [
-          DetailRow(label: 'Poincaré SD1 / SD2', value: '${irr['sd1']} / ${irr['sd2']} ms'),
-          if (irr['pnn50'] != null) DetailRow(label: 'pNN50', value: '${irr['pnn50']}%'),
+          DetailRow(label: 'Poincaré SD1 / SD2', value: '${irr!['sd1']} / ${irr!['sd2']} ms'),
+          if (irr!['pnn50'] != null) DetailRow(label: 'pNN50', value: '${irr!['pnn50']}%'),
         ])),
       ],
     ]));

--- a/lib/ui/screens/metric_row.dart
+++ b/lib/ui/screens/metric_row.dart
@@ -33,6 +33,7 @@ const Map<String, String> kMetricInfo = {
   'sleeping_hr': 'Average heart rate while you slept.',
   'resp': 'Breaths per minute, derived from heart-rate variability.',
   'spo2': 'Blood-oxygen relative to your own baseline.',
+  'skin_temp': 'Skin temperature vs your personal overnight baseline. Relative (Δ), not an absolute thermometer.',
   'hrr60': 'How fast your HR drops a minute after peak effort — fitness marker.',
   'illness': 'A combined resting-HR / HRV / temperature signal that can flag early illness.',
   'debt': 'Sleep you owe from falling short of your need on recent nights.',

--- a/lib/ui/screens/metric_screen.dart
+++ b/lib/ui/screens/metric_screen.dart
@@ -28,6 +28,7 @@ class MetricScreen extends StatefulWidget {
   final String Function(double v)? valueFmt;
   final DetailBuilder todayDetail;
   final DayDetailBuilder dayDetail;
+  final Widget? action; // optional top-right action (e.g. AI coach button)
   const MetricScreen({
     super.key,
     required this.title,
@@ -37,6 +38,7 @@ class MetricScreen extends StatefulWidget {
     required this.todayDetail,
     required this.dayDetail,
     this.valueFmt,
+    this.action,
   });
 
   @override
@@ -80,6 +82,7 @@ class _MetricScreenState extends State<MetricScreen> {
                 const SizedBox(width: Sp.x3),
               ],
               Expanded(child: Text(widget.title, style: AppText.h1)),
+              if (widget.action != null) widget.action!,
             ]),
             const SizedBox(height: Sp.x4),
             Align(

--- a/lib/ui/screens/metric_screen.dart
+++ b/lib/ui/screens/metric_screen.dart
@@ -45,6 +45,14 @@ class MetricScreen extends StatefulWidget {
 
 class _MetricScreenState extends State<MetricScreen> {
   int _tab = 0;
+  int _refresh = 0; // bumped on pull-to-refresh → woven into child keys to force re-fetch
+
+  // Pull-to-refresh: remount the visible child (today detail or the drill bars) so it
+  // re-fetches its endpoint. The brief await keeps the spinner up while children load.
+  Future<void> _onRefresh() async {
+    setState(() => _refresh++);
+    await Future<void>.delayed(const Duration(milliseconds: 600));
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -55,7 +63,10 @@ class _MetricScreenState extends State<MetricScreen> {
       backgroundColor: AppColors.bg,
       body: SafeArea(
         bottom: false,
-        child: ListView(
+        child: RefreshIndicator(
+          onRefresh: _onRefresh,
+          color: widget.accent,
+          child: ListView(
           physics: const AlwaysScrollableScrollPhysics(),
           padding: const EdgeInsets.symmetric(horizontal: Sp.screen),
           children: [
@@ -77,10 +88,10 @@ class _MetricScreenState extends State<MetricScreen> {
             ),
             const SizedBox(height: Sp.x5),
             if (_tab == 0)
-              widget.todayDetail(context)
+              KeyedSubtree(key: ValueKey('today-$_refresh'), child: widget.todayDetail(context))
             else
               _DrillLevel(
-                key: ValueKey('$scale-root'),
+                key: ValueKey('$scale-$_refresh-root'),
                 title: widget.title,
                 icon: widget.icon,
                 metric: widget.metric,
@@ -92,6 +103,7 @@ class _MetricScreenState extends State<MetricScreen> {
               ),
             const SizedBox(height: 110),
           ],
+          ),
         ),
       ),
     );

--- a/lib/ui/screens/screens.dart
+++ b/lib/ui/screens/screens.dart
@@ -7,6 +7,7 @@ import '../../theme/tokens.dart';
 import '../kit/kit.dart';
 import '../sleep/sleep_detail_screen.dart';
 import '../activity/strain_detail_screen.dart';
+import '../heart/live_hr_tile.dart';
 import 'metric_screen.dart';
 import 'detail_cards.dart';
 
@@ -41,6 +42,8 @@ class HeartScreen extends StatelessWidget {
         icon: Ic.heart,
         accent: AppColors.coral,
         todayDetail: (ctx) => Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          const LiveHrTile(),
+          const SizedBox(height: Sp.x4),
           HeartDayCard(date: todayUtc()),
           const SectionExtras(section: 'heart'),
         ]),

--- a/lib/ui/screens/screens.dart
+++ b/lib/ui/screens/screens.dart
@@ -3,11 +3,17 @@
 // Today's per-metric cards (one canonical screen, reached from everywhere).
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../state/app_state.dart';
+import '../../theme/theme.dart';
 import '../../theme/tokens.dart';
 import '../kit/kit.dart';
 import '../sleep/sleep_detail_screen.dart';
 import '../activity/strain_detail_screen.dart';
 import '../heart/live_hr_tile.dart';
+import '../cycle/cycle_screen.dart';
+import '../spotcheck/spot_check_screen.dart';
+import '../coach/ai_coach_screen.dart';
 import 'metric_screen.dart';
 import 'detail_cards.dart';
 
@@ -44,6 +50,8 @@ class HeartScreen extends StatelessWidget {
         todayDetail: (ctx) => Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
           const LiveHrTile(),
           const SizedBox(height: Sp.x4),
+          const SpotCheckEntryCard(),
+          const SizedBox(height: Sp.x4),
           HeartDayCard(date: todayUtc()),
           const SectionExtras(section: 'heart'),
         ]),
@@ -79,10 +87,90 @@ class BodyScreen extends StatelessWidget {
         metric: 'strain',
         icon: Ic.strain,
         accent: AppColors.coral,
+        action: Builder(builder: (ctx) => GestureDetector(
+              onTap: () => Navigator.of(ctx).push(
+                  MaterialPageRoute(builder: (_) => const AiCoachScreen())),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: Sp.x3, vertical: 8),
+                decoration: BoxDecoration(
+                    color: AppColors.coral, borderRadius: BorderRadius.circular(R.pill)),
+                child: Row(mainAxisSize: MainAxisSize.min, children: [
+                  const AppIcon(Ic.ai, size: 16, color: Colors.white),
+                  const SizedBox(width: 6),
+                  Text('AI Coach', style: AppText.label.copyWith(color: Colors.white)),
+                ]),
+              ),
+            )),
         todayDetail: (ctx) => Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
           StrainDetailScreen(date: todayUtc(), embedded: true),
+          const CycleEntryCard(),
           const SectionExtras(section: 'body'),
         ]),
         dayDetail: (ctx, date) => StrainDetailScreen(date: date, embedded: true),
       );
+}
+
+/// Tappable entry to the live HRV spot-check.
+class SpotCheckEntryCard extends StatelessWidget {
+  const SpotCheckEntryCard({super.key});
+  @override
+  Widget build(BuildContext context) {
+    return ProCard(
+      onTap: () => Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => const SpotCheckScreen())),
+      child: Row(children: [
+        Container(
+          padding: const EdgeInsets.all(9),
+          decoration: BoxDecoration(
+              color: AppColors.good.withValues(alpha: 0.14),
+              borderRadius: BorderRadius.circular(R.chip)),
+          child: AppIcon(Ic.pulse, size: 18, color: AppColors.good),
+        ),
+        const SizedBox(width: Sp.x3),
+        Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Text('Live HRV spot check', style: AppText.label),
+          const SizedBox(height: 2),
+          Text('A quick 60-second reading, any time', style: AppText.captionMuted),
+        ])),
+        AppIcon(Ic.arrowRight, size: 18, color: AppColors.inkMuted),
+      ]),
+    );
+  }
+}
+
+/// Tappable entry to the Cycle screen — shown only when the user has explicitly
+/// opted in (Profile → Track menstrual cycle). Consent-gated, never inferred.
+class CycleEntryCard extends StatelessWidget {
+  const CycleEntryCard({super.key});
+  @override
+  Widget build(BuildContext context) {
+    final track = context.select<AppState, bool>((s) {
+      final v = s.user?['track_cycle'];
+      return v == true || v == 1;
+    });
+    if (!track) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(top: Sp.x6),
+      child: ProCard(
+        onTap: () => Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const CycleScreen())),
+        child: Row(children: [
+          Container(
+            padding: const EdgeInsets.all(9),
+            decoration: BoxDecoration(
+                color: AppColors.coral.withValues(alpha: 0.14),
+                borderRadius: BorderRadius.circular(R.chip)),
+            child: AppIcon(Ic.calendar, size: 18, color: AppColors.coral),
+          ),
+          const SizedBox(width: Sp.x3),
+          Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+            Text('Cycle tracking', style: AppText.label),
+            const SizedBox(height: 2),
+            Text('Phase, next period & fertile window', style: AppText.captionMuted),
+          ])),
+          AppIcon(Ic.arrowRight, size: 18, color: AppColors.inkMuted),
+        ]),
+      ),
+    );
+  }
 }

--- a/lib/ui/sleep/sleep_detail_screen.dart
+++ b/lib/ui/sleep/sleep_detail_screen.dart
@@ -308,7 +308,11 @@ class _SleepDetailScreenState extends State<SleepDetailScreen> {
       backgroundColor: AppColors.bg,
       body: SafeArea(
         bottom: false,
-        child: ListView(
+        child: RefreshIndicator(
+          onRefresh: _load,
+          color: AppColors.coral,
+          child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
           padding: const EdgeInsets.symmetric(horizontal: Sp.screen),
           children: [
             const SizedBox(height: Sp.x4),
@@ -317,6 +321,7 @@ class _SleepDetailScreenState extends State<SleepDetailScreen> {
             ..._sections(),
             const SizedBox(height: 40),
           ],
+          ),
         ),
       ),
     );

--- a/lib/ui/sleep/sleep_detail_screen.dart
+++ b/lib/ui/sleep/sleep_detail_screen.dart
@@ -117,6 +117,29 @@ class _SleepDetailScreenState extends State<SleepDetailScreen> {
   num? get _remMin => _num(_stages['rem_min']);
   num? get _lightMin => _num(_stages['light_min']);
 
+  // Sleep cycles (ultradian NREM↔REM, fractal-cycle method on HRV). Beta.
+  List<Map<String, dynamic>> get _cycles {
+    final raw = _data['cycles'];
+    if (raw is! List) return const [];
+    return raw.map((e) => _map(e)).where((m) => m.isNotEmpty).toList();
+  }
+
+  num? get _cyclesMean => _num(_data['cycles_mean_min']);
+
+  List<MapEntry<int, double>> get _cycleSeries {
+    final raw = _data['cycle_series'];
+    if (raw is! List) return const [];
+    final out = <MapEntry<int, double>>[];
+    for (final p in raw) {
+      final m = _map(p);
+      final t = _num(m['t'])?.toInt();
+      final z = _num(m['z'])?.toDouble();
+      if (t != null && z != null) out.add(MapEntry(t, z));
+    }
+    out.sort((a, b) => a.key.compareTo(b.key));
+    return out;
+  }
+
   Map<String, dynamic> get _nocturnal => _map(_data['nocturnal']);
   Map<String, dynamic> get _resp => _map(_data['resp']);
   bool get _hasNocturnal => _num(_nocturnal['sleeping_hr_avg']) != null;
@@ -259,6 +282,11 @@ class _SleepDetailScreenState extends State<SleepDetailScreen> {
       const SizedBox(height: Sp.x6),
       SectionHeader('Stages'),
       _stageBreakdown(),
+      // Cycles sit directly under Stages (same block — not a separate section).
+      if (detailedAvailable(widget.date) && _cycles.isNotEmpty) ...[
+        const SizedBox(height: Sp.x3),
+        _cyclesCard(),
+      ],
       const SizedBox(height: Sp.x6),
       SectionHeader('Efficiency'),
       _efficiencyCard(),
@@ -467,6 +495,78 @@ class _SleepDetailScreenState extends State<SleepDetailScreen> {
           ],
           const SizedBox(height: Sp.x4),
           _legend(),
+        ],
+      ),
+    );
+  }
+
+  // ── sleep cycles (fractal-cycle method on HRV) ─────────────────────────────
+
+  Widget _cyclesCard() {
+    final series = _cycleSeries;
+    final cycles = _cycles;
+    final onset = _num(_data['onset_ts'])?.toInt();
+    final wake = _num(_data['wake_ts'])?.toInt();
+    return ProCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text('Cycles', style: AppText.h2),
+              const SizedBox(width: Sp.x2),
+              Tag('beta', color: AppColors.coral),
+              const Spacer(),
+              Text('${cycles.length} cycle${cycles.length == 1 ? '' : 's'}',
+                  style: AppText.metricSm.copyWith(fontSize: 18)),
+            ],
+          ),
+          const SizedBox(height: Sp.x2),
+          Text(
+            _cyclesMean == null
+                ? 'Ultradian NREM–REM cycles'
+                : 'Average ${_hm(_cyclesMean)} per cycle',
+            style: AppText.captionMuted,
+          ),
+          const SizedBox(height: Sp.x4),
+          if (series.length >= 4 && onset != null && wake != null && wake > onset) ...[
+            SizedBox(
+              height: 76,
+              child: CustomPaint(
+                size: Size.infinite,
+                painter: _CyclePainter(
+                  series: series,
+                  cycles: cycles,
+                  onset: onset,
+                  wake: wake,
+                  line: AppColors.coral,
+                  marker: AppColors.coralDeep,
+                  grid: AppColors.surfaceAlt,
+                ),
+              ),
+            ),
+            const SizedBox(height: Sp.x2),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(_clock(onset), style: AppText.captionMuted),
+                Text(_clock(wake), style: AppText.captionMuted),
+              ],
+            ),
+          ] else
+            SizedBox(
+              height: 48,
+              child: Center(
+                child: Text('Not enough overnight HRV to resolve cycles',
+                    style: AppText.captionMuted),
+              ),
+            ),
+          const SizedBox(height: Sp.x3),
+          Text(
+            'Each rise-and-fall of your overnight heart-rate variability is one sleep '
+            'cycle (~90 min). Diamonds mark the boundaries between cycles.',
+            style: AppText.captionMuted,
+          ),
         ],
       ),
     );
@@ -872,4 +972,107 @@ class _HypnogramPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_HypnogramPainter old) => old.segs != segs;
+}
+
+/// Draws the overnight HRV (z-RMSSD) wave across [onset, wake] with vertical
+/// boundary lines + diamonds at each detected sleep-cycle edge — the cardiac
+/// analog of the paper's fractal-slope cycle figure.
+class _CyclePainter extends CustomPainter {
+  final List<MapEntry<int, double>> series;
+  final List<Map<String, dynamic>> cycles;
+  final int onset;
+  final int wake;
+  final Color line;
+  final Color marker;
+  final Color grid;
+  _CyclePainter({
+    required this.series,
+    required this.cycles,
+    required this.onset,
+    required this.wake,
+    required this.line,
+    required this.marker,
+    required this.grid,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final span = (wake - onset).toDouble();
+    if (span <= 0 || series.isEmpty) return;
+
+    double zmin = double.infinity, zmax = -double.infinity;
+    for (final e in series) {
+      if (e.value < zmin) zmin = e.value;
+      if (e.value > zmax) zmax = e.value;
+    }
+    if (!(zmax > zmin)) zmax = zmin + 1;
+
+    double xOf(int t) => (((t - onset) / span).clamp(0.0, 1.0)) * size.width;
+    double yOf(double z) {
+      final n = (z - zmin) / (zmax - zmin); // 0..1
+      return size.height - n * size.height * 0.80 - size.height * 0.10;
+    }
+
+    // cycle boundary verticals
+    final bounds = <int>{};
+    for (final c in cycles) {
+      final s = (c['start_ts'] as num?)?.toInt();
+      final e = (c['end_ts'] as num?)?.toInt();
+      if (s != null) bounds.add(s);
+      if (e != null) bounds.add(e);
+    }
+    final gp = Paint()..color = grid..strokeWidth = 1;
+    for (final t in bounds) {
+      final x = xOf(t);
+      canvas.drawLine(Offset(x, 0), Offset(x, size.height), gp);
+    }
+
+    // the HRV curve
+    final path = Path();
+    bool started = false;
+    for (final e in series) {
+      final x = xOf(e.key);
+      final y = yOf(e.value);
+      if (!started) {
+        path.moveTo(x, y);
+        started = true;
+      } else {
+        path.lineTo(x, y);
+      }
+    }
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = line
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2.5
+        ..strokeJoin = StrokeJoin.round,
+    );
+
+    // diamonds at each boundary, snapped to the curve's nearest z
+    final mp = Paint()..color = marker;
+    for (final t in bounds) {
+      double bestD = double.infinity, by = size.height / 2;
+      for (final e in series) {
+        final d = (e.key - t).abs().toDouble();
+        if (d < bestD) {
+          bestD = d;
+          by = yOf(e.value);
+        }
+      }
+      final x = xOf(t);
+      const r = 4.0;
+      final dia = Path()
+        ..moveTo(x, by - r)
+        ..lineTo(x + r, by)
+        ..lineTo(x, by + r)
+        ..lineTo(x - r, by)
+        ..close();
+      canvas.drawPath(dia, mp);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_CyclePainter old) =>
+      old.series != series || old.cycles != cycles;
 }

--- a/lib/ui/sleep/sleep_periods_screen.dart
+++ b/lib/ui/sleep/sleep_periods_screen.dart
@@ -74,7 +74,13 @@ class _SleepPeriodsScreenState extends State<SleepPeriodsScreen> {
       backgroundColor: AppColors.bg,
       body: SafeArea(
         bottom: false,
-        child: ListView(
+        child: RefreshIndicator(
+          onRefresh: _load,
+          color: AppColors.coral,
+          child: ListView(
+          // AlwaysScrollable so pull-to-refresh fires even when content is short
+          // (loading / empty / error) — the common "refresh doesn't work" cause.
+          physics: const AlwaysScrollableScrollPhysics(),
           padding: const EdgeInsets.symmetric(horizontal: Sp.screen),
           children: [
             const SizedBox(height: Sp.x4),
@@ -104,6 +110,7 @@ class _SleepPeriodsScreenState extends State<SleepPeriodsScreen> {
             ],
             const SizedBox(height: 40),
           ],
+          ),
         ),
       ),
     );

--- a/lib/ui/sleep/sleep_periods_screen.dart
+++ b/lib/ui/sleep/sleep_periods_screen.dart
@@ -185,6 +185,12 @@ class _SleepPeriodsScreenState extends State<SleepPeriodsScreen> {
             Text('${_clock(onset)} – ${_clock(wake)}',
                 style: AppText.label.copyWith(color: AppColors.inkSoft)),
           ],
+          if (_hypList(p).isNotEmpty) ...[
+            const SizedBox(height: Sp.x4),
+            // Per-nap hypnogram — the same banded timeline as the main sleep, so a
+            // nap shows its own stage progression (only rendered when present).
+            _HypnoStrip(segments: _hypList(p), colorOf: _stageColor),
+          ],
           if (stages != null) ...[
             const SizedBox(height: Sp.x4),
             _stageBar(stages),
@@ -194,6 +200,13 @@ class _SleepPeriodsScreenState extends State<SleepPeriodsScreen> {
         ],
       ),
     );
+  }
+
+  // Per-period hypnogram points [{t, stage}] from /day/v2/sleep (empty if none).
+  List<Map<String, dynamic>> _hypList(Map<String, dynamic> p) {
+    final h = p['hypnogram'];
+    if (h is List) return h.whereType<Map>().map((e) => e.cast<String, dynamic>()).toList();
+    return const [];
   }
 
   Widget _stageBar(Map<String, dynamic> s) {
@@ -288,4 +301,44 @@ class _SleepPeriodsScreenState extends State<SleepPeriodsScreen> {
           ),
         ),
       ]);
+}
+
+/// Compact per-nap hypnogram: each downsampled {t, stage} point drawn as a band at
+/// its sleep-depth row (awake top → deep bottom). Self-contained; colors injected.
+class _HypnoStrip extends StatelessWidget {
+  final List<Map<String, dynamic>> segments;
+  final Color Function(String) colorOf;
+  const _HypnoStrip({required this.segments, required this.colorOf});
+
+  @override
+  Widget build(BuildContext context) => SizedBox(
+        height: 40,
+        width: double.infinity,
+        child: CustomPaint(painter: _HypnoPainter(segments, colorOf)),
+      );
+}
+
+class _HypnoPainter extends CustomPainter {
+  final List<Map<String, dynamic>> pts;
+  final Color Function(String) colorOf;
+  _HypnoPainter(this.pts, this.colorOf);
+  static const _rank = {'awake': 0, 'rem': 1, 'light': 2, 'deep': 3};
+
+  @override
+  void paint(Canvas c, Size s) {
+    if (pts.length < 2) return;
+    final n = pts.length;
+    final bandH = s.height / 4;
+    final w = s.width / (n - 1);
+    final paint = Paint();
+    for (int i = 0; i < n - 1; i++) {
+      final st = (pts[i]['stage'] as String?) ?? 'light';
+      final r = (_rank[st] ?? 2).toDouble();
+      paint.color = colorOf(st);
+      c.drawRect(Rect.fromLTWH(i * w, r * bandH, w + 0.5, bandH - 1), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_HypnoPainter old) => old.pts != pts;
 }

--- a/lib/ui/spotcheck/spot_check_screen.dart
+++ b/lib/ui/spotcheck/spot_check_screen.dart
@@ -1,0 +1,127 @@
+// Spot check — an on-demand ~60s live HRV reading. Enables wrist-gated optical +
+// realtime records, collects beat-to-beat RR, and computes HRV server-side. Honest:
+// a quick snapshot, not your nightly recovery (that's measured over a full sleep).
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../state/app_state.dart';
+import '../../theme/theme.dart';
+import '../../theme/tokens.dart';
+import '../kit/kit.dart';
+import '../kit/charts.dart';
+
+class SpotCheckScreen extends StatelessWidget {
+  const SpotCheckScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final app = context.watch<AppState>();
+    final connected = app.isConnected;
+    final active = app.spotActive;
+    final result = app.spotResult;
+    final err = app.spotError;
+    final remaining = app.spotRemaining;
+    final progress = active
+        ? (AppState.spotDuration - remaining) / AppState.spotDuration
+        : 0.0;
+    final liveHr = app.device.liveHr;
+
+    return Scaffold(
+      backgroundColor: AppColors.bg,
+      body: SafeArea(
+        bottom: false,
+        child: ListView(
+          padding: const EdgeInsets.symmetric(horizontal: Sp.screen),
+          children: [
+            const SizedBox(height: Sp.x4),
+            Row(children: [
+              RoundIconButton(Ic.arrowLeft, onTap: () {
+                if (active) app.cancelSpotCheck();
+                Navigator.of(context).pop();
+              }),
+              const SizedBox(width: Sp.x3),
+              Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+                Text('Spot check', style: AppText.h1),
+                const SizedBox(height: 4),
+                Text('A quick live HRV reading', style: AppText.caption),
+              ])),
+            ]),
+            const SizedBox(height: Sp.x8),
+
+            // The ring: countdown while scanning, else the last RMSSD or a prompt.
+            Center(child: RingStat(
+              t: active ? progress.clamp(0.0, 1.0) : (result?['ok'] == true ? 1.0 : 0.0),
+              color: AppColors.good, size: 200, stroke: 16,
+              center: active
+                  ? Column(mainAxisSize: MainAxisSize.min, children: [
+                      Text('$remaining', style: AppText.display),
+                      Text('seconds', style: AppText.caption),
+                      if (liveHr != null && liveHr > 0) ...[
+                        const SizedBox(height: 4),
+                        Text('♥ $liveHr bpm', style: AppText.captionMuted),
+                      ],
+                    ])
+                  : (result?['ok'] == true
+                      ? Column(mainAxisSize: MainAxisSize.min, children: [
+                          Text('${result!['rmssd']}', style: AppText.display),
+                          Text('ms RMSSD', style: AppText.caption),
+                        ])
+                      : AppIcon(Ic.pulse, size: 56, color: AppColors.inkMuted)),
+            )),
+            const SizedBox(height: Sp.x8),
+
+            if (active)
+              ProCard(child: Padding(padding: const EdgeInsets.all(Sp.x4), child: Row(children: [
+                AppIcon(Ic.info, size: 16, color: AppColors.coralDeep),
+                const SizedBox(width: Sp.x3),
+                Expanded(child: Text('Keep the band snug and sit still. Breathe normally — '
+                    'movement adds noise to the reading.', style: AppText.captionMuted)),
+              ])))
+            else if (result?['ok'] == true) ...[
+              _resultCard(result!),
+            ] else if (err != null)
+              ProCard(child: Padding(padding: const EdgeInsets.all(Sp.x4), child: Text(err, style: AppText.captionMuted))),
+
+            const SizedBox(height: Sp.x6),
+
+            if (!active)
+              FilledButton.icon(
+                onPressed: connected ? app.startSpotCheck : null,
+                icon: const AppIcon(Ic.pulse, size: 18, color: Colors.white),
+                label: Text(result == null ? 'Start 60-second scan' : 'Scan again'),
+              )
+            else
+              OutlinedButton(onPressed: app.cancelSpotCheck, child: const Text('Cancel')),
+
+            if (!connected && !active) ...[
+              const SizedBox(height: Sp.x3),
+              Text('Connect your band to run a spot check.',
+                  style: AppText.captionMuted, textAlign: TextAlign.center),
+            ],
+
+            const SizedBox(height: Sp.x6),
+            Text('A spot check is a snapshot of your current state. Your daily recovery '
+                'is measured over a full night of sleep and is more reliable for trends.',
+                style: AppText.captionMuted),
+            const SizedBox(height: 80),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _resultCard(Map r) => ProCard(child: Column(children: [
+        _row('RMSSD', '${r['rmssd'] ?? '—'}', 'ms'),
+        if (r['sdnn'] != null) _row('SDNN', '${r['sdnn']}', 'ms'),
+        if (r['pnn50'] != null) _row('pNN50', '${r['pnn50']}', '%'),
+        if (r['mean_hr'] != null) _row('Mean HR', '${r['mean_hr']}', 'bpm'),
+        if (r['n_beats'] != null) _row('Beats analysed', '${r['n_beats']}', ''),
+      ]));
+
+  Widget _row(String label, String value, String unit) =>
+      Padding(padding: const EdgeInsets.symmetric(vertical: Sp.x2), child: Row(children: [
+        Expanded(child: Text(label, style: AppText.body)),
+        Text(unit.isEmpty ? value : '$value $unit', style: AppText.label),
+      ]));
+}

--- a/lib/widget/widget_service.dart
+++ b/lib/widget/widget_service.dart
@@ -16,6 +16,9 @@ class WidgetService {
 
   /// WidgetKit "kind" (Swift) / Android provider class name.
   static const String _iOSName = 'OpenStrapWidget';
+
+  /// WidgetKit "kind" for the lock-screen Band Battery widget (Swift).
+  static const String _batteryIOSName = 'OpenStrapBatteryWidget';
   static const String _androidName = 'OpenStrapWidgetProvider';
 
   static bool _inited = false;
@@ -56,6 +59,26 @@ class WidgetService {
       await setI('updated_at', DateTime.now().millisecondsSinceEpoch ~/ 1000);
 
       await HomeWidget.updateWidget(iOSName: _iOSName, androidName: _androidName);
+    } catch (_) {/* widgets unavailable / not configured yet — ignore */}
+  }
+
+  /// Push the band's battery snapshot for the lock-screen Band Battery widget.
+  /// Battery is a live BLE value (not in /today), so that widget never refreshes
+  /// over the network — it renders whatever we last wrote here. Call from the
+  /// device-state hook, but only when pct/charging actually changed (the hook
+  /// fires ~1 Hz on live HR; reloading the widget every tick is wasteful).
+  /// Sentinel: pct -1 = never seen the band. [name] is the strap's advertising
+  /// name (the widget falls back to "Strap" when empty/null).
+  static Future<void> pushBattery(int? pct, bool? charging, String? name) async {
+    try {
+      await init();
+      await HomeWidget.saveWidgetData<int>('batt_pct', pct ?? -1);
+      await HomeWidget.saveWidgetData<bool>('batt_charging', charging ?? false);
+      await HomeWidget.saveWidgetData<String>('batt_name', name ?? '');
+      await HomeWidget.saveWidgetData<int>(
+          'batt_at', DateTime.now().millisecondsSinceEpoch ~/ 1000);
+      await HomeWidget.updateWidget(
+          iOSName: _batteryIOSName, androidName: _androidName);
     } catch (_) {/* widgets unavailable / not configured yet — ignore */}
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -392,6 +392,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
+  installed_apps:
+    dependency: "direct main"
+    description:
+      name: installed_apps
+      sha256: "62b9cb196e2b34558ef0586024251e5dcc5a08199ea0c55c708f0ecc53116341"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   io:
     dependency: transitive
     description:
@@ -512,6 +520,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  notification_listener_service:
+    dependency: "direct main"
+    description:
+      name: notification_listener_service
+      sha256: "79cdf3e8b1eedc66aa0f3fce46f2f7bba5752f33d6566396bee7598882ac931d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   objective_c:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -302,6 +302,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.0.0"
+  flutter_math_fork:
+    dependency: transitive
+    description:
+      name: flutter_math_fork
+      sha256: "6d5f2f1aa57ae539ffb0a04bb39d2da67af74601d685a161aff7ce5bda5fa407"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.4"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.3.1"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
+  flutter_svg:
+    dependency: transitive
+    description:
+      name: flutter_svg
+      sha256: "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -336,6 +400,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.3.3"
+  gpt_markdown:
+    dependency: "direct main"
+    description:
+      name: gpt_markdown
+      sha256: c14c2a4599a67df5b6a984808cbb7631b8d15c91984ffdd7998597b93a6ff136
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.7"
   home_widget:
     dependency: "direct main"
     description:
@@ -576,6 +648,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -941,6 +1021,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.10.1"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:
@@ -1021,6 +1109,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.3"
+  vector_graphics:
+    dependency: transitive
+    description:
+      name: vector_graphics
+      sha256: "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  vector_graphics_codec:
+    dependency: transitive
+    description:
+      name: vector_graphics_codec
+      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.13"
+  vector_graphics_compiler:
+    dependency: transitive
+    description:
+      name: vector_graphics_compiler
+      sha256: "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.6"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,8 @@ dependencies:
   url_launcher: ^6.3.0
   notification_listener_service: ^1.0.0
   installed_apps: ^2.1.1
+  flutter_secure_storage: ^10.3.1
+  gpt_markdown: ^1.1.7
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,8 @@ dependencies:
   package_info_plus: ^8.1.0
   ota_update: ^7.1.0
   url_launcher: ^6.3.0
+  notification_listener_service: ^1.0.0
+  installed_apps: ^2.1.1
 
 dev_dependencies:
   flutter_test:

--- a/test/protocol_test.dart
+++ b/test/protocol_test.dart
@@ -102,14 +102,11 @@ void main() {
 
     test('record 0 matches whoop.py exactly', () {
       final r = parseR24(hexToBytes(records[0]['hex'] as String))!;
+      // Edge decodes the HEADER only (ts/counter/hr); the cloud owns the sensor
+      // block. Sensor-field decoding is covered by the cloud golden test
+      // (openstrap-protocol/ts/test_decoder.ts) + the Python reference.
       expect(r.tsEpoch, 1775395266);
       expect(r.hr, 98);
-      expect(r.spo2, 94);
-      expect(r.skinTempC, closeTo(33.5, 0.001));
-      expect(r.restingHr, 81);
-      expect(r.accelG[0], closeTo(-0.1502, 0.0005));
-      expect(r.accelG[1], closeTo(-0.3311, 0.0005));
-      expect(r.accelG[2], closeTo(1.0006, 0.0005));
     });
 
     test('all 550 records decode without throwing', () {


### PR DESCRIPTION
## feat/wake-trigger → main

### v2 UX
- Pull-to-refresh on all screens; per-nap hypnograms; RR-aware sleep so Today ⇄ Sleep durations match.

### AI Coach (BYOK, agentic) — new
- Bring-your-own OpenAI-compatible key (stored in device keychain via `flutter_secure_storage`); calls the provider directly — never through OpenStrap servers.
- Agentic tool-calling over the user's own data (read tools) + actions (writes require explicit confirmation).
- Charts the AI builds from fetched data, rendered natively + animated (robust parser for wrapped/string/unit'd values, single-point handling).
- Markdown answers (`gpt_markdown`), dynamic model picker (live `/models`, search + custom-tick), strict **health-only** scope (refuses off-topic/code), playful status messages.
- Multi-session chat history persisted on disk (per-user), browse/continue/delete. Entry: **AI Coach** button on the Body screen.

### Other features — new
- **Menstrual cycle**: opt-in `CycleScreen` (phase, next-period, fertile window, body overlay) behind a Profile toggle.
- **Live HRV spot-check**: 60s wrist-gated optical scan → HRV result (Heart screen).
- **Skin-temperature** section + **always-on irregular-rhythm** card on Heart.
- **Units toggle** (metric/imperial), local display preference.
- Fix: recap share sheet `sharePositionOrigin` (iOS popover crash).

> New deps: `flutter_secure_storage`, `gpt_markdown`. Verify native plugins with a release build before OTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
