### PR TITLE
perf(upload): single 60s flusher as the sole upload trigger

### DIFF
--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -79,23 +79,19 @@ class AppState extends ChangeNotifier {
   /// notification and the live drain + flush continue.
   bool _background = false;
 
-  /// One session-long flusher. It uploads pending raw records on a steady cadence and,
-  /// because the uploader RETAINS rows on any non-200 (a transient rate-limit 429
-  /// included), each tick also retries whatever the last tick couldn't send. No
-  /// per-record flushing and no backoff/cooldown — a plain ~15s cadence sits well under
-  /// the backend rate limit (burst 30, refill 0.5/s) on its own. On iOS the timer simply
-  /// fires on the next BLE-notification resume when the app was suspended.
   // THE single upload path. Every record source (live 0x28/R10/IMU, historical drain)
   // only ever STORES locally (raw_records, hex PK, retain-until-200). This one timer is
   // the ONLY thing that POSTs: it kicks once on start, then uploads everything pending
-  // every _kFlushInterval, deleting each chunk only on its confirmed 200. Uniform
+  // every _kFlushInterval, deleting each chunk only on its confirmed 200 (so a non-200/
+  // 429 just leaves rows queued for the next tick — no backoff needed; the 60s cadence
+  // sits well under the backend rate limit of burst 30 / refill 0.5/s). Uniform
   // behaviour everywhere — no per-event upload() calls to drift out of sync.
   //
   // The 60s cadence collapses the steady-state 1 Hz trickle from ~1 POST/15s (~5,760/
   // day) to ~1 POST/min (~1,440/day) — ~4× fewer R2 puts + D1 writes + Workers requests,
   // with zero data loss (cloud metrics land at the wake-close, so ≤1 min upload latency
-  // is invisible). Connection-independent: keeps flushing through background; only
-  // endSession stops it. A non-200/429 leaves rows queued for the next tick.
+  // is invisible). Connection-independent: keeps flushing through background and across
+  // reconnects; stopped only on session teardown (logout / signOut / unpair / endSession).
   Timer? _flushTimer;
   static const Duration _kFlushInterval = Duration(seconds: 60);
 
@@ -360,13 +356,16 @@ class AppState extends ChangeNotifier {
     await LocalDb.insertRecord(raw, sample);
   }
 
-  /// Start the session-long flusher (idempotent). Kicks once immediately so a fresh
-  /// session start / reconnect uploads without waiting a full interval, then runs every
-  /// _kFlushInterval. uploadPending() no-ops cheaply when nothing is queued, so the tick
-  /// is unconditional. Stopped only by endSession (survives backgrounding).
+  /// Start the session-long flusher (idempotent). On a COLD start (no timer yet) it kicks
+  /// once immediately so the first session doesn't wait a full interval, then runs every
+  /// _kFlushInterval. If the timer is already running — foreground-reclaim or a
+  /// mid-session reconnect, since the flusher survives both — this is a no-op and the
+  /// already-running timer carries the upload on its next tick (≤_kFlushInterval).
+  /// uploadPending() no-ops cheaply when nothing is queued, so the tick is unconditional.
+  /// Stopped on session teardown only (logout / signOut / unpair / endSession).
   void _startFlusher() {
-    if (_flushTimer != null) return; // already running (e.g. foreground-reclaim mid-session)
-    if (!uploading) unawaited(upload()); // immediate kick on (re)start
+    if (_flushTimer != null) return; // already running — timer survives background + reconnect
+    if (!uploading) unawaited(upload()); // immediate kick on cold start
     _flushTimer = Timer.periodic(_kFlushInterval, (_) {
       if (!uploading) unawaited(upload());
     });
@@ -479,7 +478,9 @@ class AppState extends ChangeNotifier {
   Future<void> openSession() async {
     if (busy || paired == null || !isAuthenticated) return;
     // Returning to the foreground with the connection still alive (kept during
-    // background): don't tear it down and reconnect — just reclaim ownership and flush.
+    // background): don't tear it down and reconnect — just reclaim ownership. The
+    // flusher kept running through the background, so uploads are already current;
+    // _startFlusher() below is a no-op (timer alive) and no explicit flush is needed.
     final wasBackground = _background;
     _background = false;
     if (wasBackground && engine.isConnected) {

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -85,8 +85,19 @@ class AppState extends ChangeNotifier {
   /// per-record flushing and no backoff/cooldown — a plain ~15s cadence sits well under
   /// the backend rate limit (burst 30, refill 0.5/s) on its own. On iOS the timer simply
   /// fires on the next BLE-notification resume when the app was suspended.
+  // THE single upload path. Every record source (live 0x28/R10/IMU, historical drain)
+  // only ever STORES locally (raw_records, hex PK, retain-until-200). This one timer is
+  // the ONLY thing that POSTs: it kicks once on start, then uploads everything pending
+  // every _kFlushInterval, deleting each chunk only on its confirmed 200. Uniform
+  // behaviour everywhere — no per-event upload() calls to drift out of sync.
+  //
+  // The 60s cadence collapses the steady-state 1 Hz trickle from ~1 POST/15s (~5,760/
+  // day) to ~1 POST/min (~1,440/day) — ~4× fewer R2 puts + D1 writes + Workers requests,
+  // with zero data loss (cloud metrics land at the wake-close, so ≤1 min upload latency
+  // is invisible). Connection-independent: keeps flushing through background; only
+  // endSession stops it. A non-200/429 leaves rows queued for the next tick.
   Timer? _flushTimer;
-  static const Duration _kFlushInterval = Duration(seconds: 15);
+  static const Duration _kFlushInterval = Duration(seconds: 60);
 
   bool get backendChosen => config?.chosen ?? false;
   bool get isAuthenticated => session?.isValid ?? false;
@@ -349,9 +360,14 @@ class AppState extends ChangeNotifier {
     await LocalDb.insertRecord(raw, sample);
   }
 
-  /// Start the session-long flusher (idempotent). Cancelled on disconnect / sign-out.
+  /// Start the session-long flusher (idempotent). Kicks once immediately so a fresh
+  /// session start / reconnect uploads without waiting a full interval, then runs every
+  /// _kFlushInterval. uploadPending() no-ops cheaply when nothing is queued, so the tick
+  /// is unconditional. Stopped only by endSession (survives backgrounding).
   void _startFlusher() {
-    _flushTimer ??= Timer.periodic(_kFlushInterval, (_) {
+    if (_flushTimer != null) return; // already running (e.g. foreground-reclaim mid-session)
+    if (!uploading) unawaited(upload()); // immediate kick on (re)start
+    _flushTimer = Timer.periodic(_kFlushInterval, (_) {
       if (!uploading) unawaited(upload());
     });
   }
@@ -470,8 +486,7 @@ class AppState extends ChangeNotifier {
       IosBleRestore.foregroundActive = true;
       await IosBleRestore.setOwnsBand(true);
       EdgeTracking.start(); // Android: keep the foreground service up (idempotent)
-      _startFlusher();
-      unawaited(upload());
+      _startFlusher(); // timer was running through background; this is a no-op if so
       return;
     }
     _setBusy(true);
@@ -505,7 +520,8 @@ class AppState extends ChangeNotifier {
       _log('Drained ${report.records} records in ${report.batches} batches '
           '(${report.complete ? "complete" : "idle-stopped"}).');
       dbCounts = await LocalDb.counts();
-      await upload();
+      // No explicit upload here — the flusher (kicked on start, then every 60s) is the
+      // single upload path; the freshly-drained backlog goes up on its next tick.
     } catch (e) {
       lastError = e.toString();
     } finally {
@@ -539,9 +555,9 @@ class AppState extends ChangeNotifier {
           // buffered to flash while we were out of range. A 30s cap silently cut a
           // long gap (e.g. a phone-free run) short and lost the rest.
           await engine.runSync();
-          await upload();
           await engine.enableLiveStreams();
           dbCounts = await LocalDb.counts();
+          // Upload handled by the flusher (single path) — runs within the next tick.
           _log('Reconnected — backlog drained.');
           break;
         }
@@ -561,9 +577,9 @@ class AppState extends ChangeNotifier {
     try {
       await engine.runSync();
       await engine.enableLiveStreams();
-      await upload();
       dbCounts = await LocalDb.counts();
       notifyListeners();
+      // Upload handled by the always-running flusher (single path), next tick ≤60s.
     } catch (e) {
       _log('Resync failed: $e');
     }


### PR DESCRIPTION
## What

Collapses the six `upload()` triggers in `AppState` (one 15s periodic flusher + five event-driven calls: foreground-reclaim, post-drain, reconnect, forceResync) into **one always-running flusher**. It kicks once on start, then uploads everything pending every **60s**.

## Why

All record sources — live `0x28`/`R10`/`0x33` and historical drain — already store locally to `raw_records` (hex PK, `INSERT OR IGNORE`, retain-until-200). The only thing that varied was *when we POST*. Six triggers meant six things to keep in sync. This makes the 60s flusher the **single** thing that POSTs, so upload behaviour is uniform everywhere — one path: if it breaks, it all breaks; if it works, it works everywhere.

## Cost impact

The 15s timer turned the steady-state ~1 Hz trickle into a POST every 15s (~**5,760/day**). At 60s that's ~**1,440/day** — **~4× fewer** R2 Class A puts + D1 row writes + Workers requests (R2 puts and D1 writes are 1:1 with POSTs). Roughly **\$1.15 → \$0.30 per user/mo at 1,000 users**. The `_kFlushInterval` constant can be raised further (e.g. 5 min → ~290/day, ~\$0.08/user) at no fidelity cost if more latency is acceptable.

## Safety / invariants preserved

- **Delete-by-hex on confirmed 200** (retain-until-200) is unchanged — the no-data-loss invariant. A non-200/429 leaves rows queued for the next tick.
- **Raw-first** `_flushDrain()` (local write before ACK) untouched.
- **iOS headless-recovery** (`runHeadlessSync`) keeps its direct `uploadPending()` — it runs in a separate background isolate where `AppState`/the timer don't exist, but uses the *same* primitive + same delete-by-hex semantics.

## Behaviour change (accepted)

Freshly-drained data now waits ≤60s for the next tick instead of uploading instantly. Invisible to cloud-derived metrics (HRV/recovery/etc. are computed at the wake-close, not on arrival).

## Edge cases covered

| Case | Behaviour |
|---|---|
| Network down / timeout / 429 | non-200 → rows retained → retried next tick |
| App killed mid-upload | only confirmed-200 hexes deleted; rest upload next session |
| Backlog after long disconnect | one tick drains it all in 300-record chunks |
| Live + drain overlap (same second) | hex PK dedupes locally; backend dedupes by (user,device,counter) |

## Testing

- `flutter analyze` clean.
- ✅ **Device-verified** (real band → v2 backend): kick-on-start (`Uploaded 159/159 records`), steady-state 60s tick with multi-chunk loop (`Uploaded 743/743 records` = 300+300+143), events path (`Uploaded 20 events`), and delete-by-hex/retain-until-200 (pending drains to 0, nothing stuck). Connect → drain → live → keep-alive lifecycle unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)