### PR TITLE
feat(workouts): detected-vs-selected + phases + type confirm/correct + classifier accuracy; daytime HRV / restlessness / desaturation

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -60,7 +60,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>
-		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -82,6 +82,14 @@ class BleEngine {
   bool _liveEnabled = false;
   Timer? _heartbeat;
 
+  // Wall-clock of the last BLE notification received on ANY characteristic. iOS can
+  // resume the app with the peripheral still flagged "connected" while its GATT
+  // notifications silently died during suspension (they don't auto-resume) — the UI
+  // reads connected but no events ever arrive. The foreground-reclaim path consults this
+  // to tell a genuinely live link (recent data) from a stale one (force a reconnect).
+  DateTime _lastRx = DateTime.fromMillisecondsSinceEpoch(0);
+  Duration get sinceLastRx => DateTime.now().difference(_lastRx);
+
   void _setConn(String c) {
     state.connection = c;
     onState(state);
@@ -227,6 +235,7 @@ class BleEngine {
       _send(Cmd.linkValid, const [0x00]);
     });
 
+    _lastRx = DateTime.now(); // fresh link — never treat as stale on an immediate resume
     _setConn('connected');
     _log('Connected + subscribed.');
     return true;
@@ -235,6 +244,7 @@ class BleEngine {
   Future<void> _subscribe(BluetoothCharacteristic c, String role) async {
     await c.setNotifyValue(true);
     _subs.add(c.onValueReceived.listen((chunk) {
+      _lastRx = DateTime.now(); // any notification = the link is genuinely delivering
       for (final frame in _asm[role]!.feed(chunk)) {
         if (frame.valid) _onFrame(role, frame);
       }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:provider/provider.dart';
 
 import 'app.dart';
@@ -12,6 +13,17 @@ import 'widget/widget_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // iOS CoreBluetooth State Preservation & Restoration: opt the flutter_blue_plus
+  // central (the one that actually subscribes to the band's HR/event characteristics)
+  // into a restore identifier. Apple preserves a connection AND its characteristic
+  // subscriptions ONLY for a central created with a restore id — without this, a
+  // suspended app resumes with the peripheral still flagged "connected" but its GATT
+  // notifications dead until a full reconnect+re-subscribe (the "connected, no events"
+  // bug). MUST be set before any other FBP call. No-op on Android.
+  try {
+    await FlutterBluePlus.setOptions(restoreState: true);
+  } catch (_) {/* older plugin / unsupported platform — ignore */}
 
   // Optional startup services. A failure in any one of these must NEVER block the
   // first frame — they are awaited before runApp, so an unguarded throw (e.g. the

--- a/lib/net/api_client.dart
+++ b/lib/net/api_client.dart
@@ -298,6 +298,19 @@ class ApiClient {
     return _decode(resp.body);
   }
 
+  /// POST /workout/:id/type {type} → confirm/correct an auto-detected workout's type.
+  /// Feeds the classifier calibration ledger. Returns {type, type_source}.
+  Future<Map<String, dynamic>> setWorkoutType(String id, String type) async {
+    final resp = await _authed((h) => _client.post(_u('/workout/$id/type'),
+        headers: h, body: jsonEncode({'type': type})));
+    if (resp.statusCode != 200) throw ApiException(resp.statusCode, resp.body);
+    return _decode(resp.body);
+  }
+
+  /// GET /day/hrv?date= → daytime (waking) HRV ultradian timeline.
+  Future<Map<String, dynamic>> getDayHrv(String date) =>
+      _getObj('/day/hrv', {'date': date});
+
   /// GET /trend/:metric?scale=week|month|quarter&anchor=YYYY-MM-DD
   /// → server-aggregated buckets (7 daily / weekly-mean / monthly-mean bars) with
   /// coverage + target + achieved, for the Metric Explorer. Drill = re-call with a

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -495,7 +495,16 @@ class AppState extends ChangeNotifier {
       await IosBleRestore.setOwnsBand(true);
       EdgeTracking.start(); // Android: keep the foreground service up (idempotent)
       _startFlusher(); // timer was running through background; this is a no-op if so
-      return;
+      // iOS can resume with the peripheral still flagged "connected" while its GATT
+      // notifications died during suspension — UI shows connected but NO events arrive,
+      // and only a kill+reopen (full reconnect) recovers. Trust DATA, not the flag: if a
+      // notification arrived recently the link is genuinely live → keep the fast reclaim.
+      // Otherwise it's stale → tear it down and fall through to a clean reconnect, which
+      // re-subscribes (the only place setNotifyValue runs) and drains the gap.
+      if (engine.sinceLastRx < const Duration(seconds: 30)) return;
+      _log('Resume: no BLE data for ${engine.sinceLastRx.inSeconds}s — stale link, reconnecting.');
+      await engine.disconnect();
+      // fall through to the full connect → subscribe → drain path below
     }
     _setBusy(true);
     lastError = null;

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -501,7 +501,20 @@ class AppState extends ChangeNotifier {
       // notification arrived recently the link is genuinely live → keep the fast reclaim.
       // Otherwise it's stale → tear it down and fall through to a clean reconnect, which
       // re-subscribes (the only place setNotifyValue runs) and drains the gap.
-      if (engine.sinceLastRx < const Duration(seconds: 30)) return;
+      if (engine.sinceLastRx < const Duration(seconds: 30)) {
+        // Healthy link → fast reclaim. But the fast path skips the band polls the full
+        // connect path runs, so the cached battery %/charging/strap-name/alarm go stale
+        // (charge only refreshed on a cold restart). Re-poll them in the background so the
+        // UI stays current without forcing a reconnect. Non-blocking; failures are benign.
+        unawaited(() async {
+          try {
+            await engine.getBattery();
+            await engine.getStrapName();
+            await engine.getAlarm();
+          } catch (_) {}
+        }());
+        return;
+      }
       _log('Resume: no BLE data for ${engine.sinceLastRx.inSeconds}s — stale link, reconnecting.');
       await engine.disconnect();
       // fall through to the full connect → subscribe → drain path below

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -94,6 +94,13 @@ class AppState extends ChangeNotifier {
   // reconnects; stopped only on session teardown (logout / signOut / unpair / endSession).
   Timer? _flushTimer;
   static const Duration _kFlushInterval = Duration(seconds: 60);
+  // Backfill fast-drain: while a large local backlog remains (e.g. the morning drain of a
+  // full night the band buffered while disconnected), re-upload after this short delay
+  // instead of waiting the full _kFlushInterval, so thousands of records clear in minutes
+  // rather than over many 60 s ticks. The delay lets a little more BLE backlog accumulate
+  // so each pass sends a full _kBackfillBatch. Self-limiting — it stops re-arming once
+  // pending drops below kBacklogThreshold, and the steady 60 s timer resumes as baseline.
+  static const Duration _kBackfillFlushDelay = Duration(seconds: 2);
 
   bool get backendChosen => config?.chosen ?? false;
   bool get isAuthenticated => session?.isValid ?? false;
@@ -610,17 +617,36 @@ class AppState extends ChangeNotifier {
     if (uploading) return;
     uploading = true;
     notifyListeners();
+    bool progressed = false;
     try {
-      await _uploadInner();
+      progressed = await _uploadInner();
     } finally {
       uploading = false;
       notifyListeners();
     }
+    // Backfill fast-drain: after a successful, progress-making pass that still leaves a
+    // large backlog (the band kept feeding flash records while we uploaded), re-drain
+    // promptly instead of waiting the full trickle interval. Gated on `progressed` so a
+    // 429 / network failure falls back to the steady 60 s timer's retry rather than
+    // spinning, and on `_flushTimer != null` so it only runs during an active session.
+    if (progressed &&
+        _flushTimer != null &&
+        (dbCounts['pending'] ?? 0) > kBacklogThreshold) {
+      Timer(_kBackfillFlushDelay, () {
+        if (_flushTimer != null && !uploading) unawaited(upload());
+      });
+    }
   }
 
-  Future<void> _uploadInner() async {
+  /// Returns true if a raw-record upload pass succeeded AND moved records (i.e. made
+  /// progress) — used to decide whether to keep fast-draining a backlog.
+  Future<bool> _uploadInner() async {
     final uploader = Uploader(api!);
-    final result = await uploader.uploadPending(onChunk: () async {
+    // Size the batch to the current backlog: big batches blast through a night's drain,
+    // small batches keep the steady trickle's payloads tiny (see uploader.dart).
+    final pending = (await LocalDb.counts())['pending'] ?? 0;
+    final result = await uploader.uploadPending(
+        batchSize: batchSizeForBacklog(pending), onChunk: () async {
       dbCounts = await LocalDb.counts();
       notifyListeners();
     });
@@ -641,6 +667,7 @@ class AppState extends ChangeNotifier {
     }
     dbCounts = await LocalDb.counts();
     notifyListeners();
+    return result.ok && result.attempted > 0;
   }
 
   void _setBusy(bool b) {

--- a/lib/sync/background_sync.dart
+++ b/lib/sync/background_sync.dart
@@ -36,7 +36,8 @@ Future<bool> runHeadlessSync() async {
 
     // 1. Flush any backlog first — covers the case where a prior run captured
     //    records but the upload leg failed (offline, etc.).
-    await uploader.uploadPending();
+    await uploader.uploadPending(
+        batchSize: batchSizeForBacklog((await LocalDb.counts())['pending'] ?? 0));
     await uploader.uploadEvents();
 
     // 2. Connect → drain → upload. No live streams (battery): in and out.
@@ -59,7 +60,10 @@ Future<bool> runHeadlessSync() async {
       // short, the drain persists what it got (flush-before-ACK) and the next wake
       // resumes from the cursor — so a longer budget only helps, never hurts.
       await engine.runSync();
-      await uploader.uploadPending();
+      // Post-drain: the band's offline flash backlog is now in local DB — a full night
+      // is thousands of records, so size up the batch (backfill mode).
+      await uploader.uploadPending(
+          batchSize: batchSizeForBacklog((await LocalDb.counts())['pending'] ?? 0));
       await uploader.uploadEvents();
     } finally {
       await engine.disconnect();

--- a/lib/sync/uploader.dart
+++ b/lib/sync/uploader.dart
@@ -6,6 +6,22 @@
 import '../data/db.dart';
 import '../net/api_client.dart';
 
+// ── Backfill-aware batch sizing ────────────────────────────────────────────────
+// The steady 1 Hz trickle and the morning drain of a full night the band buffered
+// while disconnected are two very different workloads. The backend rate limit counts
+// per POST (30 req / 60 s / user), NOT per record, and the day-packed minute store does
+// the same D1 work whatever the batch size — so a large backlog uploads in BIGGER
+// batches to lift the effective record ceiling ~5× (30×300 ≈ 9k/min → 30×1500 ≈ 45k/min)
+// while the trickle stays on small batches to keep payloads tiny. ~1.5k caps payload at
+// a few hundred KB (well under the 100 MB Worker body limit) with CPU headroom to spare.
+const int kTrickleBatch = 300;
+const int kBackfillBatch = 1500;
+const int kBacklogThreshold = 1000; // pending records above which we switch to backfill
+
+/// Pick an upload batch size from the current pending-record backlog.
+int batchSizeForBacklog(int pending) =>
+    pending > kBacklogThreshold ? kBackfillBatch : kTrickleBatch;
+
 class UploadResult {
   final int attempted;
   final int accepted;

--- a/lib/ui/screens/detail_cards.dart
+++ b/lib/ui/screens/detail_cards.dart
@@ -229,7 +229,7 @@ class HeartDayCard extends StatelessWidget {
             ]),
           ],
 
-          if (resp != null || spo2 != null) ...[
+          if (resp != null || spo2 != null || dmap['desaturation'] is Map) ...[
             const SizedBox(height: Sp.x6),
             SectionHeader('Respiratory'),
             MetricGroup([
@@ -239,6 +239,13 @@ class HeartDayCard extends StatelessWidget {
               if (spo2 != null)
                 MetricRow(icon: Ic.droplet, accent: AppColors.coralDeep, label: 'Blood-oxygen',
                     info: infoFor('spo2'), value: '${spo2['value']}', unit: 'Δ'),
+              // Overnight desaturation screen (RELATIVE, not diagnostic) — clustered dips
+              // in the red/IR ratio vs your baseline. An apnea-style screening signal only.
+              if (dmap['desaturation'] is Map)
+                MetricRow(icon: Ic.droplet, accent: AppColors.warn, label: 'Desaturation dips',
+                    info: 'Number of relative blood-oxygen dips overnight (per hour). A screen, not a diagnosis — talk to a clinician if it stays high.',
+                    value: '${(dmap['desaturation'] as Map)['events'] ?? 0}',
+                    unit: '· ${(dmap['desaturation'] as Map)['odi'] ?? 0}/h'),
             ]),
           ],
 

--- a/lib/ui/stress/stress_screen.dart
+++ b/lib/ui/stress/stress_screen.dart
@@ -28,6 +28,7 @@ class _StressScreenState extends State<StressScreen> {
   _Phase _phase = _Phase.loading;
   String? _error;
   Map<String, dynamic> _data = const {};
+  Map<String, dynamic> _hrv = const {}; // /day/hrv (daytime ultradian HRV)
 
   @override
   void initState() {
@@ -44,9 +45,13 @@ class _StressScreenState extends State<StressScreen> {
     setState(() { _phase = _Phase.loading; _error = null; });
     try {
       final res = await api.getDayStress(widget.date);
+      // Daytime HRV is best-effort — don't fail the whole screen if it's absent.
+      Map<String, dynamic> hrv = const {};
+      try { hrv = await api.getDayHrv(widget.date); } catch (_) {/* optional */}
       if (!mounted) return;
       setState(() {
         _data = res;
+        _hrv = hrv;
         final hasStress = _stress.isNotEmpty && _score != null;
         final hasSleep = _sleepStress.isNotEmpty && _sleepScore != null;
         _phase = (hasStress || hasSleep) ? _Phase.ready : _Phase.empty;
@@ -131,6 +136,7 @@ class _StressScreenState extends State<StressScreen> {
             else ...[
               if (_score != null) _hero(),
               ..._hrvSection(),
+              ..._daytimeHrvSection(),
               ..._timelineSection(),
               ..._sleepStressSection(),
               ..._driversSection(),
@@ -242,6 +248,10 @@ class _StressScreenState extends State<StressScreen> {
     if (ss.isEmpty || _sleepScore == null) return const [];
     final arousals = _num(ss['arousal_events'])?.toInt() ?? 0;
     final restless = _num(ss['restless_min'])?.toInt() ?? 0;
+    // Richer movement-restlessness (calcRestlessness), distinct from HR-surge arousal.
+    final rest = _map(ss['restlessness']);
+    final bouts = _num(rest['movement_bouts'])?.toInt();
+    final stillMin = _num(rest['longest_still_min'])?.toInt();
     return [
       const SizedBox(height: Sp.x6),
       const SectionHeader('Overnight arousal'),
@@ -253,6 +263,31 @@ class _StressScreenState extends State<StressScreen> {
           MetricRow(icon: Ic.activity, accent: AppColors.inkSoft, label: 'Disturbance',
               info: 'Count of possible arousals and total restless time.',
               value: '$arousals events · ${_hm(restless)}'),
+        if (bouts != null)
+          MetricRow(icon: Ic.activity, accent: AppColors.inkSoft, label: 'Restlessness',
+              info: 'How fragmented the night was — number of times you shifted, and your longest unbroken still stretch.',
+              value: stillMin != null ? '$bouts shifts · ${_hm(stillMin)} still' : '$bouts shifts'),
+      ])),
+    ];
+  }
+
+  // Daytime (waking) HRV — the ultradian RMSSD rhythm from /day/hrv. Complements the
+  // nocturnal recovery score: a sense of autonomic state across the day.
+  List<Widget> _daytimeHrvSection() {
+    final h = _map(_hrv['daytime_hrv']);
+    final med = _num(h['rmssd_median'])?.toInt();
+    final n = _num(h['n_windows'])?.toInt() ?? 0;
+    if (med == null || n < 3) return const [];
+    return [
+      const SizedBox(height: Sp.x6),
+      const SectionHeader('Daytime HRV'),
+      ProCard(child: Column(children: [
+        MetricRow(icon: Ic.pulse, accent: AppColors.good, label: 'Median daytime RMSSD',
+            info: 'Heart-rate variability across your waking hours (ultradian rhythm), excluding your main sleep. Higher generally means more recovered/parasympathetic.',
+            value: '$med', unit: 'ms'),
+        MetricRow(icon: Ic.activity, accent: AppColors.inkSoft, label: 'Coverage',
+            info: 'Number of 5-minute windows with enough beat-to-beat data to measure.',
+            value: '$n', unit: 'windows'),
       ])),
     ];
   }

--- a/lib/ui/workouts/workouts_screen.dart
+++ b/lib/ui/workouts/workouts_screen.dart
@@ -99,6 +99,39 @@ Future<void> startWorkoutFlow(BuildContext context) async {
   } catch (_) {/* surfaced as no-op; user can retry */}
 }
 
+/// Bottom-sheet type picker (no workout start) — used to confirm/correct an
+/// auto-detected workout's type. Returns the chosen type, or null if dismissed.
+Future<String?> pickWorkoutType(BuildContext context, {String title = 'Set workout type'}) {
+  return showModalBottomSheet<String>(
+    context: context,
+    backgroundColor: AppColors.surface,
+    shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(R.card))),
+    builder: (_) => Padding(
+      padding: const EdgeInsets.all(Sp.x5),
+      child: Column(mainAxisSize: MainAxisSize.min, crossAxisAlignment: CrossAxisAlignment.start, children: [
+        Text(title, style: AppText.h2),
+        const SizedBox(height: Sp.x4),
+        Wrap(spacing: Sp.x3, runSpacing: Sp.x3, children: [
+          for (final e in _exercises)
+            GestureDetector(
+              onTap: () => Navigator.pop(context, e.$1),
+              child: Container(
+                width: 96, padding: const EdgeInsets.symmetric(vertical: Sp.x4),
+                decoration: BoxDecoration(color: AppColors.surfaceAlt, borderRadius: BorderRadius.circular(R.card)),
+                child: Column(children: [
+                  AppIcon(e.$3, size: 26, color: AppColors.coral),
+                  const SizedBox(height: Sp.x2),
+                  Text(e.$2, style: AppText.label),
+                ]),
+              ),
+            ),
+        ]),
+        const SizedBox(height: Sp.x4),
+      ]),
+    ),
+  );
+}
+
 class WorkoutsScreen extends StatefulWidget {
   const WorkoutsScreen({super.key});
   @override
@@ -192,8 +225,20 @@ class _WorkoutsScreenState extends State<WorkoutsScreen> {
   }
 
   // Swipe-to-delete wrapper. Live sessions aren't deletable (finish them first).
+  // Confirm/correct an auto-detected workout's type → feeds the classifier calibration
+  // ledger, and pins the type so re-derivation won't overwrite it.
+  Future<void> _correctType(Map<String, dynamic> w) async {
+    final id = w['id'] as String?;
+    if (id == null) return;
+    final t = await pickWorkoutType(context, title: 'Correct workout type');
+    if (t == null || !mounted) return;
+    final api = context.read<AppState>().api;
+    if (api == null) return;
+    try { await api.setWorkoutType(id, t); _load(); } catch (_) {/* retryable */}
+  }
+
   Widget _row(Map<String, dynamic> w) {
-    final tile = _WorkoutTile(w);
+    final tile = _WorkoutTile(w, onCorrect: () => _correctType(w));
     if (w['status'] == 'live') return tile;
     return Dismissible(
       key: ValueKey(w['id']),
@@ -306,6 +351,23 @@ class _SummaryHero extends StatelessWidget {
           _miniStat('$kcal', 'kcal'),
           _miniStat(avgStrain == null ? '—' : avgStrain.toStringAsFixed(1), 'avg strain'),
         ]),
+        // Classifier calibration: how often the auto-detected type matched what you
+        // confirmed/corrected. Shown once you've reviewed at least one — tells us (and
+        // you) when the activity model needs retraining.
+        ...(() {
+          final cls = (summary['classifier'] as Map?)?.cast<String, dynamic>();
+          final acc = (cls?['accuracy'] as num?)?.toDouble();
+          final reviewed = (cls?['reviewed'] as num?)?.toInt() ?? 0;
+          if (acc == null || reviewed <= 0) return const <Widget>[];
+          return [
+            const SizedBox(height: Sp.x5),
+            Row(children: [
+              AppIcon(Icons.verified_outlined, size: 15, color: AppColors.inkMuted),
+              const SizedBox(width: Sp.x2),
+              Text('Type accuracy ${(acc * 100).round()}% · $reviewed reviewed', style: AppText.caption),
+            ]),
+          ];
+        })(),
         if (zoneMin.length == 5 && zoneMin.any((v) => v > 0)) ...[
           const SizedBox(height: Sp.x5),
           Text('TIME IN ZONES', style: AppText.overline),
@@ -333,10 +395,13 @@ class _SummaryHero extends StatelessWidget {
 
 class _WorkoutTile extends StatelessWidget {
   final Map<String, dynamic> w;
-  const _WorkoutTile(this.w);
+  final VoidCallback? onCorrect;
+  const _WorkoutTile(this.w, {this.onCorrect});
   @override
   Widget build(BuildContext context) {
     final live = w['status'] == 'live';
+    final detected = w['detected'] == true; // auto / auto_live
+    final phases = (w['segments'] as List?)?.length ?? 0;
     final strain = (w['strain'] as num?);
     // No worn HR minutes in the window → avg_hr comes back 0 and strain 0. That's
     // not a zero-effort workout, it's missing data (band wasn't syncing). Show it
@@ -355,13 +420,24 @@ class _WorkoutTile extends StatelessWidget {
           Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
             Row(children: [
               Text(_typeLabel(w['type'] as String?), style: AppText.label),
-              if (w['source'] == 'auto') ...[const SizedBox(width: Sp.x2), Tag('AUTO', color: AppColors.inkMuted)],
-              if (live) ...[const SizedBox(width: Sp.x2), Tag('LIVE', color: AppColors.coral)],
+              if (live) ...[const SizedBox(width: Sp.x2), Tag('LIVE', color: AppColors.coral)]
+              else if (detected) ...[const SizedBox(width: Sp.x2), Tag('DETECTED', color: AppColors.inkMuted)]
+              else ...[const SizedBox(width: Sp.x2), Tag('LOGGED', color: AppColors.inkMuted)],
+              if (phases > 1) ...[const SizedBox(width: Sp.x2), Text('· $phases phases', style: AppText.captionMuted)],
             ]),
             const SizedBox(height: 2),
             Text('${_whenLabel(w['start_ts'] as int?)} · ${hm(w['duration_min'] as num?)} · ${noData ? 'no HR' : '${w['avg_hr'] ?? '—'} bpm'}',
                 style: AppText.captionMuted),
           ])),
+          // Correct an auto-detected type (calibration). Manual workouts keep their type.
+          if (!live && detected && onCorrect != null) ...[
+            GestureDetector(
+              onTap: onCorrect,
+              behavior: HitTestBehavior.opaque,
+              child: Padding(padding: const EdgeInsets.all(6),
+                  child: AppIcon(Icons.edit_outlined, size: 16, color: AppColors.inkMuted)),
+            ),
+          ],
           if (!live) ...[
             noData
                 ? Text('No data', style: AppText.captionMuted)


### PR DESCRIPTION
UI for the backend workout HAR engine + new honest metrics.

## Workouts screen
- **Detected vs Selected**: auto-detected workouts tagged `DETECTED`, manual `LOGGED`, plus `LIVE`.
- **Phase breakdown**: multi-activity workouts show their phase count (run→cycle etc.).
- **Confirm / correct type**: pencil on a detected workout → type picker → `POST /workout/:id/type` (feeds the classifier calibration ledger and pins the type so re-derivation won't overwrite it).
- **Classifier accuracy** chip in the training hero (how often the model was right, once you've reviewed any) — so we know when the activity model needs retraining.

## New metric surfacing
- **Stress screen**: richer restlessness (shifts + longest-still stretch) + a **Daytime HRV** section (`/day/hrv` — waking ultradian RMSSD).
- **Lungs view** (`detail_cards`): overnight **desaturation dips** (ODI, clearly labelled screening-only, not diagnostic).

## API client
- `setWorkoutType(id, type)`, `getDayHrv(date)`.

`dart analyze` on touched files: no new issues (only pre-existing `use_null_aware_elements` style infos).
