### PR TITLE
Feat/health export

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -42,7 +42,7 @@ android {
         applicationId = "wtf.openstrap.openstrap_edge"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        minSdk = maxOf(26, flutter.minSdkVersion) // Health Connect requires API 26+
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -41,6 +41,10 @@
     <uses-permission android:name="android.permission.health.WRITE_RESPIRATORY_RATE" />
     <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED" />
     <uses-permission android:name="android.permission.health.WRITE_ACTIVE_CALORIES_BURNED" />
+    <uses-permission android:name="android.permission.health.READ_BASAL_METABOLIC_RATE" />
+    <uses-permission android:name="android.permission.health.WRITE_BASAL_METABOLIC_RATE" />
+    <uses-permission android:name="android.permission.health.READ_STEPS" />
+    <uses-permission android:name="android.permission.health.WRITE_STEPS" />
     <uses-permission android:name="android.permission.health.READ_SLEEP" />
     <uses-permission android:name="android.permission.health.WRITE_SLEEP" />
     <uses-permission android:name="android.permission.health.READ_EXERCISE" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,6 +27,24 @@
          Play-distributed), so broad visibility is acceptable here. -->
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
+    <!-- ── Health Connect (export to Google Health Connect) ──
+         The `health` plugin treats a WRITE request as READ+WRITE (hasPermissions
+         checks both), so the READ_* permissions MUST be declared too even though
+         we only write. -->
+    <uses-permission android:name="android.permission.health.READ_HEART_RATE" />
+    <uses-permission android:name="android.permission.health.WRITE_HEART_RATE" />
+    <uses-permission android:name="android.permission.health.READ_RESTING_HEART_RATE" />
+    <uses-permission android:name="android.permission.health.WRITE_RESTING_HEART_RATE" />
+    <uses-permission android:name="android.permission.health.READ_HEART_RATE_VARIABILITY" />
+    <uses-permission android:name="android.permission.health.WRITE_HEART_RATE_VARIABILITY" />
+    <uses-permission android:name="android.permission.health.READ_RESPIRATORY_RATE" />
+    <uses-permission android:name="android.permission.health.WRITE_RESPIRATORY_RATE" />
+    <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED" />
+    <uses-permission android:name="android.permission.health.WRITE_ACTIVE_CALORIES_BURNED" />
+    <uses-permission android:name="android.permission.health.READ_SLEEP" />
+    <uses-permission android:name="android.permission.health.WRITE_SLEEP" />
+    <uses-permission android:name="android.permission.health.READ_EXERCISE" />
+    <uses-permission android:name="android.permission.health.WRITE_EXERCISE" />
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
 
     <application
@@ -54,7 +72,24 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Health Connect: permission-rationale entry point (required). -->
+            <intent-filter>
+                <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
+            </intent-filter>
         </activity>
+
+        <!-- Health Connect rationale for Android 14+ (VIEW_PERMISSION_USAGE). -->
+        <activity-alias
+            android:name="ViewPermissionUsageActivity"
+            android:exported="true"
+            android:targetActivity=".MainActivity"
+            android:permission="android.permission.START_VIEW_PERMISSION_USAGE">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW_PERMISSION_USAGE" />
+                <category android:name="android.intent.category.HEALTH_PERMISSIONS" />
+            </intent-filter>
+        </activity-alias>
+
         <!-- Edge Tracking foreground service (background BLE drain). -->
         <service
             android:name=".EdgeTrackingService"
@@ -123,5 +158,7 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- Health Connect app discovery (for install/status checks). -->
+        <package android:name="com.google.android.apps.healthdata" />
     </queries>
 </manifest>

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/MainActivity.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/MainActivity.kt
@@ -1,6 +1,6 @@
 package wtf.openstrap.openstrap_edge
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
 /**
  * Attaches to the long-lived engine pre-warmed in [EdgeApplication] rather than spinning
@@ -11,8 +11,12 @@ import io.flutter.embedding.android.FlutterActivity
  *
  * Platform channels are registered on the engine in EdgeApplication (NativeChannels), not
  * here, so they exist even while no Activity is attached (headless channel calls work).
+ *
+ * FlutterFragmentActivity (not FlutterActivity) is required by the `health` plugin — its
+ * Health Connect permission flow uses the AndroidX activity-result APIs, which need a
+ * FragmentActivity host. The cached-engine overrides work the same on either base.
  */
-class MainActivity : FlutterActivity() {
+class MainActivity : FlutterFragmentActivity() {
     override fun getCachedEngineId(): String = EdgeApplication.ENGINE_ID
     override fun shouldDestroyEngineWithHost(): Boolean = false
 }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,6 @@
 PODS:
+  - device_info_plus (0.0.1):
+    - Flutter
   - DKImagePickerController/Core (4.3.9):
     - DKImagePickerController/ImageDataManager
     - DKImagePickerController/Resource
@@ -42,6 +44,8 @@ PODS:
   - flutter_secure_storage_darwin (10.0.0):
     - Flutter
     - FlutterMacOS
+  - health (1.0.4):
+    - Flutter
   - home_widget (0.0.1):
     - Flutter
   - package_info_plus (0.4.5):
@@ -64,11 +68,13 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
   - flutter_blue_plus_darwin (from `.symlinks/plugins/flutter_blue_plus_darwin/darwin`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
+  - health (from `.symlinks/plugins/health/ios`)
   - home_widget (from `.symlinks/plugins/home_widget/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
@@ -85,6 +91,8 @@ SPEC REPOS:
     - SwiftyGif
 
 EXTERNAL SOURCES:
+  device_info_plus:
+    :path: ".symlinks/plugins/device_info_plus/ios"
   file_picker:
     :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
@@ -95,6 +103,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_local_notifications/ios"
   flutter_secure_storage_darwin:
     :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
+  health:
+    :path: ".symlinks/plugins/health/ios"
   home_widget:
     :path: ".symlinks/plugins/home_widget/ios"
   package_info_plus:
@@ -111,6 +121,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/workmanager_apple/ios"
 
 SPEC CHECKSUMS:
+  device_info_plus: 71ffc6ab7634ade6267c7a93088ed7e4f74e5896
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
   file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
@@ -118,6 +129,7 @@ SPEC CHECKSUMS:
   flutter_blue_plus_darwin: 20a08bfeaa0f7804d524858d3d8744bcc1b6dbc3
   flutter_local_notifications: 395056b3175ba4f08480a7c5de30cd36d69827e4
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
+  health: a4ddeac72091000e94776864d0028f6be31ec7a5
   home_widget: f169fc41fd807b4d46ab6615dc44d62adbf9f64f
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -36,6 +36,10 @@
 	</array>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>OpenStrap connects to your WHOOP band over Bluetooth to sync your health data.</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>OpenStrap reads recent samples to avoid writing duplicates into Apple Health.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>OpenStrap writes your sleep, resting heart rate, HRV, respiratory rate, energy and workouts into Apple Health.</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>OpenStrap connects to your WHOOP band over Bluetooth to sync your health data.</string>
 	<key>NSSupportsLiveActivities</key>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -6,5 +6,9 @@
 	<array>
 		<string>$(APP_GROUP_IDENTIFIER)</string>
 	</array>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+	<key>com.apple.developer.healthkit.access</key>
+	<array/>
 </dict>
 </plist>

--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -102,7 +102,13 @@ import 'substrate.dart';
 /// Cole–Kripke/DoG stager's main-session AASM metrics + hypnogram (parallel
 /// ESTIMATE; the single-source `sleep` block stays the headline). Bumping
 /// re-derives non-finalized recent days so the new blocks populate.
-const int kAlgoVersion = 16;
+/// v17: STEPS (24/7 ESTIMATE = ambulatory-minutes × cadence, personalized by the
+/// live 100 Hz pedometer's cadence calibration) + TOTAL DAILY ENERGY (TDEE via
+/// HR-flex: Mifflin BMR floor + active Keytel surplus). New scalars `steps` +
+/// `calories_total` → metric_series; `steps`/`calories_total` bundle blocks. 1 Hz
+/// still can't COUNT steps (Nyquist) — real counts come from live streaming, which
+/// also tunes this estimate. Bumping re-derives non-finalized days so they fill.
+const int kAlgoVersion = 17;
 
 /// Raw is kept this many days past derivation, then pruned (derived stays).
 const int rawRetentionDays = 14;
@@ -188,11 +194,15 @@ class DerivationEngine {
       _log('derive: ${todo.length}/${days.length} day(s) '
           '(${force ? "force" : heavy ? "heavy" : "light"}; v$kAlgoVersion)');
 
+      // Personal cadence model (live 100 Hz pedometer) → tunes the 1 Hz daily
+      // step ESTIMATE. Read once per pass and threaded into every day.
+      final stepCalib = await LocalDb.getStepCalibration();
+
       var done = 0;
       for (var i = 0; i < todo.length; i++) {
         final day = todo[i];
         try {
-          await _deriveDay(sub, day, profile, dataNowSec);
+          await _deriveDay(sub, day, profile, dataNowSec, stepCalib: stepCalib);
           done++;
         } catch (e) {
           _log('derive day ${day.date} FAILED/skipped: $e');
@@ -273,6 +283,8 @@ class DerivationEngine {
       _log('rescan: baseline changed — re-deriving ${todo.length}/${days.length} '
           'recent day(s) (incl. finalized; v$kAlgoVersion)');
 
+      final stepCalib = await LocalDb.getStepCalibration();
+
       var done = 0;
       for (var i = 0; i < todo.length; i++) {
         final day = todo[i];
@@ -282,7 +294,7 @@ class DerivationEngine {
           // recomputed `finalized` flag stays true for a day already past its
           // 48 h horizon, so the day remains locked w.r.t. run() — only its
           // baseline-relative scalars change.
-          await _deriveDay(sub, day, profile, dataNowSec);
+          await _deriveDay(sub, day, profile, dataNowSec, stepCalib: stepCalib);
           done++;
         } catch (e) {
           _log('rescan day ${day.date} FAILED/skipped: $e');
@@ -361,11 +373,13 @@ class DerivationEngine {
     if (sub.isEmpty || dates.isEmpty) return 0;
     final days = calendarDays(sub);
     final dataNowSec = sub.lastTs ?? 0;
+    final stepCalib = await LocalDb.getStepCalibration();
     var done = 0;
     for (final day in days) {
       if (!dates.contains(day.date)) continue;
       try {
-        await _deriveDay(sub, day, profile, dataNowSec, forceFinalize: true);
+        await _deriveDay(sub, day, profile, dataNowSec,
+            forceFinalize: true, stepCalib: stepCalib);
         done++;
         onDayDone?.call(day.date);
       } catch (e) {
@@ -386,7 +400,7 @@ class DerivationEngine {
 
   Future<void> _deriveDay(
       Substrate sub, PhysioDay day, Profile profile, int dataNowSec,
-      {bool forceFinalize = false}) async {
+      {bool forceFinalize = false, ana.StepCalibration? stepCalib}) async {
     // Slice the substrate to the day container and to the SLEEP window.
     final daySub = sub.slice(day.startSec, day.endSec);
     final sleepSub = day.hasSleep
@@ -463,6 +477,15 @@ class DerivationEngine {
           'true step counts come from live workout streaming',
     };
 
+    // ── STEPS (24/7 ESTIMATE) + TOTAL DAILY ENERGY (TDEE) ─────────────────────
+    // 1 Hz cannot COUNT steps (Nyquist) — but it can detect ambulatory MINUTES
+    // and multiply by a cadence (steps/min) for an honest 24/7 ESTIMATE. The
+    // live 100 Hz pedometer (app_state) counts real steps AND personalizes the
+    // cadence this estimate uses (stepCalib). TDEE = HR-flex (BMR floor + active
+    // Keytel surplus). Both need accel/HR from daySub + the profile, so they run
+    // here on the main isolate (like activeMin), not in the pure bundle pipeline.
+    _stepsAndEnergy(bundle, scMap, daySub, profile, stepCalib);
+
     // ── More substrate-derived detail blocks (computed here, where the full
     //    sliced substrate lives — same pattern as activeMin; these are fresh
     //    <String,dynamic> blocks so ints are safe, unlike the double? scalars). ─
@@ -535,6 +558,9 @@ class DerivationEngine {
         'spo2': sc('spo2'),
         'active_min': sc('active_min'),
         'calories': sc('calories'),
+        // 24/7 step ESTIMATE (ambulatory-min × cadence) + total daily energy.
+        'steps': sc('steps'),
+        'calories_total': sc('calories_total'),
         // Sleep-stage minutes + HRV freq/stability trends.
         'rem_min': sc('rem_min'),
         'deep_min': sc('deep_min'),
@@ -803,6 +829,101 @@ class DerivationEngine {
       if (tot > 0 && (moveSec[m] ?? 0) / tot >= activeFrac) active++;
     });
     return active;
+  }
+
+  /// 24/7 step ESTIMATE (Tier B) + total daily energy (TDEE), written into the
+  /// bundle's `steps` block + `scalars` (steps, calories_total). 1 Hz can't COUNT
+  /// steps (Nyquist) — this is ambulatory-minutes × cadence, personalized by the
+  /// live pedometer's [stepCalib]. TDEE is the HR-flex method (Mifflin BMR floor +
+  /// active Keytel surplus). Best-effort; leaves scalars null on missing data.
+  void _stepsAndEnergy(
+    Map<String, dynamic> bundle,
+    Map<String, dynamic>? scMap,
+    Substrate daySub,
+    Profile profile,
+    ana.StepCalibration? stepCalib,
+  ) {
+    try {
+      if (daySub.length < 60) return;
+      // Per-minute ENMO over the whole day (van Hees), and per-minute mean HR
+      // aligned 1:1 to those minutes (for the walking HR-gate).
+      final motion = ana.enmoSeries(daySub.accelSamples()).minutes;
+      if (motion.isEmpty) return;
+      final hrByMin = <int, List<double>>{};
+      final allHrByMin = <int, List<double>>{};
+      for (var i = 0; i < daySub.length; i++) {
+        final h = daySub.hr[i];
+        if (h <= 0) continue;
+        final mi = daySub.tsSec[i] ~/ 60;
+        (hrByMin[mi] ??= <double>[]).add(h.toDouble());
+        (allHrByMin[mi] ??= <double>[]).add(h.toDouble());
+      }
+      double meanOf(List<double> l) => l.reduce((a, b) => a + b) / l.length;
+      final hrPerMin = <double>[
+        for (final mm in motion)
+          () {
+            final l = hrByMin[(mm.tsMinStartMs / 60000).round()];
+            return (l == null || l.isEmpty) ? 0.0 : meanOf(l);
+          }()
+      ];
+
+      final rhr = (scMap?['rhr'] as num?)?.toDouble();
+      final est = ana.dailyStepEstimate(
+        motion,
+        hrPerMin: hrPerMin,
+        restingHr: rhr,
+        calib: stepCalib,
+      );
+      if (est.present) {
+        final v = est.value!;
+        scMap?['steps'] = v.steps.toDouble();
+        bundle['steps'] = <String, dynamic>{
+          'value': v.steps,
+          'estimated': true,
+          'ambulatory_min': v.ambulatoryMinutes,
+          'cadence_used_spm': v.cadenceUsed,
+          'calibrated': v.calibrated,
+          'confidence': est.confidence,
+          'tier': est.tier,
+          'inputs_used': est.inputs_used,
+          'note': est.note,
+        };
+      }
+
+      // Total daily energy (TDEE) — HR-flex over the day's per-minute HR.
+      if (profile.isComplete) {
+        final perMinFull = <double>[
+          for (final mi in (allHrByMin.keys.toList()..sort()))
+            meanOf(allHrByMin[mi]!)
+        ];
+        final sexStr = profile.sex == 'm'
+            ? 'male'
+            : (profile.sex == 'f' ? 'female' : 'nonbinary');
+        final e = ana.Calories.dailyEnergy(
+          perMinFull,
+          profile: ana.WorkoutUserProfile(
+            weightKg: profile.weightKg!,
+            heightCm: profile.heightCm!,
+            age: profile.ageYears!.toDouble(),
+            sex: sexStr,
+          ),
+          hrmax: profile.hrMaxTanaka,
+        );
+        scMap?['calories_total'] = e.total.roundToDouble();
+        bundle['calories_total'] = <String, dynamic>{
+          'value': e.total.round(),
+          'active': e.active.round(),
+          'basal': e.basal.round(),
+          'confidence': 0.5,
+          'tier': 'ESTIMATE',
+          'inputs_used': const ['hr_1hz', 'profile'],
+          'note': 'total daily energy: Mifflin BMR floor + active Keytel surplus '
+              '(HR-flex)',
+        };
+      }
+    } catch (e) {
+      _log('steps/energy skipped: $e');
+    }
   }
 
   /// Auto-detected workouts for the day via [ana.WorkoutDetector] over the

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -10,6 +10,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:openstrap_analytics/onehz.dart' as ana;
 import 'package:openstrap_protocol/openstrap_protocol.dart' as proto;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -127,8 +128,13 @@ class LocalDb {
           // it to tell a stalled cursor from a healthy one. Additive.
           await _createSyncCursor(db);
         }
+        if (oldV < 11) {
+          // Live workout steps (Tier-A pedometer over the session's 100 Hz
+          // R10 accel). Additive nullable column — old rows read null.
+          await db.execute('ALTER TABLE sessions ADD COLUMN steps INTEGER');
+        }
       },
-      version: 10,
+      version: 11,
     );
   }
 
@@ -350,6 +356,7 @@ class LocalDb {
         max_hr INTEGER,
         duration_min INTEGER,
         zone_min_json TEXT,
+        steps INTEGER,
         source TEXT NOT NULL DEFAULT 'manual',
         created_at INTEGER NOT NULL
       )
@@ -967,6 +974,30 @@ class LocalDb {
       conflictAlgorithm: ConflictAlgorithm.replace,
     );
   }
+
+  // ── step-cadence calibration (baselines key `step_cadence`) ─────────────────
+  // The personal cadence model the live 100 Hz pedometer learns and the 1 Hz
+  // daily step ESTIMATE consumes (see analytics steps.dart). Stored as the
+  // StepCalibration JSON so live walking steadily tunes the 24/7 estimate.
+
+  /// The persisted personal cadence model, or null if never calibrated.
+  static Future<ana.StepCalibration?> getStepCalibration() async {
+    final row = await baseline('step_cadence');
+    final json = row?['payload_json'];
+    if (json is! String) return null;
+    try {
+      final m = jsonDecode(json);
+      return m is Map
+          ? ana.StepCalibration.fromJson(m.cast<String, dynamic>())
+          : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Persist the personal cadence model (overwrites — it's a running estimate).
+  static Future<void> putStepCalibration(ana.StepCalibration c) =>
+      putBaseline('step_cadence', jsonEncode(c.toJson()));
 
   // ── journal I/O ─────────────────────────────────────────────────────────────
 

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -199,11 +199,15 @@ class LocalRepositoryImpl extends LocalRepository {
       // Headline 0–21 strain (the strain gauge already expects a 0–21 scale).
       'strain': _scalarMetric(_scalar(b, 'strain'), 'ESTIMATE'),
       'wear_min': _scalarMetric(_wearMin(b), 'HIGH', unit: 'min'),
-      // Active calories (Keytel HR→kcal over the wake span).
+      // Active calories (Keytel HR→kcal over the wake span) + total daily energy
+      // (TDEE: Mifflin BMR floor + active surplus).
       'calories': _scalarMetric(_scalar(b, 'calories')?.round(), 'ESTIMATE', unit: 'kcal'),
-      // Activity minutes shown on the steps tile (labeled "active min"); real
-      // steps stay live-only. `active_min` carried separately for the trend.
-      'steps': _scalarMetric(activeMin, 'ESTIMATE', unit: 'active min'),
+      'calories_total':
+          _scalarMetric(_scalar(b, 'calories_total')?.round(), 'ESTIMATE', unit: 'kcal'),
+      // STEPS — 24/7 ESTIMATE (ambulatory-minutes × cadence; 1 Hz can't COUNT
+      // steps, the live pedometer personalizes the cadence). `active_min` is the
+      // separate raw movement-minutes metric.
+      'steps': _scalarMetric(_scalar(b, 'steps')?.round(), 'ESTIMATE', unit: 'steps'),
       'active_min': _scalarMetric(activeMin, 'ESTIMATE', unit: 'min'),
     };
 
@@ -587,7 +591,9 @@ class LocalRepositoryImpl extends LocalRepository {
       },
       'curve': [for (final p in curve) {'v': (p as Map)['v']}],
       'calories': _scalar(b, 'calories')?.round(),
-      'steps': null, // 1 Hz can't count steps; activity-minutes lives on Today
+      // Total daily energy (TDEE) + 24/7 step ESTIMATE (live pedometer tunes it).
+      'calories_total': _scalar(b, 'calories_total')?.round(),
+      'steps': _scalar(b, 'steps')?.round(),
       'hr': {
         'max': (hrStats?['max'] as num?)?.toInt(),
         'avg': (hrStats?['avg'] as num?)?.toInt(),
@@ -933,8 +939,10 @@ class LocalRepositoryImpl extends LocalRepository {
         return ('min', 'active');
       case 'calories':
         return ('kcal', 'calories');
+      case 'calories_total':
+        return ('kcal', 'total calories');
       case 'steps':
-        return ('min', 'active');
+        return ('steps', 'steps');
       case 'resp_rate':
         return ('rpm', 'respiratory rate');
       case 'light':
@@ -976,8 +984,8 @@ class LocalRepositoryImpl extends LocalRepository {
         return 'worn_min';
       case 'efficiency': // sleep-efficiency % trend
         return 'efficiency';
-      case 'steps': // 1 Hz has no steps; the tile/trend uses activity minutes
-        return 'active_min';
+      case 'steps': // 24/7 step ESTIMATE series (ambulatory-min × cadence)
+        return 'steps';
       case 'light':
         return 'light_min';
       case 'deep':
@@ -1048,6 +1056,7 @@ class LocalRepositoryImpl extends LocalRepository {
       'strain': (r['strain'] as num?)?.toDouble(),
       'calories': (r['calories'] as num?)?.round(),
       'duration_min': (r['duration_min'] as num?)?.toInt(),
+      'steps': (r['steps'] as num?)?.toInt(),
       'zone_min': zoneMin,
     };
   }

--- a/lib/health/health_export.dart
+++ b/lib/health/health_export.dart
@@ -39,7 +39,6 @@ enum HealthLinkState {
 class HealthExporter {
   final _health = Health();
   bool _configured = false;
-  final Set<HealthDataType> _granted = {};
 
   /// True on iOS/macOS (Apple Health); false on Android (Health Connect).
   static bool get isApple => Platform.isIOS || Platform.isMacOS;
@@ -61,6 +60,8 @@ class HealthExporter {
         _hrvType,
         HealthDataType.RESPIRATORY_RATE,
         HealthDataType.ACTIVE_ENERGY_BURNED,
+        HealthDataType.BASAL_ENERGY_BURNED,
+        HealthDataType.STEPS,
         HealthDataType.SLEEP_DEEP,
         HealthDataType.SLEEP_REM,
         HealthDataType.SLEEP_LIGHT,
@@ -69,13 +70,12 @@ class HealthExporter {
         HealthDataType.WORKOUT,
       ];
 
-  bool get ready =>
-      _granted.contains(HealthDataType.RESTING_HEART_RATE) ||
-      _granted.contains(HealthDataType.SLEEP_SESSION) ||
-      _granted.contains(HealthDataType.SLEEP_DEEP);
-
-  String get grantedSummary =>
-      _granted.isEmpty ? 'none' : _granted.map((t) => t.name).join(', ');
+  // We do NOT gate on a write-permission check: HealthKit hides write-auth by
+  // design, and Health Connect's hasPermissions(WRITE) frequently returns
+  // null/false even after the user grants everything — which would leave the UI
+  // stuck on "Grant access" forever. Instead we ATTEMPT every write and let the
+  // platform enforce (ungranted writes silently no-op). The only hard gate is
+  // store AVAILABILITY (Health Connect installed/updated on Android).
 
   Future<void> _ensureConfigured() async {
     if (_configured) return;
@@ -85,22 +85,6 @@ class HealthExporter {
     } catch (e) {
       debugPrint('[health] configure: $e');
     }
-  }
-
-  Future<void> _refreshGranted() async {
-    _granted.clear();
-    for (final t in _types) {
-      try {
-        if (await _health
-                .hasPermissions([t], permissions: [HealthDataAccess.WRITE]) ==
-            true) {
-          _granted.add(t);
-        }
-      } catch (e) {
-        debugPrint('[health] hasPermissions(${t.name}): $e');
-      }
-    }
-    debugPrint('[health] granted: $grantedSummary (ready=$ready)');
   }
 
   Future<HealthLinkState?> _androidUnavailable() async {
@@ -119,42 +103,33 @@ class HealthExporter {
     return null;
   }
 
-  /// CHECK existing permissions WITHOUT prompting. Startup-safe, never throws.
+  /// Store availability (no permission prompt). `ready` = installed/updated &
+  /// writable-in-principle; we can't reliably know the per-type grant, so the
+  /// app attempts writes regardless. Never throws.
   Future<HealthLinkState> check() async {
     await _ensureConfigured();
     try {
-      final un = await _androidUnavailable();
-      if (un != null) return un;
-      await _refreshGranted();
-      return ready ? HealthLinkState.ready : HealthLinkState.needsPermission;
+      return await _androidUnavailable() ?? HealthLinkState.ready;
     } catch (e) {
       debugPrint('[health] check: $e');
       return HealthLinkState.unsupported;
     }
   }
 
-  /// REQUEST write permission (system dialog). Call ONLY from a user gesture.
+  /// Open the system grant flow (HealthKit sheet / Health Connect permission UI).
+  /// Call from a user gesture. Returns availability; we never block on the
+  /// (unreliable) post-grant permission read.
   Future<HealthLinkState> request() async {
     await _ensureConfigured();
+    final un = await _androidUnavailable();
+    if (un != null) return un;
     try {
-      final un = await _androidUnavailable();
-      if (un != null) return un;
-      await _refreshGranted();
-      final missing = _types.where((t) => !_granted.contains(t)).toList();
-      if (missing.isNotEmpty) {
-        try {
-          await _health.requestAuthorization(missing,
-              permissions: missing.map((_) => HealthDataAccess.WRITE).toList());
-        } catch (e) {
-          debugPrint('[health] requestAuthorization: $e');
-        }
-        await _refreshGranted();
-      }
-      return ready ? HealthLinkState.ready : HealthLinkState.needsPermission;
+      await _health.requestAuthorization(_types,
+          permissions: _types.map((_) => HealthDataAccess.WRITE).toList());
     } catch (e) {
-      debugPrint('[health] request: $e');
-      return HealthLinkState.unsupported;
+      debugPrint('[health] requestAuthorization: $e');
     }
+    return HealthLinkState.ready;
   }
 
   /// Send the user to the Play Store to install Health Connect (Android only).
@@ -195,10 +170,8 @@ class HealthExporter {
   /// re-written on each call. [reset] re-exports the whole retained window.
   /// Returns the number of days written. Never throws.
   Future<int> exportAll({bool reset = false, void Function(int days)? onProgress}) async {
-    if (!ready) {
-      await check();
-      if (!ready) return 0;
-    }
+    await _ensureConfigured();
+    if (await _androidUnavailable() != null) return 0; // HC missing/outdated
     try {
       if (reset) await LocalDb.setCursor('health_export_through', '');
       final cursor = await LocalDb.getCursor('health_export_through') ?? '';
@@ -253,7 +226,6 @@ class HealthExporter {
     // Idempotency: remove OUR previously-written samples for this day (HealthKit /
     // Health Connect only let an app delete its own data), then re-write fresh.
     for (final t in _types) {
-      if (!_granted.contains(t)) continue;
       try {
         await _health.delete(type: t, startTime: dayStart, endTime: dayEnd);
       } catch (e) {
@@ -274,7 +246,7 @@ class HealthExporter {
 
     Future<void> writeAt(HealthDataType type, num? v, HealthDataUnit unit,
         DateTime t) async {
-      if (v == null || v <= 0 || !_granted.contains(type)) return;
+      if (v == null || v <= 0) return;
       try {
         await _health.writeHealthData(
             value: v.toDouble(),
@@ -296,8 +268,7 @@ class HealthExporter {
 
     // Active energy over the whole day.
     final cal = sc('calories');
-    if (cal != null && cal > 0 &&
-        _granted.contains(HealthDataType.ACTIVE_ENERGY_BURNED)) {
+    if (cal != null && cal > 0) {
       try {
         await _health.writeHealthData(
             value: cal.toDouble(),
@@ -310,6 +281,36 @@ class HealthExporter {
       }
     }
 
+    // Basal energy = total daily energy (TDEE) − active, over the whole day.
+    final calTotal = sc('calories_total');
+    if (calTotal != null && cal != null && calTotal > cal) {
+      try {
+        await _health.writeHealthData(
+            value: (calTotal - cal).toDouble(),
+            type: HealthDataType.BASAL_ENERGY_BURNED,
+            startTime: dayStart,
+            endTime: dayEnd,
+            unit: HealthDataUnit.KILOCALORIE);
+      } catch (e) {
+        debugPrint('[health] write basal energy: $e');
+      }
+    }
+
+    // Steps (24/7 estimate) over the whole day.
+    final steps = sc('steps');
+    if (steps != null && steps > 0) {
+      try {
+        await _health.writeHealthData(
+            value: steps.toDouble(),
+            type: HealthDataType.STEPS,
+            startTime: dayStart,
+            endTime: dayEnd,
+            unit: HealthDataUnit.COUNT);
+      } catch (e) {
+        debugPrint('[health] write steps: $e');
+      }
+    }
+
     // Sleep stages from the per-segment hypnogram (real time ranges).
     final segs = (_sub(b, 'series')?['hypnogram'] as List?) ?? const [];
     for (final s in segs) {
@@ -319,7 +320,7 @@ class HealthExporter {
       final stage = s['stage']?.toString();
       if (st == null || en == null || en <= st || stage == null) continue;
       final type = _sleepType(stage);
-      if (type == null || !_granted.contains(type)) continue;
+      if (type == null) continue;
       try {
         await _health.writeHealthData(
             value: 0,
@@ -332,7 +333,7 @@ class HealthExporter {
     }
 
     // Workouts (manual/live/detected) finalized in this calendar day.
-    if (_granted.contains(HealthDataType.WORKOUT)) {
+    {
       try {
         final rows = await LocalDb.sessionsInRange(
             dayStart.millisecondsSinceEpoch ~/ 1000,

--- a/lib/health/health_export.dart
+++ b/lib/health/health_export.dart
@@ -1,0 +1,412 @@
+// health_export.dart — write each day's derived metrics to the platform health
+// store: Apple Health (HealthKit) on iOS, Google Health Connect on Android.
+//
+// Honesty rule (same as the rest of the app): only export what the band/our
+// pipeline measures or derives for real — sleep stages, resting HR, HRV
+// (SDNN on iOS / RMSSD on Android), respiratory rate, active energy, workouts.
+// NOT the proprietary scores (recovery/strain/readiness) or relative-only signals
+// (SpO₂ / skin-temp) — no native type, would be fabricated.
+//
+// Continuous + idempotent: a day is exported AS SOON AS it's derived (no waiting
+// for finalization). Because a recent day can re-derive, every export DELETES our
+// prior samples for that day's window before writing fresh ones — so re-running
+// never duplicates. Days in the contiguous FINALIZED prefix are immutable, so once
+// exported they're skipped (tracked by the `health_export_through` cursor); the
+// recent tail is re-written each pass until it finalizes.
+//
+// Nothing here throws — a missing/locked health store yields a HealthLinkState or
+// a 0 count, never an exception.
+
+import 'dart:convert';
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:health/health.dart';
+
+import '../data/db.dart';
+
+/// What we can do with the health store right now.
+enum HealthLinkState {
+  unknown,
+  ready, // permission granted, can write
+  needsPermission, // store available, user hasn't granted write access
+  notInstalled, // Android: Health Connect not installed
+  needsUpdate, // Android: Health Connect needs a Play update
+  unsupported, // no health store on this device (iPad / simulator)
+}
+
+class HealthExporter {
+  final _health = Health();
+  bool _configured = false;
+  final Set<HealthDataType> _granted = {};
+
+  /// True on iOS/macOS (Apple Health); false on Android (Health Connect).
+  static bool get isApple => Platform.isIOS || Platform.isMacOS;
+
+  /// Display name of the platform health store.
+  static String get storeName => isApple ? 'Apple Health' : 'Health Connect';
+
+  /// HealthKit only stores SDNN; Health Connect stores RMSSD — write whichever
+  /// the platform supports (both are real, from cleaned RR).
+  HealthDataType get _hrvType => isApple
+      ? HealthDataType.HEART_RATE_VARIABILITY_SDNN
+      : HealthDataType.HEART_RATE_VARIABILITY_RMSSD;
+
+  /// The metric scalar feeding the HRV type (sdnn on iOS, rmssd on Android).
+  String get _hrvScalarKey => isApple ? 'sdnn' : 'rmssd';
+
+  List<HealthDataType> get _types => [
+        HealthDataType.RESTING_HEART_RATE,
+        _hrvType,
+        HealthDataType.RESPIRATORY_RATE,
+        HealthDataType.ACTIVE_ENERGY_BURNED,
+        HealthDataType.SLEEP_DEEP,
+        HealthDataType.SLEEP_REM,
+        HealthDataType.SLEEP_LIGHT,
+        HealthDataType.SLEEP_AWAKE,
+        HealthDataType.SLEEP_SESSION,
+        HealthDataType.WORKOUT,
+      ];
+
+  bool get ready =>
+      _granted.contains(HealthDataType.RESTING_HEART_RATE) ||
+      _granted.contains(HealthDataType.SLEEP_SESSION) ||
+      _granted.contains(HealthDataType.SLEEP_DEEP);
+
+  String get grantedSummary =>
+      _granted.isEmpty ? 'none' : _granted.map((t) => t.name).join(', ');
+
+  Future<void> _ensureConfigured() async {
+    if (_configured) return;
+    try {
+      await _health.configure();
+      _configured = true;
+    } catch (e) {
+      debugPrint('[health] configure: $e');
+    }
+  }
+
+  Future<void> _refreshGranted() async {
+    _granted.clear();
+    for (final t in _types) {
+      try {
+        if (await _health
+                .hasPermissions([t], permissions: [HealthDataAccess.WRITE]) ==
+            true) {
+          _granted.add(t);
+        }
+      } catch (e) {
+        debugPrint('[health] hasPermissions(${t.name}): $e');
+      }
+    }
+    debugPrint('[health] granted: $grantedSummary (ready=$ready)');
+  }
+
+  Future<HealthLinkState?> _androidUnavailable() async {
+    if (!Platform.isAndroid) return null;
+    try {
+      final s = await _health.getHealthConnectSdkStatus();
+      if (s == HealthConnectSdkStatus.sdkUnavailable) {
+        return HealthLinkState.notInstalled;
+      }
+      if (s == HealthConnectSdkStatus.sdkUnavailableProviderUpdateRequired) {
+        return HealthLinkState.needsUpdate;
+      }
+    } catch (e) {
+      debugPrint('[health] sdkStatus: $e');
+    }
+    return null;
+  }
+
+  /// CHECK existing permissions WITHOUT prompting. Startup-safe, never throws.
+  Future<HealthLinkState> check() async {
+    await _ensureConfigured();
+    try {
+      final un = await _androidUnavailable();
+      if (un != null) return un;
+      await _refreshGranted();
+      return ready ? HealthLinkState.ready : HealthLinkState.needsPermission;
+    } catch (e) {
+      debugPrint('[health] check: $e');
+      return HealthLinkState.unsupported;
+    }
+  }
+
+  /// REQUEST write permission (system dialog). Call ONLY from a user gesture.
+  Future<HealthLinkState> request() async {
+    await _ensureConfigured();
+    try {
+      final un = await _androidUnavailable();
+      if (un != null) return un;
+      await _refreshGranted();
+      final missing = _types.where((t) => !_granted.contains(t)).toList();
+      if (missing.isNotEmpty) {
+        try {
+          await _health.requestAuthorization(missing,
+              permissions: missing.map((_) => HealthDataAccess.WRITE).toList());
+        } catch (e) {
+          debugPrint('[health] requestAuthorization: $e');
+        }
+        await _refreshGranted();
+      }
+      return ready ? HealthLinkState.ready : HealthLinkState.needsPermission;
+    } catch (e) {
+      debugPrint('[health] request: $e');
+      return HealthLinkState.unsupported;
+    }
+  }
+
+  /// Send the user to the Play Store to install Health Connect (Android only).
+  Future<void> install() async {
+    if (!Platform.isAndroid) return;
+    try {
+      await _health.installHealthConnect();
+    } catch (e) {
+      debugPrint('[health] installHealthConnect: $e');
+    }
+  }
+
+  // ── export ────────────────────────────────────────────────────────────────
+
+  /// Export every day not in the immutable finalized prefix — including TODAY and
+  /// other not-yet-finalized days — DELETING our prior samples for each first so a
+  /// re-derive never duplicates. The cursor (`health_export_through`) advances only
+  /// over the contiguous finalized-and-exported prefix; the recent tail is
+  /// re-written on each call. [reset] re-exports the whole retained window.
+  /// Returns the number of days written. Never throws.
+  Future<int> exportAll({bool reset = false, void Function(int days)? onProgress}) async {
+    if (!ready) {
+      await check();
+      if (!ready) return 0;
+    }
+    try {
+      if (reset) await LocalDb.setCursor('health_export_through', '');
+      final cursor = await LocalDb.getCursor('health_export_through') ?? '';
+      final rows = await LocalDb.recentDayResults(400); // newest-first
+      final ascending = rows.reversed.toList();
+      var done = 0;
+      var newCursor = cursor;
+      var prefixContiguous = true; // still extending the finalized prefix?
+      for (final row in ascending) {
+        final date = (row['day_id'] ?? row['date'])?.toString();
+        if (date == null || date.isEmpty) continue;
+        if (cursor.isNotEmpty && date.compareTo(cursor) <= 0) {
+          continue; // immutable finalized prefix — already exported
+        }
+        final finalized = (row['finalized'] as num?)?.toInt() == 1;
+        final bundle = _decode(row['payload_json']);
+        if (bundle == null || bundle['skipped'] == true) {
+          if (!finalized) prefixContiguous = false;
+          continue;
+        }
+        final ok = await _exportDay(date, bundle); // delete-then-write (idempotent)
+        if (ok) {
+          done++;
+          onProgress?.call(done);
+        }
+        // Advance the cursor only while the finalized prefix stays unbroken; the
+        // first non-finalized day stops it (that day re-exports next pass).
+        if (prefixContiguous && finalized) {
+          newCursor = date;
+        } else {
+          prefixContiguous = false;
+        }
+      }
+      if (newCursor != cursor) {
+        await LocalDb.setCursor('health_export_through', newCursor);
+      }
+      debugPrint('[health] exported $done day(s); finalized-cursor=$newCursor');
+      return done;
+    } catch (e) {
+      debugPrint('[health] exportAll: $e');
+      return 0;
+    }
+  }
+
+  /// Write one day's metrics. DELETES our prior samples for the day window first
+  /// (so a re-derive overwrites instead of duplicating). Best-effort; never throws.
+  Future<bool> _exportDay(String date, Map<String, dynamic> b) async {
+    final dayStart = _localMidnight(date);
+    if (dayStart == null) return false;
+    final dayEnd = dayStart.add(const Duration(days: 1));
+
+    // Idempotency: remove OUR previously-written samples for this day (HealthKit /
+    // Health Connect only let an app delete its own data), then re-write fresh.
+    for (final t in _types) {
+      if (!_granted.contains(t)) continue;
+      try {
+        await _health.delete(type: t, startTime: dayStart, endTime: dayEnd);
+      } catch (e) {
+        debugPrint('[health] delete ${t.name}: $e');
+      }
+    }
+
+    final scalars = (b['scalars'] as Map?)?.cast<String, dynamic>() ?? const {};
+    num? sc(String k) => scalars[k] is num ? scalars[k] as num : null;
+
+    // Sleep window → a representative instant for the nightly scalars.
+    final win = _sub(b, 'sleep.window.value');
+    final onMs = (win?['onset_ms'] as num?)?.toDouble();
+    final offMs = (win?['offset_ms'] as num?)?.toDouble();
+    final mid = (onMs != null && offMs != null)
+        ? DateTime.fromMillisecondsSinceEpoch(((onMs + offMs) / 2).round())
+        : dayStart.add(const Duration(hours: 12));
+
+    Future<void> writeAt(HealthDataType type, num? v, HealthDataUnit unit,
+        DateTime t) async {
+      if (v == null || v <= 0 || !_granted.contains(type)) return;
+      try {
+        await _health.writeHealthData(
+            value: v.toDouble(),
+            type: type,
+            startTime: t,
+            endTime: t,
+            unit: unit);
+      } catch (e) {
+        debugPrint('[health] write ${type.name}: $e');
+      }
+    }
+
+    // Nightly cardiac/respiratory scalars (single sample at the sleep midpoint).
+    await writeAt(HealthDataType.RESTING_HEART_RATE, sc('rhr'),
+        HealthDataUnit.BEATS_PER_MINUTE, mid);
+    await writeAt(_hrvType, sc(_hrvScalarKey), HealthDataUnit.MILLISECOND, mid);
+    await writeAt(HealthDataType.RESPIRATORY_RATE, sc('resp_rate'),
+        HealthDataUnit.RESPIRATIONS_PER_MINUTE, mid);
+
+    // Active energy over the whole day.
+    final cal = sc('calories');
+    if (cal != null && cal > 0 &&
+        _granted.contains(HealthDataType.ACTIVE_ENERGY_BURNED)) {
+      try {
+        await _health.writeHealthData(
+            value: cal.toDouble(),
+            type: HealthDataType.ACTIVE_ENERGY_BURNED,
+            startTime: dayStart,
+            endTime: dayEnd,
+            unit: HealthDataUnit.KILOCALORIE);
+      } catch (e) {
+        debugPrint('[health] write energy: $e');
+      }
+    }
+
+    // Sleep stages from the per-segment hypnogram (real time ranges).
+    final segs = (_sub(b, 'series')?['hypnogram'] as List?) ?? const [];
+    for (final s in segs) {
+      if (s is! Map) continue;
+      final st = (s['start'] as num?)?.toInt();
+      final en = (s['end'] as num?)?.toInt();
+      final stage = s['stage']?.toString();
+      if (st == null || en == null || en <= st || stage == null) continue;
+      final type = _sleepType(stage);
+      if (type == null || !_granted.contains(type)) continue;
+      try {
+        await _health.writeHealthData(
+            value: 0,
+            type: type,
+            startTime: DateTime.fromMillisecondsSinceEpoch(st * 1000),
+            endTime: DateTime.fromMillisecondsSinceEpoch(en * 1000));
+      } catch (e) {
+        debugPrint('[health] write sleep ${type.name}: $e');
+      }
+    }
+
+    // Workouts (manual/live/detected) finalized in this calendar day.
+    if (_granted.contains(HealthDataType.WORKOUT)) {
+      try {
+        final rows = await LocalDb.sessionsInRange(
+            dayStart.millisecondsSinceEpoch ~/ 1000,
+            dayEnd.millisecondsSinceEpoch ~/ 1000);
+        for (final r in rows) {
+          if ((r['status']?.toString() ?? '') == 'live') continue;
+          final st = (r['start_ts'] as num?)?.toInt();
+          final en = (r['end_ts'] as num?)?.toInt();
+          if (st == null || en == null || en <= st) continue;
+          await _health.writeWorkoutData(
+            activityType: _activity(r['type']?.toString()),
+            start: DateTime.fromMillisecondsSinceEpoch(st * 1000),
+            end: DateTime.fromMillisecondsSinceEpoch(en * 1000),
+            totalEnergyBurned: (r['calories'] as num?)?.round(),
+          );
+        }
+      } catch (e) {
+        debugPrint('[health] write workouts: $e');
+      }
+    }
+    return true;
+  }
+
+  HealthDataType? _sleepType(String stage) {
+    switch (stage) {
+      case 'deep':
+        return HealthDataType.SLEEP_DEEP;
+      case 'rem':
+        return HealthDataType.SLEEP_REM;
+      case 'light':
+      case 'nrem':
+        return HealthDataType.SLEEP_LIGHT;
+      case 'wake':
+      case 'awake':
+        return HealthDataType.SLEEP_AWAKE;
+      default:
+        return null;
+    }
+  }
+
+  HealthWorkoutActivityType _activity(String? type) {
+    switch ((type ?? '').toLowerCase()) {
+      case 'run':
+      case 'running':
+        return HealthWorkoutActivityType.RUNNING;
+      case 'cycle':
+      case 'cycling':
+      case 'bike':
+      case 'biking':
+        return HealthWorkoutActivityType.BIKING;
+      case 'walk':
+      case 'walking':
+        return HealthWorkoutActivityType.WALKING;
+      case 'swim':
+      case 'swimming':
+        return HealthWorkoutActivityType.SWIMMING;
+      case 'strength':
+      case 'weights':
+      case 'lifting':
+        return HealthWorkoutActivityType.STRENGTH_TRAINING;
+      case 'yoga':
+        return HealthWorkoutActivityType.YOGA;
+      case 'hiit':
+        return HealthWorkoutActivityType.HIGH_INTENSITY_INTERVAL_TRAINING;
+      default:
+        return HealthWorkoutActivityType.OTHER;
+    }
+  }
+
+  static Map<String, dynamic>? _decode(Object? json) {
+    if (json is! String) return null;
+    try {
+      final d = jsonDecode(json);
+      return d is Map ? d.cast<String, dynamic>() : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static Map<String, dynamic>? _sub(Map<String, dynamic>? b, String path) {
+    var cur = b;
+    for (final p in path.split('.')) {
+      final n = cur?[p];
+      cur = n is Map ? n.cast<String, dynamic>() : null;
+      if (cur == null) return null;
+    }
+    return cur;
+  }
+
+  static DateTime? _localMidnight(String ymd) {
+    final p = ymd.split('-');
+    if (p.length != 3) return null;
+    final y = int.tryParse(p[0]), m = int.tryParse(p[1]), d = int.tryParse(p[2]);
+    if (y == null || m == null || d == null) return null;
+    return DateTime(y, m, d);
+  }
+}

--- a/lib/health/health_export.dart
+++ b/lib/health/health_export.dart
@@ -20,6 +20,7 @@
 import 'dart:convert';
 import 'dart:io' show Platform;
 
+import 'package:android_intent_plus/android_intent.dart';
 import 'package:flutter/foundation.dart';
 import 'package:health/health.dart';
 
@@ -163,6 +164,25 @@ class HealthExporter {
       await _health.installHealthConnect();
     } catch (e) {
       debugPrint('[health] installHealthConnect: $e');
+    }
+  }
+
+  /// Open the Health Connect app / settings so the user can enable OpenStrap's
+  /// access manually — the reliable path when the in-app request dialog is locked
+  /// out. Android-only. API 34+ folds HC into system settings; older uses the HC
+  /// app, so try the modern action first then fall back.
+  Future<void> openSettings() async {
+    if (!Platform.isAndroid) return;
+    for (final action in const [
+      'android.health.connect.action.HEALTH_HOME_SETTINGS',
+      'androidx.health.ACTION_HEALTH_CONNECT_SETTINGS',
+    ]) {
+      try {
+        await AndroidIntent(action: action).launch();
+        return;
+      } catch (e) {
+        debugPrint('[health] open settings ($action): $e');
+      }
     }
   }
 

--- a/lib/models/payloads.dart
+++ b/lib/models/payloads.dart
@@ -108,7 +108,10 @@ class TodayData {
   Metric get rhrDelta => metricOf(_daily, 'resting_hr_delta');
   Metric get wearTime => metricOf(_daily, 'wear_min');
   Metric get calories => metricOf(_daily, 'calories'); // active calories (est.)
-  Metric get steps => metricOf(_daily, 'steps'); // real detected steps (est.)
+  Metric get caloriesTotal =>
+      metricOf(_daily, 'calories_total'); // total daily energy (TDEE, est.)
+  Metric get steps => metricOf(_daily, 'steps'); // 24/7 step estimate
+  Metric get activeMin => metricOf(_daily, 'active_min'); // movement minutes
 
   /// Body alert (illness/overtraining) — {signal, kind, triggers, note} or null.
   Map<String, dynamic>? get bodyAlert {

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -17,6 +17,8 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show HapticFeedback;
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:openstrap_analytics/onehz.dart' as ana;
+import 'package:openstrap_protocol/openstrap_protocol.dart' as proto;
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -706,6 +708,123 @@ class AppState extends ChangeNotifier {
     if (spotActive && (pt == 0x28 || pt == 0x2B)) {
       if (_spotFrames.length < 8000) _spotFrames.add(hex);
     }
+    // LIVE STEP COUNTER. The dedicated 0x33 IMU stream is the high-rate live
+    // accel — it arrives ~10 frames/s (10 samples each), so it drives a smooth,
+    // responsive count. Full R10 (0x2B) is only a fallback when the IMU stream
+    // isn't flowing (and live 0x2B is often R10-LITE, which carries no accel).
+    // `frameAccel` returns |a|(g) samples for both; once 0x33 is seen we ignore
+    // 0x2B to avoid double-counting the same motion from two stream formats.
+    if (pt == 0x33) {
+      _imuStreamSeen = true;
+      final f = _safeFrameAccel(hex);
+      if (f != null) _ingestLiveMags(f.mags);
+    } else if (pt == 0x2B && !_imuStreamSeen) {
+      final f = _safeFrameAccel(hex);
+      if (f != null) _ingestLiveMags(f.mags);
+    }
+  }
+
+  proto.ImuFrame? _safeFrameAccel(String hex) {
+    try {
+      return proto.frameAccel(hex);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // ── live pedometer (foreground 100 Hz R10 accel) ────────────────────────────
+  // Real step counting via the LOCKED AN-2554 pedometer (analytics `pedometer`),
+  // the same algorithm + ×1.11 gain the backend calibrated on a 100-step walk.
+  // AN-2554's gain was calibrated on PER-MINUTE contiguous signals, so we count
+  // in 60 s chunks: each full minute is committed into `_committedRaw`, and the
+  // still-filling partial minute is re-counted each frame for a live readout.
+  // AN-2554's CONFIRM=8 regularity gate reads 0 at rest (rejects fidgeting).
+  final List<double> _magMin = []; // current minute's magnitude signal
+  int _committedRaw = 0; // raw (pre-gain) steps from completed minutes
+  int _liveSamples = 0; // total 100 Hz samples streamed this session
+  double _liveEnmoSum = 0; // 1 Hz-equivalent ENMO accumulator (for calibration)
+  int _liveEnmoN = 0;
+  bool _imuStreamSeen = false; // prefer the 0x33 IMU stream once it appears
+  static const int _minuteSamples = 6000; // 60 s @ 100 Hz — calibration chunk
+
+  /// Raw (pre-gain) session step total = committed minutes + the partial minute.
+  int get _liveRaw => _committedRaw + ana.pedometer(_magMin);
+
+  /// Steps counted on the live 100 Hz stream this connected session (real,
+  /// gain-applied). Used for cadence calibration. 0 when not streaming.
+  int get liveSteps => (_liveRaw * ana.StepParams.gain).round();
+
+  // Snapshot of the RAW session total at the moment a manual workout started, so
+  // the live-session screen shows steps FOR THIS WORKOUT (not since connection).
+  int? _workoutRawBase;
+
+  /// Steps taken since the active workout started (real, live, gain-applied).
+  /// 0 when no workout is running. This is what the workout screen shows.
+  int get workoutSteps {
+    if (activeWorkout == null || _workoutRawBase == null) return 0;
+    final raw = _liveRaw - _workoutRawBase!;
+    return raw > 0 ? (raw * ana.StepParams.gain).round() : 0;
+  }
+
+  void _ingestLiveMags(List<double> mags) {
+    if (mags.isEmpty) return;
+    // Append this frame's |a|(g) samples (gravity INCLUDED — AN-2554's dynamic
+    // threshold rides the ~1 g baseline). Also accumulate a 1 Hz-equivalent ENMO
+    // sample (mean |a| − 1 g) for cadence calibration.
+    var magSum = 0.0;
+    for (final m in mags) {
+      _magMin.add(m);
+      magSum += m;
+    }
+    _liveSamples += mags.length;
+    final e = (magSum / mags.length) - 1.0;
+    _liveEnmoSum += e > 0 ? e : 0.0;
+    _liveEnmoN++;
+
+    // Commit each completed minute into the raw total (matches the gain's
+    // per-minute calibration), then keep counting the next partial minute.
+    while (_magMin.length >= _minuteSamples) {
+      final minute = _magMin.sublist(0, _minuteSamples);
+      _magMin.removeRange(0, _minuteSamples);
+      _committedRaw += ana.pedometer(minute);
+    }
+    notifyListeners(); // live readout re-counts the partial minute on read
+  }
+
+  /// Reset the live step counter for a fresh connected session.
+  void _resetLivePedometer() {
+    _magMin.clear();
+    _committedRaw = 0;
+    _liveSamples = 0;
+    _liveEnmoSum = 0;
+    _liveEnmoN = 0;
+    _imuStreamSeen = false;
+  }
+
+  /// End-of-session: if the bout is credible walking, fold it into the personal
+  /// cadence calibration (persisted) so the 24/7 estimate gets more accurate.
+  Future<void> _finalizeLivePedometer() async {
+    final steps = liveSteps; // gain-applied
+    final durS = _liveSamples / 100.0;
+    final enmo = _liveEnmoN > 0 ? _liveEnmoSum / _liveEnmoN : 0.0;
+    _resetLivePedometer();
+    if (steps <= 0 || durS < 20) return;
+    final cadence = steps / (durS / 60.0);
+    // Any nonzero AN-2554 count is CONFIRM-gated gait; confidence is high when
+    // the cadence lands in a walking band (else let calibrateCadence reject it).
+    final conf = (cadence >= 60 && cadence <= 200) ? 0.85 : 0.4;
+    final result = ana.PedometerResult(steps, durS, cadence, 0.0, conf);
+    try {
+      final prior = await LocalDb.getStepCalibration();
+      final next = ana.calibrateCadence(prior, result, enmo);
+      if (next != null && !identical(next, prior)) {
+        await LocalDb.putStepCalibration(next);
+        _log('[steps] cadence calibrated → '
+            '${next.cadenceSpm.toStringAsFixed(0)} spm (n=${next.n})');
+      }
+    } catch (e) {
+      _log('[steps] calibration skipped: $e');
+    }
   }
 
   void _onEngineState(DeviceState s) {
@@ -723,6 +842,9 @@ class AppState extends ChangeNotifier {
           s.batteryPct == null ? null : battPct, s.charging, s.strapName));
     }
     if (_prevConn != 'disconnected' && s.connection == 'disconnected') {
+      // Live stream ended → fold this bout into the personal cadence calibration
+      // (best-effort; only credible walking updates it) and reset the counter.
+      unawaited(_finalizeLivePedometer());
       if (_keepAlive && isPaired && !_reconnecting) {
         _log('Connection dropped — reconnecting…');
         // If we're backgrounded, also arm the iOS restore path: if the in-process
@@ -880,6 +1002,7 @@ class AppState extends ChangeNotifier {
         return;
       }
       await engine.enableLiveStreams();
+      _resetLivePedometer(); // fresh live step count for this connected session
       await engine.getBattery();
       await engine.getStrapName(); // populate strap name + alarm for the Profile UI
       await engine.getAlarm();
@@ -1105,6 +1228,9 @@ class AppState extends ChangeNotifier {
       workoutId: id,
       type: type,
     );
+    // Scope the live step count to THIS workout: remember the running session
+    // raw total now, so `workoutSteps` reports only steps taken from here on.
+    _workoutRawBase = _liveRaw;
     // Persist the live session (INSERT OR REPLACE — idempotent if repo already
     // inserted this id). Final stats are written on stop.
     unawaited(LocalDb.putSession({
@@ -1143,6 +1269,7 @@ class AppState extends ChangeNotifier {
     _workoutTimer = null;
     final w = activeWorkout!;
     final finalKcal = w.calories.round();
+    final wSteps = workoutSteps; // real steps taken during this workout
     // Persist the finalized session before clearing the live state. No per-zone
     // minute tallies are tracked live, so zone_min is honestly empty.
     final id = w.workoutId ?? 'w${w.startTime.millisecondsSinceEpoch}';
@@ -1157,9 +1284,11 @@ class AppState extends ChangeNotifier {
       'max_hr': w.maxHrSeen > 0 ? w.maxHrSeen : null,
       'duration_min': w.elapsed.inMinutes,
       'zone_min_json': jsonEncode(const <num>[]),
+      if (wSteps > 0) 'steps': wSteps,
       'source': 'manual',
       'created_at': w.startTime.millisecondsSinceEpoch,
     }));
+    _workoutRawBase = null;
     activeWorkout = null;
     notifyListeners();
     _log('Live session ended. Burned $finalKcal kcal.');

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -31,6 +31,7 @@ import '../data/db.dart';
 import '../data/local_repository.dart';
 import '../data/local_repository_impl.dart';
 import '../gestures/gesture_settings.dart';
+import '../health/health_export.dart';
 import '../import/noop_import.dart';
 import '../import/whoop_import.dart';
 import '../gestures/gesture_dispatcher.dart';
@@ -140,6 +141,10 @@ class AppState extends ChangeNotifier {
     // Load the user's backend-URL override (if any) so the cloud client resolves
     // it ahead of the build-time BACKEND_URL.
     BackendClient.overrideUrl = prefs.getString(_kBackendUrl);
+    healthSyncEnabled = prefs.getBool(_kHealthSync) ?? false;
+    // Best-effort, no prompt: learn the current health-permission state so the
+    // Profile toggle reflects reality on open.
+    if (healthSyncEnabled) unawaited(checkHealth());
   }
 
   // ── backend URL (cloud import / existing-user login) ────────────────────────
@@ -229,6 +234,52 @@ class AppState extends ChangeNotifier {
     } catch (_) {/* best-effort */}
     notifyListeners();
     return counts.values.fold<int>(0, (a, b) => a + b);
+  }
+
+  // ── platform health export (Apple Health / Health Connect) ──────────────────
+  final HealthExporter _healthExport = HealthExporter();
+  HealthLinkState healthState = HealthLinkState.unknown;
+  bool healthSyncEnabled = false;
+  static const String _kHealthSync = 'health_sync';
+
+  /// "Apple Health" (iOS) or "Health Connect" (Android).
+  String get healthStoreName => HealthExporter.storeName;
+  bool get healthIsApple => HealthExporter.isApple;
+
+  /// Check current permission state WITHOUT prompting (startup-safe).
+  Future<void> checkHealth() async {
+    healthState = await _healthExport.check();
+    notifyListeners();
+  }
+
+  /// Prompt for write access (user gesture). On grant + enabled, kick a sync.
+  Future<void> requestHealth() async {
+    healthState = await _healthExport.request();
+    notifyListeners();
+    if (healthState == HealthLinkState.ready && healthSyncEnabled) {
+      unawaited(healthSyncNow());
+    }
+  }
+
+  /// Android: open the Play Store to install/update Health Connect.
+  Future<void> installHealthConnect() => _healthExport.install();
+
+  /// Toggle continuous export. Enabling requests permission + does a first sync.
+  Future<void> setHealthSync(bool on) async {
+    healthSyncEnabled = on;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_kHealthSync, on);
+    notifyListeners();
+    if (on) {
+      await requestHealth();
+      if (healthState == HealthLinkState.ready) unawaited(healthSyncNow());
+    }
+  }
+
+  /// Export all finalized-but-unexported days now. Returns days written.
+  Future<int> healthSyncNow() async {
+    final n = await _healthExport.exportAll();
+    return n;
   }
 
   /// Merge + persist local profile fields. Returns the updated map. Replaces the
@@ -386,6 +437,20 @@ class AppState extends ChangeNotifier {
             if (n > 0) notifyListeners(); // screens re-read the refreshed scalars
           } catch (e) {
             _log('[derive] rescan failed: $e');
+          }
+        }());
+      }
+      // Continuous health export: push freshly-derived days (incl. TODAY) to Apple
+      // Health / Health Connect AS SOON as they're computed — runs on BOTH the
+      // light (every drain) and heavy passes, not only on finalize. Idempotent
+      // (delete-then-write), best-effort, never throws into the BLE/derive path.
+      if (healthSyncEnabled) {
+        unawaited(() async {
+          try {
+            final n = await _healthExport.exportAll();
+            if (n > 0) _log('[health] exported $n day(s)');
+          } catch (e) {
+            _log('[health] export failed: $e');
           }
         }());
       }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -264,6 +264,12 @@ class AppState extends ChangeNotifier {
   /// Android: open the Play Store to install/update Health Connect.
   Future<void> installHealthConnect() => _healthExport.install();
 
+  /// Android: open the Health Connect app/settings so the user can enable our
+  /// per-app access manually. Re-checks state when they come back.
+  Future<void> openHealthConnect() async {
+    await _healthExport.openSettings();
+  }
+
   /// Toggle continuous export. Enabling requests permission + does a first sync.
   Future<void> setHealthSync(bool on) async {
     healthSyncEnabled = on;

--- a/lib/ui/activity/live_session_screen.dart
+++ b/lib/ui/activity/live_session_screen.dart
@@ -477,9 +477,11 @@ class _ControlPanel extends StatelessWidget {
             child: Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
               _Stat(label: 'CALORIES', value: workout.calories.round().toString(), unit: 'kcal', icon: Ic.fire),
               _Stat(label: 'STRAIN', value: workout.strain.toStringAsFixed(1), unit: '', icon: Ic.strain),
-              _Stat(label: 'BURN/MIN',
-                  value: (workout.calories / math.max(1, workout.elapsed.inMinutes)).toStringAsFixed(1),
-                  unit: '', icon: Ic.pulse),
+              // Real steps counted on the live 100 Hz stream, scoped to THIS
+              // workout (resets at start, not at connection).
+              _Stat(label: 'STEPS',
+                  value: context.watch<AppState>().workoutSteps.toString(),
+                  unit: '', icon: Ic.run),
             ]),
           ),
         ),

--- a/lib/ui/activity/strain_detail_screen.dart
+++ b/lib/ui/activity/strain_detail_screen.dart
@@ -333,7 +333,11 @@ class _StrainDetailScreenState extends State<StrainDetailScreen> {
         ],
         if (fitness != null) DetailRow(label: 'Fitness trend', value: fitness),
         if (cals != null) DetailRow(label: 'Active calories', value: '${cals.round()} kcal'),
-        if (steps != null) DetailRow(label: 'Steps', value: '${steps.round()}'),
+        if (_num(_data['calories_total']) != null)
+          DetailRow(
+              label: 'Total calories',
+              value: '${_num(_data['calories_total'])!.round()} kcal'),
+        if (steps != null) DetailRow(label: 'Steps (est.)', value: '${steps.round()}'),
         // Edwards zone-weighted "effort" (0–100) — finer-grained intensity read
         // than the 0–21 headline, over the per-second wake HR.
         if (effort != null) DetailRow(label: 'Effort (0–100)', value: '${effort.round()}'),

--- a/lib/ui/profile/profile_screen.dart
+++ b/lib/ui/profile/profile_screen.dart
@@ -617,78 +617,65 @@ class _HealthSection extends StatelessWidget {
 
   Widget _statusRow(BuildContext context, HealthLinkState st, String store) {
     final messenger = ScaffoldMessenger.of(context);
-    switch (st) {
-      case HealthLinkState.ready:
-        return Row(children: [
-          AppIcon(Ic.check, size: 16, color: AppColors.good),
-          const SizedBox(width: Sp.x2),
-          Expanded(
-              child: Text('Connected — new days sync automatically.',
-                  style: AppText.captionMuted)),
-          TextButton(
-            onPressed: () async {
-              final n = await app.healthSyncNow();
-              messenger.showSnackBar(SnackBar(
-                  content: Text(n > 0
-                      ? 'Synced $n day${n == 1 ? '' : 's'} to $store.'
-                      : 'Already up to date.')));
-            },
-            child: const Text('Sync now'),
-          ),
-        ]);
-      case HealthLinkState.needsPermission:
-      case HealthLinkState.unknown:
-        // Tapping "Grant access" opens the platform permission flow — on Android
-        // that's the Health Connect app, where the user enables OpenStrap. The
-        // subtitle tells them what to do once it opens.
-        final subtitle = app.healthIsApple
-            ? 'When the Apple Health sheet opens, turn ON every category so '
-                'OpenStrap can write them, then come back.'
-            : 'Opens Health Connect. There, allow OpenStrap to write the data '
-                'above — App permissions → OpenStrap → Allow all — then come back.';
-        return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          Row(children: [
-            Expanded(
-                child: Text('Grant write access to add your data to $store.',
-                    style: AppText.captionMuted)),
-            const SizedBox(width: Sp.x2),
-            FilledButton(
-              onPressed: () => app.requestHealth(),
-              style: FilledButton.styleFrom(
-                  backgroundColor: AppColors.coral,
-                  visualDensity: VisualDensity.compact),
-              child: const Text('Grant access',
-                  style: TextStyle(color: Colors.white)),
-            ),
-          ]),
-          const SizedBox(height: Sp.x2),
-          Text(subtitle,
-              style: AppText.caption.copyWith(color: AppColors.inkMuted)),
-          if (!app.healthIsApple)
-            Align(
-              alignment: Alignment.centerLeft,
-              child: TextButton(
-                onPressed: () async {
-                  await app.openHealthConnect();
-                  await app.checkHealth(); // re-read state when they return
-                },
-                style: TextButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(vertical: 4),
-                    visualDensity: VisualDensity.compact),
-                child: const Text('Open Health Connect'),
-              ),
-            ),
-        ]);
-      case HealthLinkState.notInstalled:
-        return _cta('$store isn’t installed. Install it, then come back.',
-            'Install', () => app.installHealthConnect());
-      case HealthLinkState.needsUpdate:
-        return _cta('$store needs an update before we can write to it.',
-            'Update', () => app.installHealthConnect());
-      case HealthLinkState.unsupported:
-        return Text('$store isn’t available on this device.',
-            style: AppText.captionMuted);
+    // Health Connect must be installed/updated first (Android).
+    if (st == HealthLinkState.notInstalled) {
+      return _cta('$store isn’t installed. Install it, then come back.',
+          'Install', () => app.installHealthConnect());
     }
+    if (st == HealthLinkState.needsUpdate) {
+      return _cta('$store needs an update before we can write to it.', 'Update',
+          () => app.installHealthConnect());
+    }
+    if (st == HealthLinkState.unsupported) {
+      return Text('$store isn’t available on this device.',
+          style: AppText.captionMuted);
+    }
+
+    // Available: we can't reliably read the per-type WRITE grant (the platform
+    // hides it), so we just keep writing and tell the user how to allow access
+    // if data isn't showing — never a stuck "Grant access" gate.
+    final subtitle = app.healthIsApple
+        ? 'New days are written automatically. If they don’t appear in Apple '
+            'Health, tap Allow access and turn ON every category.'
+        : 'New days are written automatically. If they don’t appear, open '
+            'Health Connect → App permissions → OpenStrap → Allow all.';
+    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+      Row(children: [
+        AppIcon(Ic.check, size: 16, color: AppColors.good),
+        const SizedBox(width: Sp.x2),
+        Expanded(
+            child:
+                Text('Syncing to $store.', style: AppText.captionMuted)),
+      ]),
+      const SizedBox(height: Sp.x2),
+      Text(subtitle, style: AppText.caption.copyWith(color: AppColors.inkMuted)),
+      const SizedBox(height: Sp.x2),
+      Wrap(spacing: Sp.x2, children: [
+        FilledButton(
+          onPressed: () => app.requestHealth(),
+          style: FilledButton.styleFrom(
+              backgroundColor: AppColors.coral,
+              visualDensity: VisualDensity.compact),
+          child: const Text('Allow access', style: TextStyle(color: Colors.white)),
+        ),
+        if (!app.healthIsApple)
+          OutlinedButton(
+            onPressed: () => app.openHealthConnect(),
+            style: OutlinedButton.styleFrom(visualDensity: VisualDensity.compact),
+            child: const Text('Open Health Connect'),
+          ),
+        TextButton(
+          onPressed: () async {
+            final n = await app.healthSyncNow();
+            messenger.showSnackBar(SnackBar(
+                content: Text(n > 0
+                    ? 'Synced $n day${n == 1 ? '' : 's'} to $store.'
+                    : 'Up to date — new days sync as they’re computed.')));
+          },
+          child: const Text('Sync now'),
+        ),
+      ]),
+    ]);
   }
 
   Widget _cta(String text, String label, VoidCallback onTap) => Row(children: [

--- a/lib/ui/profile/profile_screen.dart
+++ b/lib/ui/profile/profile_screen.dart
@@ -638,10 +638,47 @@ class _HealthSection extends StatelessWidget {
         ]);
       case HealthLinkState.needsPermission:
       case HealthLinkState.unknown:
-        return _cta(
-            'Grant write access so we can add your data to $store.',
-            'Grant access',
-            () => app.requestHealth());
+        // Tapping "Grant access" opens the platform permission flow — on Android
+        // that's the Health Connect app, where the user enables OpenStrap. The
+        // subtitle tells them what to do once it opens.
+        final subtitle = app.healthIsApple
+            ? 'When the Apple Health sheet opens, turn ON every category so '
+                'OpenStrap can write them, then come back.'
+            : 'Opens Health Connect. There, allow OpenStrap to write the data '
+                'above — App permissions → OpenStrap → Allow all — then come back.';
+        return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Row(children: [
+            Expanded(
+                child: Text('Grant write access to add your data to $store.',
+                    style: AppText.captionMuted)),
+            const SizedBox(width: Sp.x2),
+            FilledButton(
+              onPressed: () => app.requestHealth(),
+              style: FilledButton.styleFrom(
+                  backgroundColor: AppColors.coral,
+                  visualDensity: VisualDensity.compact),
+              child: const Text('Grant access',
+                  style: TextStyle(color: Colors.white)),
+            ),
+          ]),
+          const SizedBox(height: Sp.x2),
+          Text(subtitle,
+              style: AppText.caption.copyWith(color: AppColors.inkMuted)),
+          if (!app.healthIsApple)
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton(
+                onPressed: () async {
+                  await app.openHealthConnect();
+                  await app.checkHealth(); // re-read state when they return
+                },
+                style: TextButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    visualDensity: VisualDensity.compact),
+                child: const Text('Open Health Connect'),
+              ),
+            ),
+        ]);
       case HealthLinkState.notInstalled:
         return _cta('$store isn’t installed. Install it, then come back.',
             'Install', () => app.installHealthConnect());

--- a/lib/ui/profile/profile_screen.dart
+++ b/lib/ui/profile/profile_screen.dart
@@ -9,6 +9,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../data/db.dart';
+import '../../health/health_export.dart';
 import '../../state/app_state.dart';
 import '../../state/units_controller.dart';
 import '../../theme/theme.dart';
@@ -221,6 +222,12 @@ class ProfileScreen extends StatelessWidget {
               ),
             ),
           ),
+
+          const SizedBox(height: Sp.x7),
+
+          // ── Apple Health (iOS) / Health Connect (Android) ─────────────
+          SectionHeader(app.healthStoreName),
+          _HealthSection(app: app),
 
           const SizedBox(height: Sp.x7),
 
@@ -563,6 +570,103 @@ Future<bool?> _confirm(
 }
 
 // ── Header ──────────────────────────────────────────────────────────────────
+/// Apple Health (iOS) / Health Connect (Android) export controls: a toggle to
+/// keep pushing each day's metrics, plus state-aware CTAs (grant / install).
+class _HealthSection extends StatelessWidget {
+  final AppState app;
+  const _HealthSection({required this.app});
+
+  @override
+  Widget build(BuildContext context) {
+    final store = app.healthStoreName;
+    final st = app.healthState;
+    return ProCard(
+      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+        Row(children: [
+          Container(
+            padding: const EdgeInsets.all(9),
+            decoration: BoxDecoration(
+                color: AppColors.coralSoft,
+                borderRadius: BorderRadius.circular(R.chip)),
+            child: AppIcon(Ic.heart, size: 18, color: AppColors.coralInk),
+          ),
+          const SizedBox(width: Sp.x3),
+          Expanded(
+            child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+              Text('Sync to $store', style: AppText.label),
+              const SizedBox(height: 1),
+              Text('Sleep, resting HR, HRV, respiratory rate, energy & workouts.',
+                  style: AppText.captionMuted),
+            ]),
+          ),
+          Switch(
+            value: app.healthSyncEnabled,
+            activeThumbColor: AppColors.coral,
+            onChanged: (v) => app.setHealthSync(v),
+          ),
+        ]),
+        if (app.healthSyncEnabled) ...[
+          const SizedBox(height: Sp.x2),
+          const _HairDivider(),
+          const SizedBox(height: Sp.x3),
+          _statusRow(context, st, store),
+        ],
+      ]),
+    );
+  }
+
+  Widget _statusRow(BuildContext context, HealthLinkState st, String store) {
+    final messenger = ScaffoldMessenger.of(context);
+    switch (st) {
+      case HealthLinkState.ready:
+        return Row(children: [
+          AppIcon(Ic.check, size: 16, color: AppColors.good),
+          const SizedBox(width: Sp.x2),
+          Expanded(
+              child: Text('Connected — new days sync automatically.',
+                  style: AppText.captionMuted)),
+          TextButton(
+            onPressed: () async {
+              final n = await app.healthSyncNow();
+              messenger.showSnackBar(SnackBar(
+                  content: Text(n > 0
+                      ? 'Synced $n day${n == 1 ? '' : 's'} to $store.'
+                      : 'Already up to date.')));
+            },
+            child: const Text('Sync now'),
+          ),
+        ]);
+      case HealthLinkState.needsPermission:
+      case HealthLinkState.unknown:
+        return _cta(
+            'Grant write access so we can add your data to $store.',
+            'Grant access',
+            () => app.requestHealth());
+      case HealthLinkState.notInstalled:
+        return _cta('$store isn’t installed. Install it, then come back.',
+            'Install', () => app.installHealthConnect());
+      case HealthLinkState.needsUpdate:
+        return _cta('$store needs an update before we can write to it.',
+            'Update', () => app.installHealthConnect());
+      case HealthLinkState.unsupported:
+        return Text('$store isn’t available on this device.',
+            style: AppText.captionMuted);
+    }
+  }
+
+  Widget _cta(String text, String label, VoidCallback onTap) => Row(children: [
+        Expanded(child: Text(text, style: AppText.captionMuted)),
+        const SizedBox(width: Sp.x2),
+        FilledButton(
+          onPressed: onTap,
+          style: FilledButton.styleFrom(
+              backgroundColor: AppColors.coral,
+              visualDensity: VisualDensity.compact),
+          child: Text(label, style: TextStyle(color: Colors.white)),
+        ),
+      ]);
+}
+
 class _Header extends StatelessWidget {
   final String name;
   final VoidCallback onEdit;

--- a/lib/ui/screens/screens.dart
+++ b/lib/ui/screens/screens.dart
@@ -111,26 +111,28 @@ class BodyScreen extends StatelessWidget {
       );
 }
 
-/// Activity — daily movement (active minutes from 1 Hz wrist motion; 1 Hz can't
-/// count steps, so real step counts come only from live workouts). Bars track
-/// active minutes over Today/Week/Month/3M; the detail explains the metric and
-/// keeps the daily step-goal setter. Reached from the home "Steps/Activity" tile.
+/// Steps — daily step ESTIMATE. The band's always-on 1 Hz stream can't COUNT
+/// steps (Nyquist), so the 24/7 number is ambulatory-minutes × your cadence; the
+/// live 100 Hz workout stream counts real steps AND tunes that cadence. Bars
+/// track the daily step estimate; the detail explains it honestly and keeps the
+/// daily step-goal setter. Reached from the home "Steps" tile.
 class ActivityScreen extends StatelessWidget {
   const ActivityScreen({super.key});
   @override
   Widget build(BuildContext context) => MetricScreen(
-        title: 'Activity',
-        metric: 'steps', // → active_min series (movement minutes)
-        icon: Ic.strain,
-        accent: AppColors.coral,
-        valueFmt: (v) => v == 0 ? '' : v.toStringAsFixed(0), // active min on bars
+        title: 'Steps',
+        metric: 'steps', // → steps series (24/7 estimate)
+        icon: Ic.run,
+        accent: AppColors.good,
+        valueFmt: (v) => v == 0 ? '' : v.toStringAsFixed(0), // steps on bars
         todayDetail: (ctx) => const _ActivityDetail(),
         dayDetail: (ctx, date) => const _ActivityDetail(),
       );
 }
 
-/// Detail under the Activity trend: explains "active minutes" (honest — not a
-/// fabricated step count) + a tappable row to set the daily step goal.
+/// Detail under the Steps trend: explains the estimate honestly (24/7 estimate,
+/// real counts during live workouts that personalize your cadence) + a tappable
+/// row to set the daily step goal.
 class _ActivityDetail extends StatelessWidget {
   const _ActivityDetail();
   @override
@@ -141,18 +143,20 @@ class _ActivityDetail extends StatelessWidget {
           Container(
             padding: const EdgeInsets.all(9),
             decoration: BoxDecoration(
-                color: AppColors.coral.withValues(alpha: 0.14),
+                color: AppColors.good.withValues(alpha: 0.14),
                 borderRadius: BorderRadius.circular(R.chip)),
-            child: AppIcon(Ic.strain, size: 18, color: AppColors.coral),
+            child: AppIcon(Ic.run, size: 18, color: AppColors.good),
           ),
           const SizedBox(width: Sp.x3),
           Expanded(
               child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-            Text('Active minutes', style: AppText.label),
+            Text('Steps (estimated)', style: AppText.label),
             const SizedBox(height: 2),
             Text(
-                'Minutes you were moving, from wrist motion. Step counts need '
-                'high-rate motion — available only during live workouts.',
+                'Your all-day step count is estimated from walking minutes — the '
+                'band\'s background sensor samples too slowly to count each step. '
+                'Walk with the app open and it counts real steps and learns your '
+                'cadence, so the daily estimate keeps getting more accurate.',
                 style: AppText.captionMuted),
           ])),
         ]),

--- a/lib/ui/today/today_screen.dart
+++ b/lib/ui/today/today_screen.dart
@@ -297,12 +297,12 @@ class _TodayScreenState extends State<TodayScreen>
       _statRow(
         StatTile(
           icon: Ic.run,
-          label: 'Active',
-          value: t.steps.isEmpty ? null : '${t.steps.value!.round()}m',
+          label: 'Steps',
+          value: t.steps.isEmpty ? null : '${t.steps.value!.round()}',
           accent: AppColors.good,
           confidence: t.steps.isEmpty ? null : t.steps.confidence,
           tag: Tag.forMetric(t.steps),
-          // Active-minutes trend (Today/Week/Month/3M) + step-goal setter inside.
+          // 24/7 step ESTIMATE trend + active-minutes + step-goal setter inside.
           onTap: () => _push(() => const ActivityScreen()),
         ),
         StatTile(

--- a/lib/ui/workouts/workouts_screen.dart
+++ b/lib/ui/workouts/workouts_screen.dart
@@ -589,6 +589,10 @@ class _WorkoutDetailBodyState extends State<_WorkoutDetailBody> {
             _heroStat(noData ? '—' : '${d['max_hr'] ?? '—'}', 'max bpm'),
             _heroStat(noData ? '—' : '${d['min_hr'] ?? '—'}', 'min bpm'),
             _heroStat('${d['calories'] ?? 0}', 'kcal'),
+            // Steps are recorded only for manual workouts ridden by the live
+            // 100 Hz stream; older/auto sessions have none.
+            if ((d['steps'] as num?) != null && (d['steps'] as num) > 0)
+              _heroStat('${d['steps']}', 'steps'),
           ]),
         ]),
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.0.1"
+  android_intent_plus:
+    dependency: "direct main"
+    description:
+      name: android_intent_plus
+      sha256: "2329378af63f49b985cb2e110ac784d08374f1e2b1984be77ba9325b1c8cce11"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.3.1"
   archive:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  carp_serializable:
+    dependency: transitive
+    description:
+      name: carp_serializable
+      sha256: f039f8ea22e9437aef13fe7e9743c3761c76d401288dcb702eadd273c3e4dcef
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   characters:
     dependency: transitive
     description:
@@ -161,6 +169,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.14"
+  device_info_plus:
+    dependency: transitive
+    description:
+      name: device_info_plus
+      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.2"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.3"
   equatable:
     dependency: transitive
     description:
@@ -424,6 +448,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.7"
+  health:
+    dependency: "direct main"
+    description:
+      name: health
+      sha256: "148ce984c2119f50224b4d187552d751b91aa47f4de8968daf05e6e596ddee50"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.1.1"
   home_widget:
     dependency: "direct main"
     description:
@@ -488,6 +520,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -1251,6 +1291,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "21ec76dfc731550fd3e2ce7a33a9ea90b828fdf19a5c3bcf556fa992cfa99852"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.5"
   workmanager:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,9 @@ dependencies:
   # Apple Health (HealthKit, iOS) + Google Health Connect (Android) — export each
   # day's derived metrics to the platform health store.
   health: ^11.1.1
+  # Open the Health Connect app/settings so the user can grant per-app access
+  # manually (the reliable path when its in-app request dialog is locked out).
+  android_intent_plus: ^5.1.0
 
   # Home/lock-screen widget bridge (writes a snapshot to the App Group → WidgetKit).
   home_widget: ^0.6.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,10 @@ dependencies:
   # File picker for data imports (NOOP raw CSV, Edge .db backup, WHOOP export CSV).
   file_picker: ^8.1.6
 
+  # Apple Health (HealthKit, iOS) + Google Health Connect (Android) — export each
+  # day's derived metrics to the platform health store.
+  health: ^11.1.1
+
   # Home/lock-screen widget bridge (writes a snapshot to the App Group → WidgetKit).
   home_widget: ^0.6.0
 


### PR DESCRIPTION
This pull request adds support for exporting health data to Google Health Connect on Android and Apple Health on iOS, and introduces 24/7 step and total daily energy (TDEE) estimation to the analytics pipeline. It also updates the Android and iOS app manifests and permissions, changes the minimum Android SDK requirement, and improves the database schema to support step counts in workout sessions and personal step-cadence calibration.

**Health Connect and Apple Health integration:**

* [`android/app/src/main/AndroidManifest.xml`](diffhunk://#diff-63272c98a6330850888e633b43ba4c9decee6431a115e0d2731564838eaa1d1dR30-R51): Adds all required Health Connect permissions for reading and writing health metrics, new intent filters for permission rationale, and app discovery for Google Health Connect. [[1]](diffhunk://#diff-63272c98a6330850888e633b43ba4c9decee6431a115e0d2731564838eaa1d1dR30-R51) [[2]](diffhunk://#diff-63272c98a6330850888e633b43ba4c9decee6431a115e0d2731564838eaa1d1dR79-R96) [[3]](diffhunk://#diff-63272c98a6330850888e633b43ba4c9decee6431a115e0d2731564838eaa1d1dR165-R166)
* `ios/Runner/Info.plist`, `ios/Runner/Runner.entitlements`: Adds usage descriptions and HealthKit entitlements for reading and writing health data on iOS. [[1]](diffhunk://#diff-13a4d9d8e1fcf0ee1bd48f8728d2b8fbb885f9cca317e047a515d06552458b9fR39-R42) [[2]](diffhunk://#diff-07728c3971548b909a0b16d492a7f2ec97d7a29b59fbd600f14e8cde7c693d28R9-R12)
* [`android/app/build.gradle.kts`](diffhunk://#diff-852897104c5cf350a945bb63cd9836c04ab5209a74900a1e8938092f6b9d68fbL45-R45): Increases `minSdk` to 26, as required by Health Connect.
* [`android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/MainActivity.kt`](diffhunk://#diff-996fb9ab4895e2edb2763785b4f2a96b13e4d3260155a43ae22e16d50500562bL3-R3): Switches to `FlutterFragmentActivity` to support the Health Connect plugin's permission flow. [[1]](diffhunk://#diff-996fb9ab4895e2edb2763785b4f2a96b13e4d3260155a43ae22e16d50500562bL3-R3) [[2]](diffhunk://#diff-996fb9ab4895e2edb2763785b4f2a96b13e4d3260155a43ae22e16d50500562bR14-R19)

**Step and energy estimation (analytics):**

* [`lib/compute/derivation_engine.dart`](diffhunk://#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6L105-R111): Bumps the analytics algorithm version, adds a new `_stepsAndEnergy` method for 24/7 step estimation (using ambulatory minutes × personalized cadence) and TDEE calculation, and threads personal step-cadence calibration into the derivation pipeline. [[1]](diffhunk://#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6L105-R111) [[2]](diffhunk://#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6R197-R205) [[3]](diffhunk://#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6R286-R287) [[4]](diffhunk://#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6L285-R297) [[5]](diffhunk://#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6R376-R382) [[6]](diffhunk://#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6L389-R403) [[7]](diffhunk://#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6R480-R488) [[8]](diffhunk://#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6R561-R563)

**Database schema and calibration:**

* [`lib/data/db.dart`](diffhunk://#diff-b96f416000a07a912224053a34f440c27993e014d324d6ae8c9dfe88bb0617e6R13): Increases the database version, adds a `steps` column to the `sessions` table, and implements persistent storage for personal step-cadence calibration. [[1]](diffhunk://#diff-b96f416000a07a912224053a34f440c27993e014d324d6ae8c9dfe88bb0617e6R13) [[2]](diffhunk://#diff-b96f416000a07a912224053a34f440c27993e014d324d6ae8c9dfe88bb0617e6R131-R137) [[3]](diffhunk://#diff-b96f416000a07a912224053a34f440c27993e014d324d6ae8c9dfe88bb0617e6R359) [[4]](diffhunk://#diff-b96f416000a07a912224053a34f440c27993e014d324d6ae8c9dfe88bb0617e6R978-R1001)
* [`lib/data/local_repository_impl.dart`](diffhunk://#diff-da6b8e6c3188825ab7c7d364093ccefbd9e40a284244154fdbffd372214f6352L202-R210): Surfaces new `steps` and `calories_total` estimates as top-level metrics.

These changes enable richer health data export and more accurate daily activity metrics across Android and iOS.