### PR TITLE
feat(v25): irregular-rhythm + HRR + BRV + auto-workout + coach read-only SQL

### DIFF
--- a/lib/coach/coach_db.dart
+++ b/lib/coach/coach_db.dart
@@ -1,0 +1,171 @@
+// CoachDb — a READ-ONLY SQL layer the AI coach queries directly.
+//
+// The model emits raw SELECTs; we execute them against a SEPARATE read-only
+// handle, over DERIVED-only views (v_metric/v_daily/v_series/v_hypnogram/
+// v_sessions/v_baselines/v_insights — created by LocalDb._ensureCoachViews).
+//
+// Two layers of safety, both fail-closed:
+//   1. guardAndPrepare() — a static validator: SELECT/WITH only, single
+//      statement, no comments, no DML/DDL/PRAGMA, every FROM/JOIN target must be
+//      an allow-listed view, no base/raw table name anywhere, auto-LIMIT.
+//   2. A read-only Database handle (openDatabase readOnly:true) — even if the
+//      guard were bypassed, SQLite physically refuses writes/DDL, and raw byte
+//      tables are blocked by the guard's identifier allow-list.
+
+import 'dart:convert';
+import 'package:path/path.dart' as p;
+import 'package:sqflite/sqflite.dart';
+
+import '../data/db.dart';
+
+/// Thrown by [CoachDb.guardAndPrepare] when a query is rejected. The reason is
+/// surfaced back to the model so it can self-correct.
+class SqlGuardError implements Exception {
+  final String reason;
+  SqlGuardError(this.reason);
+  @override
+  String toString() => reason;
+}
+
+class CoachDb {
+  CoachDb._();
+
+  /// The only tables the coach may read — derived, never raw.
+  static const Set<String> allowedViews = {
+    'v_metric',
+    'v_daily',
+    'v_series',
+    'v_hypnogram',
+    'v_sessions',
+    'v_baselines',
+    'v_insights',
+  };
+
+  // Keywords that must never appear as standalone tokens (anything mutating or
+  // schema-touching). SELECT/WITH/FROM/JOIN/WHERE/etc. are fine and not listed.
+  static const Set<String> _banned = {
+    'insert', 'update', 'delete', 'drop', 'alter', 'create', 'replace',
+    'truncate', 'attach', 'detach', 'pragma', 'vacuum', 'reindex', 'analyze',
+    'begin', 'commit', 'rollback', 'savepoint', 'grant', 'revoke', 'trigger',
+    'into', 'load_extension',
+  };
+
+  // Base/raw table names that must NOT appear anywhere (force the views).
+  static const Set<String> _denyTables = {
+    'raw_records', 'decoded_onehz', 'decoded_rr', 'samples', 'sqlite_master',
+    'day_result', 'metric_series', 'baselines', 'sessions', 'notifications',
+    'derived_day', 'events', 'band_events', 'band_battery', 'live_coverage',
+    'sync_ledger', 'sync_quarantine', 'sync_cursor', 'compute_jobs',
+    'compute_freshness', 'journal', 'cycle_log', 'cycle_symptom',
+    'primitive_artifacts', 'wake_day_features', 'workout_suggestions',
+  };
+
+  static Database? _ro;
+
+  /// Open (and cache) a read-only handle. Ensures the RW handle first so the
+  /// views exist (a read-only handle can't CREATE VIEW).
+  static Future<Database> _readonly() async {
+    if (_ro != null) return _ro!;
+    await LocalDb.instance; // creates/repairs schema + views on the RW handle
+    final dir = await getDatabasesPath();
+    _ro = await openDatabase(p.join(dir, LocalDb.dbName), readOnly: true);
+    return _ro!;
+  }
+
+  static Future<void> close() async {
+    await _ro?.close();
+    _ro = null;
+  }
+
+  /// Validate + normalize an LLM-supplied SELECT. Throws [SqlGuardError] on any
+  /// rejection. Returns the (possibly LIMIT-appended) query to execute.
+  static String guardAndPrepare(String raw, {int rowCap = 200}) {
+    var s = raw.trim();
+    if (s.isEmpty) throw SqlGuardError('Empty query.');
+
+    // (a) No comments (they can hide payloads).
+    if (s.contains('--') || s.contains('/*') || s.contains('*/')) {
+      throw SqlGuardError('Comments are not allowed.');
+    }
+    // (b) Single statement — strip one optional trailing ';', reject any inner.
+    var body = s.endsWith(';') ? s.substring(0, s.length - 1).trim() : s;
+    if (body.contains(';')) {
+      throw SqlGuardError('Only one statement is allowed.');
+    }
+    // (c) Must start with SELECT or WITH.
+    final lower = body.toLowerCase();
+    if (!(lower.startsWith('select') || lower.startsWith('with'))) {
+      throw SqlGuardError('Query must start with SELECT or WITH.');
+    }
+    // (d) Tokenize; reject any banned keyword + collect identifiers.
+    final tokens = RegExp(r'[A-Za-z_][A-Za-z0-9_]*')
+        .allMatches(lower)
+        .map((m) => m.group(0)!)
+        .toList();
+    for (final t in tokens) {
+      if (_banned.contains(t)) throw SqlGuardError('Disallowed keyword: $t');
+      if (_denyTables.contains(t)) throw SqlGuardError('Table not allowed: $t');
+    }
+    // (e) CTE names declared via WITH … AS ( become valid FROM targets.
+    final cte = <String>{};
+    for (final m in RegExp(r'(?:with|,)\s+([A-Za-z_][A-Za-z0-9_]*)\s+as\s*\(',
+            caseSensitive: false)
+        .allMatches(lower)) {
+      cte.add(m.group(1)!);
+    }
+    // (f) Every FROM/JOIN target must be an allowed view (or a CTE name).
+    final refRe = RegExp(r'\b(?:from|join)\s+("?)([A-Za-z_][A-Za-z0-9_.]*)\1',
+        caseSensitive: false);
+    final refs = <String>[];
+    for (final m in refRe.allMatches(lower)) {
+      final id = m.group(2)!;
+      if (id.contains('.')) {
+        throw SqlGuardError('Schema-qualified names are not allowed: $id');
+      }
+      refs.add(id);
+    }
+    if (refs.isEmpty) throw SqlGuardError('No table reference found.');
+    for (final r in refs) {
+      if (!allowedViews.contains(r) && !cte.contains(r)) {
+        throw SqlGuardError(
+            'Table "$r" is not queryable. Allowed views: ${allowedViews.join(', ')}.');
+      }
+    }
+    // (g) Auto-append a LIMIT to protect context.
+    if (!RegExp(r'\blimit\b', caseSensitive: false).hasMatch(lower)) {
+      body = '$body LIMIT $rowCap';
+    }
+    return body;
+  }
+
+  /// Run an LLM SELECT and return compact JSON for the tool result. On a guard
+  /// rejection, returns the reason (so the model fixes its query) — never throws.
+  static Future<String> runCoachSql(String llmSql, {int rowCap = 200}) async {
+    String sql;
+    try {
+      sql = guardAndPrepare(llmSql, rowCap: rowCap);
+    } on SqlGuardError catch (e) {
+      return jsonEncode({'error': e.reason});
+    }
+    try {
+      final db = await _readonly();
+      final rows = await db.rawQuery(sql);
+      final shown = rows.take(rowCap).toList();
+      final out = <String, dynamic>{
+        'columns': shown.isEmpty ? <String>[] : shown.first.keys.toList(),
+        'rows': shown,
+        'row_count': shown.length,
+      };
+      if (rows.length > rowCap) {
+        out['note'] = 'Truncated to $rowCap of ${rows.length}+ rows. Add a '
+            'tighter WHERE or aggregate (AVG/MIN/MAX/COUNT) instead of selecting '
+            'all rows.';
+      }
+      var s = jsonEncode(out);
+      if (s.length > 16000) s = '${s.substring(0, 16000)}…(truncated)';
+      return s;
+    } catch (e) {
+      return jsonEncode({'error': 'Query failed: $e'});
+    }
+  }
+}

--- a/lib/coach/coach_engine.dart
+++ b/lib/coach/coach_engine.dart
@@ -19,6 +19,7 @@ import 'package:path_provider/path_provider.dart';
 
 import '../data/local_repository.dart';
 import 'coach_config.dart';
+import 'coach_db.dart';
 import 'coach_prompt.dart';
 
 // ── value types ──────────────────────────────────────────────────────────────
@@ -107,24 +108,31 @@ class ActionRequest {
 }
 
 /// One rendered chat item.
-enum CoachItemKind { user, assistant, chart, error }
+enum CoachItemKind { user, assistant, chart, render, error }
 
 class CoachItem {
   final CoachItemKind kind;
   final String? text;
   final ChartSpec? chart;
-  CoachItem.user(this.text) : kind = CoachItemKind.user, chart = null;
-  CoachItem.assistant(this.text) : kind = CoachItemKind.assistant, chart = null;
-  CoachItem.error(this.text) : kind = CoachItemKind.error, chart = null;
-  CoachItem.chart(this.chart) : kind = CoachItemKind.chart, text = null;
+  /// Generic render spec ({type, title?, ...payload}) drawn by [CoachRender].
+  final Map<String, dynamic>? render;
+  CoachItem.user(this.text) : kind = CoachItemKind.user, chart = null, render = null;
+  CoachItem.assistant(this.text) : kind = CoachItemKind.assistant, chart = null, render = null;
+  CoachItem.error(this.text) : kind = CoachItemKind.error, chart = null, render = null;
+  CoachItem.chart(this.chart) : kind = CoachItemKind.chart, text = null, render = null;
+  CoachItem.render(this.render) : kind = CoachItemKind.render, text = null, chart = null;
 
-  Map<String, dynamic> toJson() => {'kind': kind.name, 'text': text, 'chart': chart?.toJson()};
+  Map<String, dynamic> toJson() =>
+      {'kind': kind.name, 'text': text, 'chart': chart?.toJson(), 'render': render};
 
   static CoachItem fromJson(Map<String, dynamic> j) {
     final k = j['kind'];
     if (k == 'chart' && j['chart'] is Map) {
       final c = ChartSpec.tryParse((j['chart'] as Map).cast<String, dynamic>());
       if (c != null) return CoachItem.chart(c);
+    }
+    if (k == 'render' && j['render'] is Map) {
+      return CoachItem.render((j['render'] as Map).cast<String, dynamic>());
     }
     final t = j['text']?.toString();
     if (k == 'user') return CoachItem.user(t);
@@ -442,40 +450,22 @@ class CoachEngine {
   }) async {
     try {
       switch (name) {
-        // reads
-        case 'get_today':
-          return _enc(await api.getToday());
-        case 'get_trend':
-          return _enc(await api.getTrend('${args['metric']}', scale: '${args['scale'] ?? 'week'}'));
-        case 'get_day':
-          return _enc(await _day('${args['kind']}', '${args['date']}'));
-        case 'get_sleep_history':
-          return _enc(await api.getSleep());
-        case 'get_strain_history':
-          return _enc(await api.getStrain());
-        case 'get_sessions':
-          return _enc(await api.getSessions());
-        case 'get_workouts':
-          return _enc(await api.getWorkouts(range: '${args['range'] ?? 'month'}'));
-        case 'get_cycle':
-          return _enc(await api.getCycle());
-        case 'get_journal':
-          return _enc(await api.getJournal(range: '${args['range'] ?? '30d'}'));
-        case 'get_journal_insights':
-          return _enc(await api.getJournalInsights(range: '${args['range'] ?? '90d'}'));
-        case 'get_profile':
-          return _enc(await api.getProfile());
-        case 'get_records':
-          return _enc(await api.getRecords());
-        case 'get_history':
-          return _enc(await api.getHistory(range: '${args['range'] ?? '30d'}'));
+        // data — one read-only SQL tool over the derived views
+        case 'run_sql':
+          return await CoachDb.runCoachSql('${args['sql'] ?? ''}');
 
-        // plot
+        // plot — legacy bar/line/area figure
         case 'plot_chart':
           final spec = ChartSpec.tryParse(args);
           if (spec == null) return 'Could not parse figure; check the schema.';
           onItem(CoachItem.chart(spec));
           return 'Chart rendered for the user.';
+
+        // render — rich typed widget spec ({type, title?, ...payload})
+        case 'render':
+          if (args['type'] == null) return 'render needs a "type" field.';
+          onItem(CoachItem.render(Map<String, dynamic>.from(args)));
+          return 'Rendered "${args['type']}" for the user.';
 
         // actions (confirmed)
         case 'log_journal':
@@ -527,19 +517,6 @@ class CoachEngine {
     return await run();
   }
 
-  Future<Map<String, dynamic>> _day(String kind, String date) {
-    switch (kind) {
-      case 'sleep': return api.getDaySleep(date);
-      case 'strain': return api.getDayStrain(date);
-      case 'stress': return api.getDayStress(date);
-      case 'wear': return api.getDayWear(date);
-      case 'timeline': return api.getDayTimeline(date);
-      case 'lungs': return api.getDayLungs(date);
-      case 'heart':
-      default: return api.getDayHeart(date);
-    }
-  }
-
   String _enc(Object? data) {
     final s = jsonEncode(data);
     return s.length > 16000 ? '${s.substring(0, 16000)}…(truncated)' : s;
@@ -547,17 +524,9 @@ class CoachEngine {
 
   String _statusFor(String name, Map<String, dynamic> args) {
     switch (name) {
-      case 'get_today': return 'Reading today…';
-      case 'get_trend': return 'Pulling ${args['metric']} trend…';
-      case 'get_day': return 'Reading ${args['kind']} for ${args['date']}…';
-      case 'get_sleep_history': return 'Reading sleep history…';
-      case 'get_strain_history': return 'Reading strain history…';
-      case 'get_sessions': return 'Reading workouts…';
-      case 'get_workouts': return 'Reading workouts…';
-      case 'get_cycle': return 'Reading cycle…';
-      case 'get_journal': case 'get_journal_insights': return 'Reading journal…';
-      case 'get_records': return 'Checking your records…';
+      case 'run_sql': return 'Querying your data…';
       case 'plot_chart': return 'Plotting…';
+      case 'render': return 'Rendering ${args['type'] ?? 'figure'}…';
       default: return 'Working…';
     }
   }
@@ -575,26 +544,28 @@ class CoachEngine {
       };
 
   static final List<Map<String, dynamic>> _toolDefs = [
-    _fn('get_today', 'Today\'s snapshot: recovery, strain, sleep, resting HR, steps, readiness, skin-temp/SpO₂ deviations.', {}),
-    _fn('get_trend', 'A metric over time (server-aggregated buckets). Use for "trend/last week/month".', {
-      'metric': {'type': 'string', 'description': 'one of: strain, recovery, resting_hr, hrv, sdnn, lf_hf, hrv_cv, calories, steps, wear, readiness, vo2max, fitness, fatigue, form, monotony, acwr, dip, efficiency, deep, rem, light, regularity, resp, sleep, stress, skin_temp, spo2'},
-      'scale': {'type': 'string', 'enum': ['week', 'month', 'quarter']},
-    }, ['metric']),
-    _fn('get_day', 'Detailed data for one day & domain.', {
-      'kind': {'type': 'string', 'enum': ['heart', 'sleep', 'strain', 'stress', 'wear', 'timeline', 'lungs']},
-      'date': {'type': 'string', 'description': 'YYYY-MM-DD'},
-    }, ['kind', 'date']),
-    _fn('get_sleep_history', 'Recent nightly sleep rows.', {}),
-    _fn('get_strain_history', 'Recent daily strain rows.', {}),
-    _fn('get_sessions', 'Recent detected/auto workouts.', {}),
-    _fn('get_workouts', 'Workouts over a range.', {'range': {'type': 'string', 'enum': ['week', 'month', 'quarter']}}),
-    _fn('get_cycle', 'Menstrual cycle status + prediction (if the user enabled tracking).', {}),
-    _fn('get_journal', 'Behavior-tag journal entries.', {'range': {'type': 'string'}}),
-    _fn('get_journal_insights', 'How tags correlate with the user\'s own metrics.', {'range': {'type': 'string'}}),
-    _fn('get_profile', 'Profile: age, sex, height, weight, step goal.', {}),
-    _fn('get_records', 'Personal records & streaks.', {}),
-    _fn('get_history', 'Compact multi-metric history.', {'range': {'type': 'string'}}),
-    _fn('plot_chart', 'Render a chart for the user from data you fetched. Build the figure yourself.', {
+    _fn('run_sql',
+        'Read your health data by running ONE read-only SQLite SELECT over the '
+        'derived views. Views & columns: '
+        'v_metric(date,key,value); '
+        'v_daily(date,resting_hr,hrv,sdnn,readiness,strain,resp_rate,stress,'
+        'sleep_efficiency,sleep_min,deep_min,rem_min,light_min,nap_min,steps,'
+        'active_calories,total_calories,skin_temp_z,lf_hf,hrv_cv,dip_pct,'
+        'odi_per_hour,worn_min,hrr_bpm,brv_cv,irregular_flag); '
+        'v_series(date,series,t,v) — series ∈ hr_curve,strain_curve,hrv_timeline,'
+        'hrv_day,resp_day,skin_temp_day,zone_timeline,activity_curve; ALWAYS filter '
+        'WHERE date=\'YYYY-MM-DD\' AND series=\'…\'; '
+        'v_hypnogram(date,start_ts,end_ts,stage); '
+        'v_sessions(id,start_ts,end_ts,type,status,calories,strain,max_hr,'
+        'duration_min,steps,hrr_bpm,source,zone_min_json); '
+        'v_baselines(key,value,mean,z,delta,ratio,n,updated_at); '
+        'v_insights(id,kind,title,body,date,created_at,read). '
+        'Read-only, derived only — no other tables. Dates are \'YYYY-MM-DD\'; '
+        'timestamps are epoch seconds. Prefer aggregates (AVG/MIN/MAX/COUNT) over '
+        'SELECT *. Results are capped at 200 rows.',
+        {'sql': {'type': 'string', 'description': 'a single SELECT statement'}},
+        ['sql']),
+    _fn('plot_chart', 'Render a simple chart from data you fetched (bar/line/area). Build the figure yourself.', {
       'type': {'type': 'string', 'enum': ['bar', 'line', 'area']},
       'title': {'type': 'string'},
       'x_labels': {'type': 'array', 'items': {'type': 'string'}},
@@ -605,6 +576,22 @@ class CoachEngine {
       'unit': {'type': 'string'},
       'note': {'type': 'string'},
     }, ['type', 'x_labels', 'series']),
+    _fn('render',
+        'Render a RICH figure from data you fetched. Pick a "type" and provide its '
+        'payload. Types: line/area/bar/multi_series {x_labels,series:[{name,values}],unit}; '
+        'scatter {points:[{x,y,label?}],x_label,y_label}; '
+        'dual_axis {x_labels,left:{name,values,unit},right:{name,values,unit}}; '
+        'stacked_zone_bar {x_labels,zones:[{name,values}]}; '
+        'hypnogram {segments:[{start,end,stage}]} (stage∈wake|light|deep|rem, epoch sec); '
+        'kpi_grid {cards:[{label,value,unit?,delta?,baseline?,spark?:[n]}]}; '
+        'gauge {value,min?,max?,label?,unit?}; '
+        'heatmap {rows:[label],cols:[label],values:[[n]],unit?}; '
+        'range_band {label,value,min,max,unit?}; '
+        'table {columns:[..],rows:[[..]]}. Always include a "title".',
+        {
+          'type': {'type': 'string'},
+          'title': {'type': 'string'},
+        }, ['type']),
     _fn('log_journal', 'Log a journal entry (asks the user to confirm).', {
       'date': {'type': 'string'}, 'tags': {'type': 'array', 'items': {'type': 'string'}}, 'note': {'type': 'string'},
     }, ['date']),

--- a/lib/coach/coach_prompt.dart
+++ b/lib/coach/coach_prompt.dart
@@ -31,27 +31,51 @@ metric in your data." Do not partially comply (no code snippets, no exceptions).
 - Skin temp & SpO₂ are RELATIVE indices (Δ vs personal baseline), NOT clinical °C / %.
 - Steps: AN-2554 estimate. Cycle: log-anchored calendar method (only if user enabled it).
 
-# TOOLS — you MUST fetch before you answer. Never state a number you didn't fetch.
-Read tools (call freely, in parallel when useful):
-- get_today() — today's recovery, strain, sleep, resting HR, steps, readiness, skin-temp/SpO₂ Δ.
-- get_trend(metric, scale) — server-bucketed history. scale ∈ week|month|quarter.
-    metric ∈ strain, recovery, resting_hr, hrv, sdnn, lf_hf, hrv_cv, calories, steps, wear,
-    readiness, vo2max, fitness, fatigue, form, monotony, acwr, dip, efficiency, deep, rem,
-    light, regularity, resp, sleep, stress, skin_temp, spo2.
-- get_day(kind, date) — one day, kind ∈ heart|sleep|strain|stress|wear|timeline|lungs; date=YYYY-MM-DD.
-- get_sleep_history(), get_strain_history(), get_sessions(), get_workouts(range).
-- get_cycle() — menstrual cycle (returns enabled:false if the user hasn't opted in; respect that).
-- get_journal(range), get_journal_insights(range) — behavior tags & their correlations.
-- get_profile(), get_records() (PRs/streaks), get_history(range).
+# DATA — you MUST query before you answer. Never state a number you didn't fetch.
+You have ONE data tool: run_sql(sql). It runs a single READ-ONLY SQLite SELECT over
+the user's DERIVED data (raw signals are intentionally unavailable). Tables are VIEWS:
 
-Plot tool — call to SHOW data you fetched (the app animates it):
-- plot_chart(type, title, x_labels, series, unit, note)
-    type ∈ bar|line|area. x_labels: string[]. series: [{name, values:number[]}].
-    values MUST be PLAIN NUMBERS (e.g. 62, not "62 ms"), one per x_label, in the same order;
-    use null only for a genuine gap. For trends/comparisons plot the FULL series of points
-    (one per day/bucket) — never collapse a series to a single averaged point. Use line/area for
-    time-series, bar for one value per category. Build the figure from fetched data (you may
-    combine series, e.g. RMSSD vs resting HR).
+- v_metric(date, key, value) — every daily scalar, long form. Keys include: rhr, rmssd,
+    sdnn, readiness, strain, trimp, strain_effort, resp_rate, brv_cv, stress, spo2,
+    odi_per_hour, dip_pct, lf_hf, hrv_cv, skin_temp_z, calories, calories_total, steps,
+    nap_min, tst_min, deep_min, rem_min, light_min, efficiency, worn_min, hrr_bpm,
+    irregular_rhythm_flag. (Use this for arbitrary keys / trends.)
+- v_daily(date, resting_hr, hrv, sdnn, readiness, strain, resp_rate, stress, sleep_efficiency,
+    sleep_min, deep_min, rem_min, light_min, nap_min, steps, active_calories, total_calories,
+    skin_temp_z, lf_hf, hrv_cv, dip_pct, odi_per_hour, worn_min, hrr_bpm, brv_cv, irregular_flag)
+    — one row per day; the convenient wide view for most questions.
+- v_series(date, series, t, v) — intra-day curves. series ∈ hr_curve, strain_curve, hrv_timeline,
+    hrv_day, resp_day, skin_temp_day, zone_timeline, activity_curve. t = epoch seconds, v = value.
+    ALWAYS filter `WHERE date='YYYY-MM-DD' AND series='…'` (it is large — never SELECT * from it).
+- v_hypnogram(date, start_ts, end_ts, stage) — sleep stage segments (stage: wake|light|deep|rem).
+- v_sessions(id, start_ts, end_ts, type, status, calories, strain, max_hr, duration_min, steps,
+    hrr_bpm, source, zone_min_json) — workouts (manual/live/auto).
+- v_baselines(key, value, mean, z, delta, ratio, n, updated_at) — rolling personal baselines.
+- v_insights(id, kind, title, body, date, created_at, read) — the local insight/alert feed.
+
+Rules: SELECT only, derived views only (no raw/base tables), dates are 'YYYY-MM-DD', timestamps
+are epoch SECONDS, irregular_flag/irregular_rhythm_flag are 1/0. Prefer aggregates
+(AVG/MIN/MAX/COUNT, GROUP BY) over selecting many rows; results cap at 200 rows. If a query is
+rejected, read the error and fix it. Examples:
+  SELECT date, resting_hr, hrv, readiness FROM v_daily ORDER BY date DESC LIMIT 30
+  SELECT AVG(strain) FROM v_daily WHERE date >= '2026-06-01'
+  SELECT t, v FROM v_series WHERE date='2026-06-29' AND series='hr_curve' ORDER BY t
+
+# SHOWING DATA — prefer a chart/figure over a Markdown table for multi-point data.
+- plot_chart(type, title, x_labels, series, unit, note): simple bar|line|area. series:[{name,values:number[]}],
+    plain numbers (62, not "62 ms"), one per x_label, null only for a real gap. Plot the FULL series.
+- render(type, title, …payload): RICH figures. Pick the type that fits:
+    • line/area/bar/multi_series — {x_labels, series:[{name, values}], unit}
+    • scatter — {points:[{x,y,label?}], x_label, y_label}   (e.g. strain vs next-day recovery)
+    • dual_axis — {x_labels, left:{name,values,unit}, right:{name,values,unit}}  (e.g. HR vs HRV)
+    • stacked_zone_bar — {x_labels, zones:[{name, values}]}  (HR-zone minutes per day)
+    • hypnogram — {segments:[{start,end,stage}]}  (stage∈wake|light|deep|rem, epoch sec)
+    • kpi_grid — {cards:[{label, value, unit?, delta?, baseline?, spark?:[numbers]}]}
+    • gauge — {value, min?, max?, label?, unit?}  (e.g. recovery 0–100)
+    • heatmap — {rows:[labels], cols:[labels], values:[[numbers]], unit?}
+    • range_band — {label, value, min, max, unit?}  (a value against a target band)
+    • table — {columns:[…], rows:[[…]]}
+  Build figures ONLY from data you fetched via run_sql.
 
 Action tools — the app ASKS THE USER TO CONFIRM before any write. Only when clearly requested:
 - log_journal(date, tags, note), log_period(date), start_workout(type), end_workout(workout_id),
@@ -59,7 +83,7 @@ Action tools — the app ASKS THE USER TO CONFIRM before any write. Only when cl
 
 # OUTPUT FORMAT (strict — the app renders Markdown)
 - Be CONCISE. Lead with the direct answer in 1–2 sentences, then brief support.
-- For ANY multi-day / time-series / comparison, call plot_chart INSTEAD of a big table.
+- For ANY multi-day / time-series / comparison, call plot_chart or render INSTEAD of a big table.
   Use a small Markdown table only for ≤4 rows of non-time data.
 - Bold the key numbers. Cite the metric and day/period ("**62 ms** last night vs your **71 ms** baseline").
 - Keep structure light: at most ONE short "##" heading; do NOT use horizontal rules (---) or

--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -107,7 +107,13 @@ import 'substrate.dart';
 // v24: picks up the analytics sleep-algorithm rewrite (multi-session detection +
 // bridging + main-session pick via AdvancedSleepStager). Bumping re-derives
 // non-finalized days so past nights restage; "Re-analyze data" restages all.
-const int kAlgoVersion = 24;
+// v25: 24/7 irregular-rhythm SCREEN (day-span RR → `irregular_rhythm_flag` +
+// notification), heart-rate recovery (HRR) per auto-detected bout → `hrr_bpm`,
+// breathing-rate variability (`brv_cv`/`brv_slope`), opt-in auto-workout
+// SUGGESTIONS (workout_suggestions table + notification), and low-confidence
+// WRIST ORIENTATION during sleep (NOT body position). Bumping re-derives
+// non-finalized days; "Re-analyze data" restages all.
+const int kAlgoVersion = 25;
 
 /// Raw is kept this many days past derivation, then pruned (derived stays).
 const int rawRetentionDays = 14;
@@ -929,6 +935,8 @@ class DerivationEngine {
       date: day.date,
       dayTsSec: daySub.tsSec,
       dayHr: daySub.hr,
+      dayRrTsMs: daySub.rrTsMs,
+      dayRrMs: daySub.rrMs,
       sleepTsSec: sleepSub.tsSec,
       sleepHr: sleepSub.hr,
       sleepRrTsMs: sleepSub.rrTsMs,
@@ -1020,6 +1028,17 @@ class DerivationEngine {
     // in once high-rate accel features exist.
     bundle['detected_workouts'] = await _detectedWorkouts(daySub, day, profile);
 
+    // ── AUTO-WORKOUT SUGGESTIONS + HRR (opt-in detector over day HR+motion) ──
+    // One pass of the opt-in detector serves two features: (1) persisted "did you
+    // work out?" suggestions + a recent-day notification, and (2) heart-rate
+    // recovery (HRR) per bout → `hrr_bpm` scalar. scMap writes through to
+    // bundle['scalars'] (CastMap view), so hrr_bpm reaches the series block below.
+    await _attachWorkoutSuggestionsAndHrr(bundle, scMap, daySub, day, dataNowSec);
+
+    // ── WRIST ORIENTATION during sleep (low-confidence; NOT body position) ───
+    _attachWristOrientation(
+        bundle, daySub, day.sleepOnsetSec, day.sleepOffsetSec);
+
     // ── ADVANCED SLEEP (4-class Cole–Kripke + DoG/percentile stager) ─────────
     // A richer, AASM-style sleep read (SOL / REM-latency / disturbances + a
     // 4-class hypnogram) computed over the day substrate (needs accel, which
@@ -1090,6 +1109,11 @@ class DerivationEngine {
         'hrv_cv': sc('hrv_cv'),
         'efficiency': sc('efficiency'),
         'worn_min': sc('worn_min'),
+        // v25: 24/7 irregular-rhythm screen flag, breathing-rate variability,
+        // and mean heart-rate recovery across the day's detected bouts.
+        'irregular_rhythm_flag': sc('irregular_rhythm_flag'),
+        'brv_cv': sc('brv_cv'),
+        'hrr_bpm': sc('hrr_bpm'),
       },
     );
     history.appendScalars(scalars);
@@ -1267,6 +1291,14 @@ class DerivationEngine {
           'Sustained rise vs your baseline — a possible illness signal.',
           route: '/body',
         );
+      }
+      // 24/7 irregular-rhythm SCREEN (not a diagnosis). Fires at most once/day.
+      final irregFlag = await LocalDb.metricValueOn(date, 'irregular_rhythm_flag');
+      if (irregFlag == 1.0) {
+        await emit('irregular', 'Irregular heart rhythm — screen',
+            'Your beat-to-beat pattern looked irregular today. This is a screen, '
+            'not a diagnosis — see a clinician if you have symptoms.',
+            route: '/heart');
       }
       final score = gb?['value'] is Map ? (gb!['value'] as Map)['score'] : null;
       if (score is num && score < 34) {
@@ -2215,6 +2247,198 @@ class DerivationEngine {
       scMap?['nap_min'] = napMin.toDouble();
     } catch (e) {
       _log('naps FAILED/skipped: $e');
+    }
+  }
+
+  /// Opt-in workout SUGGESTIONS (`autoDetectWorkouts`) + HEART-RATE RECOVERY.
+  ///
+  /// One detector pass over the day's 1 Hz HR (+ gravity motion) serves both: the
+  /// detected bouts become persisted "did you work out?" suggestions (excluding
+  /// any already-saved manual/live session), and each bout's HR tail yields an
+  /// HRR-60s drop whose daily mean → `hrr_bpm`. Suggestions + the notification are
+  /// gated to RECENT days so a re-analyze / import never spams. Best-effort.
+  Future<void> _attachWorkoutSuggestionsAndHrr(
+    Map<String, dynamic> bundle,
+    Map<String, dynamic>? scMap,
+    Substrate s,
+    PreparedDerivationDay day,
+    int dataNowSec,
+  ) async {
+    try {
+      final n = s.length;
+      if (n < 60) return;
+      final hrTs = <int>[];
+      final hrBpm = <int>[];
+      for (var i = 0; i < n; i++) {
+        if (s.hr[i] > 0) {
+          hrTs.add(s.tsSec[i]);
+          hrBpm.add(s.hr[i]);
+        }
+      }
+      if (hrBpm.length < 60) return;
+      final motion =
+          ana.AutoWorkoutDetector.motionPoints(s.tsSec, s.ax, s.ay, s.az);
+      // Exclude windows the user has already logged (manual/live wins).
+      final dayLo = s.tsSec.first;
+      final dayHi = s.tsSec.last + 60;
+      final saved = await LocalDb.sessionsInRange(dayLo, dayHi);
+      final savedSpans = <ana.SavedWorkoutSpan>[
+        for (final r in saved)
+          if (r['start_ts'] is int && r['end_ts'] is int)
+            ana.SavedWorkoutSpan(r['start_ts'] as int, r['end_ts'] as int),
+      ];
+      final rhr = (scMap?['rhr'] as num?)?.round();
+      final detected = ana.autoDetectWorkouts(
+        hrTs: hrTs,
+        hrBpm: hrBpm,
+        restingBpm: rhr,
+        motion: motion,
+        savedSpans: savedSpans,
+      );
+      final bouts = detected.value ?? const [];
+
+      // HRR per bout from the per-second HR tail bracketing each bout end.
+      final drops = <double>[];
+      final boutJson = <Map<String, dynamic>>[];
+      for (final b in bouts) {
+        final m = _hrrForBout(s, b.endSec);
+        if (m != null) drops.add(m);
+        boutJson.add({
+          'start': b.startSec,
+          'end': b.endSec,
+          'avg_bpm': b.avgBpm,
+          'peak_bpm': b.peakBpm,
+          'duration_min': b.durationMin,
+          'sport': b.sport,
+          if (m != null) 'hrr_bpm': double.parse(m.toStringAsFixed(1)),
+        });
+      }
+      // Also fill HRR for already-saved sessions (manual/live) retrospectively
+      // from the substrate around each session's end — so the workout detail
+      // screen shows HRR without buffering 60 s after a live stop.
+      for (final r in saved) {
+        final id = r['id'];
+        final endTs = r['end_ts'];
+        if (id is! String || endTs is! int) continue;
+        final m = _hrrForBout(s, endTs);
+        if (m != null) {
+          drops.add(m);
+          await LocalDb.setSessionHrr(id, double.parse(m.toStringAsFixed(1)));
+        }
+      }
+      if (drops.isNotEmpty) {
+        final mean = drops.reduce((a, c) => a + c) / drops.length;
+        scMap?['hrr_bpm'] = double.parse(mean.toStringAsFixed(1));
+      }
+      bundle['workout_suggestions'] = boutJson;
+
+      // Persist + notify only for RECENT days (≤ ~36 h old) so imports/re-analyze
+      // don't resurface 90 days of prompts.
+      final recent = (dataNowSec - day.endSec) < 36 * 3600;
+      if (recent && bouts.isNotEmpty) {
+        for (final b in bouts) {
+          await LocalDb.putWorkoutSuggestion({
+            'id': '${day.date}:${b.startSec}',
+            'date': day.date,
+            'start_ts': b.startSec,
+            'end_ts': b.endSec,
+            'avg_bpm': b.avgBpm,
+            'peak_bpm': b.peakBpm,
+            'duration_min': b.durationMin,
+            'sport': b.sport,
+            'dismissed': 0,
+            'created_at': DateTime.now().millisecondsSinceEpoch,
+          });
+        }
+        final first = bouts.first;
+        await NotificationCenter.instance.emit(NotificationEvent(
+          dedupeKey: '${day.date}:auto_workout',
+          category: NotifCategory.recovery,
+          priority: NotifPriority.normal,
+          title: 'Did you work out?',
+          body: 'We spotted ~${first.durationMin} min of elevated activity. '
+              'Tap to log it.',
+          date: day.date,
+          route: '/workouts',
+        ));
+      }
+    } catch (e) {
+      _log('auto-workout/HRR FAILED/skipped: $e');
+    }
+  }
+
+  /// HRR-60s for a bout ending at [endSec]: build the per-second HR tail around
+  /// the end index and delegate to [ana.hrRecovery]. Returns the drop (bpm) or null.
+  double? _hrrForBout(Substrate s, int endSec) {
+    final n = s.length;
+    if (n == 0) return null;
+    // Find the index nearest the bout end.
+    var endIdx = -1;
+    for (var i = 0; i < n; i++) {
+      if (s.tsSec[i] >= endSec) {
+        endIdx = i;
+        break;
+      }
+    }
+    if (endIdx < 0) endIdx = n - 1;
+    const pre = 30, post = 75;
+    final lo = (endIdx - pre).clamp(0, n - 1);
+    final hi = (endIdx + post).clamp(0, n - 1);
+    final tail = <int>[for (var i = lo; i <= hi; i++) s.hr[i]];
+    final m = ana.hrRecovery(tail, endIndex: endIdx - lo, recoverySec: 60);
+    return m.present ? m.value!.dropBpm : null;
+  }
+
+  /// Low-confidence WRIST ORIENTATION during the sleep window (`positionSeries`).
+  /// Explicitly a WRIST measure (body-position PROXY), never claimed as the
+  /// sleeper's supine/side/prone body position. Emits a dominant-orientation
+  /// summary + per-position minutes + an orientation-change count. Best-effort.
+  void _attachWristOrientation(
+    Map<String, dynamic> bundle,
+    Substrate s,
+    int onsetSec,
+    int offsetSec,
+  ) {
+    try {
+      if (offsetSec <= onsetSec) return;
+      final epoch = <ana.AccelSample>[
+        for (var i = 0; i < s.length; i++)
+          if (s.tsSec[i] >= onsetSec && s.tsSec[i] < offsetSec)
+            ana.AccelSample(s.tsSec[i] * 1000.0, s.ax[i], s.ay[i], s.az[i])
+      ];
+      if (epoch.length < 60) return;
+      final tilts = ana.positionSeries(epoch, epochSec: 30);
+      if (tilts.isEmpty) return;
+      // Per-position minutes (each epoch ≈ 30 s) + orientation-change count.
+      final mins = <String, double>{};
+      var changes = 0;
+      String? prev;
+      for (final t in tilts) {
+        mins[t.position] = (mins[t.position] ?? 0) + 0.5; // 30 s
+        if (prev != null && prev != t.position) changes++;
+        prev = t.position;
+      }
+      String dominant = 'unknown';
+      var best = -1.0;
+      mins.forEach((k, v) {
+        if (v > best) {
+          best = v;
+          dominant = k;
+        }
+      });
+      bundle['wrist_orientation'] = <String, dynamic>{
+        'dominant': dominant,
+        'minutes': mins,
+        'changes': changes,
+        'epochs': tilts.length,
+        'confidence': 'low',
+        'tier': ana.Tier.relative,
+        'note': 'WRIST orientation during sleep (gravity-tilt). A body-position '
+            'PROXY, NOT supine/side/prone body position — the wrist moves '
+            'independently of the torso.',
+      };
+    } catch (e) {
+      _log('wrist-orientation FAILED/skipped: $e');
     }
   }
 

--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -113,7 +113,11 @@ import 'substrate.dart';
 // SUGGESTIONS (workout_suggestions table + notification), and low-confidence
 // WRIST ORIENTATION during sleep (NOT body position). Bumping re-derives
 // non-finalized days; "Re-analyze data" restages all.
-const int kAlgoVersion = 25;
+// v26: integration bump — the oxygen/workout PR externalized active-calorie
+// compute to `Calories.activeEnergy` (Keytel + height term) without a version
+// bump; combined with the v25 features above, bump so finalized days recompute
+// onto the new calorie formula instead of silently carrying the old values.
+const int kAlgoVersion = 26;
 
 /// Raw is kept this many days past derivation, then pruned (derived stays).
 const int rawRetentionDays = 14;

--- a/lib/compute/onehz_pipeline.dart
+++ b/lib/compute/onehz_pipeline.dart
@@ -385,7 +385,7 @@ Map<String, dynamic> deriveDayBundle(Map<String, dynamic> inputJson) {
     }
     hrZones = _wakeZoneMinutesFromSeries(wakeHr, hrMax);
     if (age != null && sex != null && weightKg != null) {
-      caloriesKcal = Calories.activeEnergy(
+      caloriesKcal = Calories.dailyEnergy(
         perMin,
         profile: WorkoutUserProfile(
           weightKg: weightKg,
@@ -394,7 +394,7 @@ Map<String, dynamic> deriveDayBundle(Map<String, dynamic> inputJson) {
           sex: sex == 'f' ? 'female' : (sex == 'm' ? 'male' : 'nonbinary'),
         ),
         hrmax: hrMax,
-      );
+      ).active; // active-energy component (Keytel surplus over basal)
     }
   }
 

--- a/lib/compute/onehz_pipeline.dart
+++ b/lib/compute/onehz_pipeline.dart
@@ -47,6 +47,10 @@ class DayBundleInput {
   // ── DAY span (wake → next wake) 1 Hz substrate ────────────────────────────
   final List<int> dayTsSec;
   final List<int> dayHr; // 0 = off-skin
+  // Day-span RR (beat-end epoch ms + interval ms) for the 24/7 irregular-rhythm
+  // screen. Sparse (0–4 beats/s); empty when no RR was captured.
+  final List<double> dayRrTsMs;
+  final List<double> dayRrMs;
 
   // ── SLEEP window 1 Hz substrate (the window from segmentSleep) ────────────
   final List<int> sleepTsSec;
@@ -90,6 +94,8 @@ class DayBundleInput {
     required this.date,
     required this.dayTsSec,
     required this.dayHr,
+    this.dayRrTsMs = const [],
+    this.dayRrMs = const [],
     required this.sleepTsSec,
     required this.sleepHr,
     required this.sleepRrTsMs,
@@ -115,6 +121,8 @@ class DayBundleInput {
     'date': date,
     'day_ts': dayTsSec,
     'day_hr': dayHr,
+    'day_rr_ts_ms': dayRrTsMs,
+    'day_rr_ms': dayRrMs,
     'sleep_ts': sleepTsSec,
     'sleep_hr': sleepHr,
     'sleep_rr_ts_ms': sleepRrTsMs,
@@ -148,6 +156,8 @@ class DayBundleInput {
       date: m['date'] as String,
       dayTsSec: ints('day_ts'),
       dayHr: ints('day_hr'),
+      dayRrTsMs: dbls('day_rr_ts_ms'),
+      dayRrMs: dbls('day_rr_ms'),
       sleepTsSec: ints('sleep_ts'),
       sleepHr: ints('sleep_hr'),
       sleepRrTsMs: dbls('sleep_rr_ts_ms'),
@@ -265,6 +275,27 @@ Map<String, dynamic> deriveDayBundle(Map<String, dynamic> inputJson) {
       : const Metric<CpcResult>.absent(
           tier: Tier.high,
           inputs_used: ['rr_cleaned'],
+        );
+
+  // ── 24/7 IRREGULAR-RHYTHM SCREEN (day-span RR; not a diagnosis) ────────────
+  // Runs over the WHOLE-DAY cleaned RR (not just sleep) so an arrhythmia screen
+  // isn't limited to the sleep window. Hard-gated on beat count + artifact inside
+  // irregularBeatScreen; returns absent on a thin/noisy day.
+  final dayCorrected = correctRr(d.dayRrMs);
+  final irregular24h = irregularBeatScreen(
+    dayCorrected.nn,
+    artifactFraction: (1.0 - dayCorrected.cleanFraction).clamp(0.0, 1.0),
+  );
+
+  // ── BREATHING-RATE VARIABILITY (per-window RSA over the sleep NN) ──────────
+  // Window the cleaned sleep NN into ~30-min bins, take each bin's RSA resp rate,
+  // then BRV = dispersion + Theil-Sen trend of those per-window rates.
+  final respWindows = _respPerWindow(nn, nnTimes);
+  final brv = respWindows.length >= 3
+      ? breathingRateVariability(respWindows)
+      : const Metric<BrvResult>.absent(
+          tier: Tier.estimate,
+          inputs_used: ['resp_rate_series'],
         );
 
   // Relative ODI over the SLEEP window's spo2 channels (desaturation screen).
@@ -422,6 +453,11 @@ Map<String, dynamic> deriveDayBundle(Map<String, dynamic> inputJson) {
       'flag': irregularFlag,
       'confidence': irregularConf,
     },
+    // 24/7 irregular-rhythm SCREEN over the whole-day RR (the headline screen
+    // that drives the opt-in notification). Sleep-only `irregular` kept above.
+    'irregular_24h': irregular24h.toJson((v) => v.toJson()),
+    // Breathing-rate variability trend (within-user only).
+    'brv': brv.toJson((v) => v.toJson()),
     // Canonical nightly HRV, matching the sleep-session windowed RMSSD
     // aggregation over the chosen sleep session. The robust estimator is
     // retained alongside it as a secondary detail for comparison/debugging.
@@ -751,6 +787,14 @@ Map<String, dynamic> deriveDayBundle(Map<String, dynamic> inputJson) {
       'tst_min': tstSec == null ? null : (tstSec / 60).roundToDouble(),
       'lf_hf': lfhf == null ? null : _round(lfhf, 3),
       'hrv_cv': hrvCv == null ? null : _round(hrvCv, 1),
+      // 24/7 irregular-rhythm screen flag (1/0) → drives trend + notification.
+      'irregular_rhythm_flag':
+          irregular24h.present ? (irregular24h.value!.flag ? 1.0 : 0.0) : null,
+      // Breathing-rate variability (CV) + Theil-Sen trend slope.
+      'brv_cv': brv.present ? _round(brv.value!.cv, 4) : null,
+      'brv_slope': brv.present && brv.value!.trendSlope != null
+          ? _round(brv.value!.trendSlope!, 4)
+          : null,
       // Sleep efficiency % + worn minutes → their own day/week/month/3M trends.
       'efficiency': effPct == null ? null : _round(effPct, 1),
       'worn_min': dayHrValid.isEmpty
@@ -761,6 +805,37 @@ Map<String, dynamic> deriveDayBundle(Map<String, dynamic> inputJson) {
 }
 
 // ── helpers (pure) ───────────────────────────────────────────────────────────
+
+/// Per-window RSA respiratory rates (br/min) for the BRV estimator. Buckets the
+/// cleaned NN into [windowMs] (~30-min) bins by beat time and runs [rsaRespRate]
+/// on each bin with ≥[minBeats] beats; keeps only resolved windows.
+List<double> _respPerWindow(
+  List<double> nn,
+  List<double> nnTimes, {
+  double windowMs = 1800000.0,
+  int minBeats = 60,
+}) {
+  if (nn.isEmpty || nn.length != nnTimes.length) return const [];
+  final t0 = nnTimes.first;
+  final binsNn = <int, List<double>>{};
+  final binsTs = <int, List<double>>{};
+  for (var i = 0; i < nn.length; i++) {
+    final idx = ((nnTimes[i] - t0) / windowMs).floor();
+    (binsNn[idx] ??= <double>[]).add(nn[i]);
+    (binsTs[idx] ??= <double>[]).add(nnTimes[i]);
+  }
+  final out = <double>[];
+  final idxs = binsNn.keys.toList()..sort();
+  for (final idx in idxs) {
+    final segNn = binsNn[idx]!;
+    if (segNn.length < minBeats) continue;
+    // NN is already artifact-corrected upstream → artifactFraction 0.
+    final r = rsaRespRate(segNn, binsTs[idx]!, artifactFraction: 0.0);
+    final b = r.present ? r.value!.brpm : null;
+    if (b != null) out.add(b);
+  }
+  return out;
+}
 
 /// Wrap a value sub-map in the {value,confidence,tier,inputs_used} envelope the
 /// serve seam reads via `.value`. Null inner → honest "—".

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -56,6 +56,8 @@ class LocalDb {
         await _createComputeState(db);
         await _createPrimitiveArtifacts(db);
         await _createLiveCoverage(db);
+        await _createWorkoutSuggestions(db);
+        await _ensureCoachViews(db);
       },
       onUpgrade: (db, oldV, newV) async {
         if (oldV < 2) await _createEvents(db);
@@ -195,11 +197,18 @@ class LocalDb {
           // `date` PK is a period-start marker) so a date can carry both.
           await _createCycleSymptom(db);
         }
+        if (oldV < 19) {
+          // v25 features: HRR per session, opt-in auto-workout suggestions, and
+          // the coach's read-only SQL views over derived data. `hrr_bpm` column +
+          // suggestions table are additive; views are (re)built in _repairOpenSchema.
+          await _ensureSessionSchema(db); // adds hrr_bpm
+          await _createWorkoutSuggestions(db);
+        }
       },
       onOpen: (db) async {
         await _repairOpenSchema(db);
       },
-      version: 18,
+      version: 19,
     );
   }
 
@@ -224,6 +233,10 @@ class LocalDb {
     await _ensureRawRecordSchema(db);
     await _ensureSessionSchema(db);
     await _ensureSyncStateSchema(db);
+    await _createWorkoutSuggestions(db);
+    // Views LAST — they depend on metric_series / day_result / baselines / sessions
+    // / notifications all existing. DROP+CREATE so a shape change takes effect.
+    await _ensureCoachViews(db);
   }
 
   // ── MENSTRUAL SYMPTOM LOG ──────────────────────────────────────────────────
@@ -542,7 +555,24 @@ class LocalDb {
         duration_min INTEGER,
         zone_min_json TEXT,
         steps INTEGER,
+        hrr_bpm REAL,
         source TEXT NOT NULL DEFAULT 'manual',
+        created_at INTEGER NOT NULL
+      )
+    ''');
+    // workout_suggestions — opt-in "did you work out?" auto-detections. Never a
+    // real session until the user confirms; `dismissed` hides a rejected one.
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS workout_suggestions (
+        id TEXT PRIMARY KEY,
+        date TEXT NOT NULL,
+        start_ts INTEGER NOT NULL,
+        end_ts INTEGER NOT NULL,
+        avg_bpm INTEGER,
+        peak_bpm INTEGER,
+        duration_min INTEGER,
+        sport TEXT,
+        dismissed INTEGER NOT NULL DEFAULT 0,
         created_at INTEGER NOT NULL
       )
     ''');
@@ -669,6 +699,169 @@ class LocalDb {
     if (!names.contains('steps')) {
       await db.execute('ALTER TABLE sessions ADD COLUMN steps INTEGER');
     }
+    if (!names.contains('hrr_bpm')) {
+      await db.execute('ALTER TABLE sessions ADD COLUMN hrr_bpm REAL');
+    }
+  }
+
+  // ── WORKOUT SUGGESTIONS (opt-in auto-detect) ───────────────────────────────
+  static Future<void> _createWorkoutSuggestions(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS workout_suggestions (
+        id TEXT PRIMARY KEY,
+        date TEXT NOT NULL,
+        start_ts INTEGER NOT NULL,
+        end_ts INTEGER NOT NULL,
+        avg_bpm INTEGER,
+        peak_bpm INTEGER,
+        duration_min INTEGER,
+        sport TEXT,
+        dismissed INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL
+      )
+    ''');
+  }
+
+  /// Upsert an auto-detected workout suggestion (id = "$date:$startSec").
+  static Future<void> putWorkoutSuggestion(Map<String, dynamic> row) async {
+    final db = await instance;
+    await db.insert('workout_suggestions', row,
+        conflictAlgorithm: ConflictAlgorithm.ignore);
+  }
+
+  /// Active (not-yet-dismissed, not-yet-confirmed) suggestions, newest first.
+  static Future<List<Map<String, dynamic>>> activeWorkoutSuggestions() async {
+    final db = await instance;
+    return db.query('workout_suggestions',
+        where: 'dismissed = 0', orderBy: 'start_ts DESC');
+  }
+
+  static Future<void> dismissWorkoutSuggestion(String id) async {
+    final db = await instance;
+    await db.update('workout_suggestions', {'dismissed': 1},
+        where: 'id = ?', whereArgs: [id]);
+  }
+
+  // ── COACH READ-ONLY SQL VIEWS (derived-only) ───────────────────────────────
+  // Re-created on every open (DROP+CREATE) so a view-shape change takes effect on
+  // upgrade. These flatten DERIVED data only; the coach's read-only SQL layer is
+  // allow-listed to these views and can never reach raw_records / decoded_*.
+  // Every view over day_result selects the LATEST algo_version per day_id.
+  static Future<void> _ensureCoachViews(Database db) async {
+    const views = [
+      'v_metric',
+      'v_daily',
+      'v_series',
+      'v_hypnogram',
+      'v_sessions',
+      'v_baselines',
+      'v_insights',
+    ];
+    for (final v in views) {
+      await db.execute('DROP VIEW IF EXISTS $v');
+    }
+    // Long-form scalar trends — the natural per-metric time series.
+    await db.execute('''
+      CREATE VIEW v_metric AS
+      SELECT date, key, value FROM metric_series
+    ''');
+    // One row per day, common scalars pivoted from metric_series (no JSON path
+    // drift; metric_series is the canonical scalar store).
+    await db.execute('''
+      CREATE VIEW v_daily AS
+      SELECT date,
+        MAX(CASE WHEN key='rhr' THEN value END)            AS resting_hr,
+        MAX(CASE WHEN key='rmssd' THEN value END)          AS hrv,
+        MAX(CASE WHEN key='sdnn' THEN value END)           AS sdnn,
+        MAX(CASE WHEN key='readiness' THEN value END)      AS readiness,
+        MAX(CASE WHEN key='strain' THEN value END)         AS strain,
+        MAX(CASE WHEN key='resp_rate' THEN value END)      AS resp_rate,
+        MAX(CASE WHEN key='stress' THEN value END)         AS stress,
+        MAX(CASE WHEN key='efficiency' THEN value END)     AS sleep_efficiency,
+        MAX(CASE WHEN key='tst_min' THEN value END)        AS sleep_min,
+        MAX(CASE WHEN key='deep_min' THEN value END)       AS deep_min,
+        MAX(CASE WHEN key='rem_min' THEN value END)        AS rem_min,
+        MAX(CASE WHEN key='light_min' THEN value END)      AS light_min,
+        MAX(CASE WHEN key='nap_min' THEN value END)        AS nap_min,
+        MAX(CASE WHEN key='steps' THEN value END)          AS steps,
+        MAX(CASE WHEN key='calories' THEN value END)       AS active_calories,
+        MAX(CASE WHEN key='calories_total' THEN value END) AS total_calories,
+        MAX(CASE WHEN key='skin_temp_z' THEN value END)    AS skin_temp_z,
+        MAX(CASE WHEN key='lf_hf' THEN value END)          AS lf_hf,
+        MAX(CASE WHEN key='hrv_cv' THEN value END)         AS hrv_cv,
+        MAX(CASE WHEN key='dip_pct' THEN value END)        AS dip_pct,
+        MAX(CASE WHEN key='odi_per_hour' THEN value END)   AS odi_per_hour,
+        MAX(CASE WHEN key='worn_min' THEN value END)       AS worn_min,
+        MAX(CASE WHEN key='hrr_bpm' THEN value END)        AS hrr_bpm,
+        MAX(CASE WHEN key='brv_cv' THEN value END)         AS brv_cv,
+        MAX(CASE WHEN key='irregular_rhythm_flag' THEN value END) AS irregular_flag
+      FROM metric_series GROUP BY date
+    ''');
+    // Intra-day curves UNNESTED from the latest day_result bundle. HEAVY — always
+    // filter by date AND series. zone_timeline uses 'z'; activity_curve is root.
+    await db.execute('''
+      CREATE VIEW v_series AS
+      WITH latest AS (
+        SELECT r.day_id, r.payload_json FROM day_result r
+        JOIN (SELECT day_id, MAX(algo_version) v FROM day_result GROUP BY day_id) m
+          ON r.day_id = m.day_id AND r.algo_version = m.v
+      )
+      SELECT l.day_id AS date, s.sk AS series,
+             json_extract(e.value,'\$.t') AS t,
+             json_extract(e.value,'\$.v') AS v
+      FROM latest l
+      JOIN (SELECT 'hr_curve' sk UNION ALL SELECT 'strain_curve'
+            UNION ALL SELECT 'hrv_timeline' UNION ALL SELECT 'hrv_day'
+            UNION ALL SELECT 'resp_day' UNION ALL SELECT 'skin_temp_day') s
+      JOIN json_each(json_extract(l.payload_json,'\$.series.'||s.sk)) e
+      UNION ALL
+      SELECT l.day_id, 'zone_timeline',
+             json_extract(e.value,'\$.t'), json_extract(e.value,'\$.z')
+      FROM latest l, json_each(json_extract(l.payload_json,'\$.series.zone_timeline')) e
+      UNION ALL
+      SELECT l.day_id, 'activity_curve',
+             json_extract(e.value,'\$.t'), json_extract(e.value,'\$.v')
+      FROM latest l, json_each(json_extract(l.payload_json,'\$.activity_curve')) e
+    ''');
+    // Sleep stage segments (different element shape from the {t,v} curves).
+    await db.execute('''
+      CREATE VIEW v_hypnogram AS
+      WITH latest AS (
+        SELECT r.day_id, r.payload_json FROM day_result r
+        JOIN (SELECT day_id, MAX(algo_version) v FROM day_result GROUP BY day_id) m
+          ON r.day_id = m.day_id AND r.algo_version = m.v
+      )
+      SELECT l.day_id AS date,
+             json_extract(e.value,'\$.start') AS start_ts,
+             json_extract(e.value,'\$.end')   AS end_ts,
+             json_extract(e.value,'\$.stage') AS stage
+      FROM latest l, json_each(json_extract(l.payload_json,'\$.series.hypnogram')) e
+    ''');
+    // Workouts (incl. HRR + steps). Passthrough.
+    await db.execute('''
+      CREATE VIEW v_sessions AS
+      SELECT id, start_ts, end_ts, type, status, calories, strain, max_hr,
+             duration_min, steps, hrr_bpm, source, zone_min_json
+      FROM sessions
+    ''');
+    // Rolling personal baselines (json_extract; missing paths return NULL safely).
+    await db.execute('''
+      CREATE VIEW v_baselines AS
+      SELECT key,
+             json_extract(payload_json,'\$.value')           AS value,
+             json_extract(payload_json,'\$.mean')            AS mean,
+             json_extract(payload_json,'\$.z')               AS z,
+             json_extract(payload_json,'\$.delta')           AS delta,
+             json_extract(payload_json,'\$.ratio')           AS ratio,
+             json_extract(payload_json,'\$.n')               AS n,
+             updated_at
+      FROM baselines
+    ''');
+    // Locally-generated insight / notification feed.
+    await db.execute('''
+      CREATE VIEW v_insights AS
+      SELECT id, kind, title, body, date, created_at, read FROM notifications
+    ''');
   }
 
   static Future<void> _ensureSyncCursorSchema(Database db) async {
@@ -2606,6 +2799,14 @@ class LocalDb {
   static Future<void> deleteSession(String id) async {
     final db = await instance;
     await db.delete('sessions', where: 'id = ?', whereArgs: [id]);
+  }
+
+  /// Backfill a session's heart-rate-recovery (bpm), computed retrospectively
+  /// from the 1 Hz substrate around the session's end during derivation.
+  static Future<void> setSessionHrr(String id, double hrrBpm) async {
+    final db = await instance;
+    await db.update('sessions', {'hrr_bpm': hrrBpm},
+        where: 'id = ?', whereArgs: [id]);
   }
 
   static Future<void> setSessionType(String id, String type) async {

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -453,6 +453,12 @@ class LocalRepositoryImpl extends LocalRepository {
       },
       // Poincaré irregular-beat screen (sd1/sd2/flag/confidence).
       'irregular': _sub(b, 'clinical')?['irregular'],
+      // 24/7 irregular-rhythm SCREEN over whole-day RR (the headline screen).
+      'irregular_24h': _sub(b, 'clinical')?['irregular_24h'],
+      // Breathing-rate variability (within-user trend).
+      'brv': _sub(b, 'clinical')?['brv'],
+      // Mean heart-rate recovery across the day's detected/saved bouts (bpm/60s).
+      'hrr': _scalar(b, 'hrr_bpm'),
       // Winsorized-EWMA personal baselines (rhr/hrv/resp/skin_temp) — robust
       // center + spread + z + cold-start status for each.
       'baselines': b['baselines'],
@@ -554,6 +560,9 @@ class LocalRepositoryImpl extends LocalRepository {
       // disturbances + stage minutes + hypnogram. ESTIMATE; the headline stages
       // above stay the single source. {present:false} when none qualifies.
       'advanced': b['advanced_sleep'],
+      // Low-confidence WRIST orientation (gravity-tilt) during sleep — a body-
+      // position PROXY, NOT supine/side/prone body position.
+      'wrist_orientation': b['wrist_orientation'],
     };
   }
 
@@ -1213,6 +1222,10 @@ class LocalRepositoryImpl extends LocalRepository {
         return ('', 'wear'); // minutes; the screen formats as Hh Mm
       case 'skin_temp':
         return ('', 'skin temp'); // relative z vs baseline
+      case 'hrr':
+        return ('bpm', 'HR recovery'); // 60-s post-exercise drop; higher = fitter
+      case 'brv':
+        return ('', 'breathing variability'); // CV of per-window respiratory rate
       default:
         return ('', metric);
     }
@@ -1245,6 +1258,10 @@ class LocalRepositoryImpl extends LocalRepository {
         return 'tst_min';
       case 'dip':
         return 'dip_pct';
+      case 'hrr':
+        return 'hrr_bpm';
+      case 'brv':
+        return 'brv_cv';
       // lf_hf, hrv_cv map to themselves (series keys match).
       default:
         return metric;
@@ -1310,6 +1327,9 @@ class LocalRepositoryImpl extends LocalRepository {
       'calories': (r['calories'] as num?)?.round(),
       'duration_min': (r['duration_min'] as num?)?.toInt(),
       'steps': (r['steps'] as num?)?.toInt(),
+      'max_hr': (r['max_hr'] as num?)?.toInt(),
+      // Heart-rate recovery (bpm drop in 60 s) backfilled during derivation.
+      'hrr60': (r['hrr_bpm'] as num?)?.round(),
       'zone_min': zoneMin,
     };
   }

--- a/lib/ui/coach/ai_coach_screen.dart
+++ b/lib/ui/coach/ai_coach_screen.dart
@@ -13,6 +13,7 @@ import '../../theme/theme.dart';
 import '../../theme/tokens.dart';
 import '../kit/kit.dart';
 import 'coach_chart.dart';
+import 'coach_render.dart';
 import 'coach_settings_screen.dart';
 
 class AiCoachScreen extends StatefulWidget {
@@ -325,6 +326,11 @@ class _AiCoachScreenState extends State<AiCoachScreen> {
         return Padding(
           padding: const EdgeInsets.only(bottom: Sp.x4),
           child: CoachChart(spec: it.chart!),
+        );
+      case CoachItemKind.render:
+        return Padding(
+          padding: const EdgeInsets.only(bottom: Sp.x4),
+          child: CoachRender(spec: it.render!),
         );
       case CoachItemKind.error:
         return Padding(

--- a/lib/ui/coach/coach_render.dart
+++ b/lib/ui/coach/coach_render.dart
@@ -1,0 +1,585 @@
+// CoachRender — renders the AI coach's rich `render(spec)` figures natively.
+//
+// The model emits a typed spec map ({type, title?, ...payload}); this widget
+// switches on `type` and draws an animated, theme-consistent figure. Tolerant of
+// missing/loose fields (LLM output): every parser fails soft to an empty figure
+// rather than throwing. Simple bar/line/area/multi_series reuse the existing
+// CoachChart via a synthesized ChartSpec; the rest are self-contained painters.
+
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+
+import '../../coach/coach_engine.dart';
+import '../../theme/theme.dart';
+import '../../theme/tokens.dart';
+import '../kit/kit.dart';
+import 'coach_chart.dart';
+
+// ── loose parsing helpers (LLM output is liberal) ─────────────────────────────
+List<dynamic> _list(dynamic v) {
+  if (v is List) return v;
+  if (v is Map && v['item'] is List) return v['item'] as List;
+  if (v is Map && v['items'] is List) return v['items'] as List;
+  return const [];
+}
+
+double? _num(dynamic v) {
+  if (v == null) return null;
+  if (v is num) return v.toDouble();
+  if (v is String) {
+    final d = double.tryParse(v.trim());
+    if (d != null) return d;
+    final m = RegExp(r'-?\d+(\.\d+)?').firstMatch(v);
+    return m == null ? null : double.tryParse(m.group(0)!);
+  }
+  if (v is Map) return _num(v['value'] ?? v['y'] ?? v['v']);
+  return null;
+}
+
+String _str(dynamic v) => v == null ? '' : v.toString();
+
+final List<Color> _palette = [
+  AppColors.coral,
+  AppColors.good,
+  AppColors.loadDetraining,
+  AppColors.warn,
+  AppColors.coralDeep,
+];
+
+/// Sleep-stage colors for the hypnogram band.
+Color _stageColor(String stage) {
+  switch (stage.toLowerCase()) {
+    case 'deep':
+      return AppColors.coralDeep;
+    case 'rem':
+      return AppColors.good;
+    case 'light':
+      return AppColors.coral;
+    case 'wake':
+    default:
+      return AppColors.warn;
+  }
+}
+
+class CoachRender extends StatelessWidget {
+  final Map<String, dynamic> spec;
+  const CoachRender({super.key, required this.spec});
+
+  @override
+  Widget build(BuildContext context) {
+    final type = _str(spec['type']).toLowerCase();
+    // Simple chart families reuse CoachChart via a synthesized ChartSpec.
+    if (type == 'line' || type == 'area' || type == 'bar' || type == 'multi_series') {
+      final cs = _chartSpecFrom(spec, type);
+      if (cs != null) return CoachChart(spec: cs);
+    }
+    final title = _str(spec['title']);
+    Widget body;
+    switch (type) {
+      case 'scatter':
+        body = _Animated((t) => _ScatterPainter(spec, t), height: 200);
+        break;
+      case 'dual_axis':
+        body = _Animated((t) => _DualAxisPainter(spec, t), height: 190);
+        break;
+      case 'stacked_zone_bar':
+        body = _Animated((t) => _StackedBarPainter(spec, t), height: 190);
+        break;
+      case 'hypnogram':
+        body = _Animated((t) => _HypnogramPainter(spec, t), height: 120);
+        break;
+      case 'gauge':
+        body = _Animated((t) => _GaugePainter(spec, t), height: 170);
+        break;
+      case 'range_band':
+        body = _RangeBand(spec);
+        break;
+      case 'kpi_grid':
+        body = _KpiGrid(spec);
+        break;
+      case 'heatmap':
+        body = _Heatmap(spec);
+        break;
+      case 'table':
+        body = _MiniTable(spec);
+        break;
+      default:
+        body = Text('Unsupported figure "$type".', style: AppText.captionMuted);
+    }
+    final note = _str(spec['note']);
+    final legend = _legend(type);
+    return ProCard(
+      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+        if (title.isNotEmpty) Text(title, style: AppText.title),
+        if (title.isNotEmpty) const SizedBox(height: Sp.x4),
+        body,
+        if (legend != null) ...[const SizedBox(height: Sp.x3), legend],
+        if (note.isNotEmpty) ...[
+          const SizedBox(height: Sp.x3),
+          Text(note, style: AppText.captionMuted),
+        ],
+      ]),
+    );
+  }
+
+  Widget? _legend(String type) {
+    if (type == 'hypnogram') {
+      return Wrap(spacing: Sp.x4, runSpacing: Sp.x2, children: [
+        for (final s in const ['wake', 'rem', 'light', 'deep'])
+          _dot(_stageColor(s), s),
+      ]);
+    }
+    if (type == 'dual_axis') {
+      final l = (spec['left'] as Map?)?.cast<String, dynamic>();
+      final r = (spec['right'] as Map?)?.cast<String, dynamic>();
+      return Wrap(spacing: Sp.x4, children: [
+        _dot(_palette[0], _str(l?['name'] ?? 'left')),
+        _dot(_palette[1], _str(r?['name'] ?? 'right')),
+      ]);
+    }
+    if (type == 'stacked_zone_bar') {
+      final zones = _list(spec['zones']);
+      return Wrap(spacing: Sp.x4, runSpacing: Sp.x2, children: [
+        for (int i = 0; i < zones.length; i++)
+          _dot(_palette[i % _palette.length],
+              _str((zones[i] as Map?)?['name'] ?? 'z$i')),
+      ]);
+    }
+    return null;
+  }
+
+  Widget _dot(Color c, String label) => Row(mainAxisSize: MainAxisSize.min, children: [
+        Container(width: 9, height: 9, decoration: BoxDecoration(color: c, shape: BoxShape.circle)),
+        const SizedBox(width: Sp.x2),
+        Text(label, style: AppText.caption),
+      ]);
+
+  ChartSpec? _chartSpecFrom(Map<String, dynamic> s, String type) {
+    final j = <String, dynamic>{
+      'type': type == 'multi_series' ? (_str(s['chart_type']).isEmpty ? 'line' : s['chart_type']) : type,
+      'title': '', // title rendered by the outer card path below
+      'x_labels': s['x_labels'] ?? s['labels'] ?? s['x'],
+      'series': s['series'],
+      'unit': s['unit'] ?? '',
+      'note': s['note'],
+    };
+    final cs = ChartSpec.tryParse(j);
+    if (cs == null) return null;
+    // Carry the title onto the ChartSpec so CoachChart shows it.
+    return ChartSpec(
+      type: cs.type,
+      title: _str(s['title']),
+      xLabels: cs.xLabels,
+      series: cs.series,
+      unit: cs.unit,
+      note: cs.note,
+    );
+  }
+}
+
+// ── animation wrapper ─────────────────────────────────────────────────────────
+class _Animated extends StatelessWidget {
+  final CustomPainter Function(double t) make;
+  final double height;
+  const _Animated(this.make, {required this.height});
+  @override
+  Widget build(BuildContext context) => TweenAnimationBuilder<double>(
+        duration: const Duration(milliseconds: 700),
+        curve: Curves.easeOutCubic,
+        tween: Tween(begin: 0, end: 1),
+        builder: (_, t, _) => SizedBox(
+          height: height,
+          width: double.infinity,
+          child: CustomPaint(painter: make(t)),
+        ),
+      );
+}
+
+// ── scatter ───────────────────────────────────────────────────────────────────
+class _ScatterPainter extends CustomPainter {
+  final Map<String, dynamic> spec;
+  final double t;
+  _ScatterPainter(this.spec, this.t);
+  @override
+  void paint(Canvas canvas, Size size) {
+    final pts = _list(spec['points'])
+        .whereType<Map>()
+        .map((m) => Offset(_num(m['x']) ?? 0, _num(m['y']) ?? 0))
+        .toList();
+    if (pts.isEmpty) return;
+    final xs = pts.map((p) => p.dx).toList(), ys = pts.map((p) => p.dy).toList();
+    var xlo = xs.reduce(math.min), xhi = xs.reduce(math.max);
+    var ylo = ys.reduce(math.min), yhi = ys.reduce(math.max);
+    if (xlo == xhi) { xlo -= 1; xhi += 1; }
+    if (ylo == yhi) { ylo -= 1; yhi += 1; }
+    const pad = 22.0;
+    final w = size.width - pad, h = size.height - pad;
+    final grid = Paint()..color = AppColors.divider..strokeWidth = 1;
+    for (var g = 0; g <= 2; g++) {
+      final y = h * g / 2;
+      canvas.drawLine(Offset(pad, y), Offset(size.width, y), grid);
+    }
+    final dot = Paint()..color = AppColors.coral..style = PaintingStyle.fill;
+    for (final p in pts) {
+      final dx = pad + w * (p.dx - xlo) / (xhi - xlo);
+      final dy = h * (1 - (p.dy - ylo) / (yhi - ylo));
+      canvas.drawCircle(Offset(dx, dy), 4 * t, dot);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _ScatterPainter o) => o.t != t || o.spec != spec;
+}
+
+// ── dual axis (two y-scales) ──────────────────────────────────────────────────
+class _DualAxisPainter extends CustomPainter {
+  final Map<String, dynamic> spec;
+  final double t;
+  _DualAxisPainter(this.spec, this.t);
+  List<double?> _vals(Map? m) => _list(m?['values']).map(_num).toList();
+  @override
+  void paint(Canvas canvas, Size size) {
+    final left = (spec['left'] as Map?), right = (spec['right'] as Map?);
+    final lv = _vals(left), rv = _vals(right);
+    final n = math.max(lv.length, rv.length);
+    if (n < 1) return;
+    const pad = 16.0;
+    final w = size.width, h = size.height - pad;
+    double xAt(int i) => n == 1 ? w / 2 : w * i / (n - 1);
+    void drawSeries(List<double?> vals, Color c) {
+      final present = vals.whereType<double>().toList();
+      if (present.isEmpty) return;
+      var lo = present.reduce(math.min), hi = present.reduce(math.max);
+      if (lo == hi) { lo -= 1; hi += 1; }
+      final path = Path();
+      final pts = <Offset>[];
+      var started = false;
+      for (var i = 0; i < vals.length; i++) {
+        final v = vals[i];
+        if (v == null) continue;
+        final pt = Offset(xAt(i), h * (1 - (v - lo) / (hi - lo)));
+        pts.add(pt);
+        if (!started) { path.moveTo(pt.dx, pt.dy); started = true; }
+        else { path.lineTo(pt.dx, pt.dy); }
+      }
+      canvas.save();
+      canvas.clipRect(Rect.fromLTWH(0, 0, size.width * t, size.height));
+      if (pts.length > 1) {
+        canvas.drawPath(path, Paint()
+          ..color = c..strokeWidth = 2.5..style = PaintingStyle.stroke
+          ..strokeJoin = StrokeJoin.round..strokeCap = StrokeCap.round);
+      }
+      final dot = Paint()..color = c;
+      for (final p in pts) {
+        canvas.drawCircle(p, pts.length == 1 ? 5 : 3, dot);
+      }
+      canvas.restore();
+    }
+    final grid = Paint()..color = AppColors.divider..strokeWidth = 1;
+    for (var g = 0; g <= 2; g++) {
+      final y = h * g / 2;
+      canvas.drawLine(Offset(0, y), Offset(w, y), grid);
+    }
+    drawSeries(lv, _palette[0]);
+    drawSeries(rv, _palette[1]);
+  }
+
+  @override
+  bool shouldRepaint(covariant _DualAxisPainter o) => o.t != t || o.spec != spec;
+}
+
+// ── stacked zone bars ─────────────────────────────────────────────────────────
+class _StackedBarPainter extends CustomPainter {
+  final Map<String, dynamic> spec;
+  final double t;
+  _StackedBarPainter(this.spec, this.t);
+  @override
+  void paint(Canvas canvas, Size size) {
+    final zones = _list(spec['zones']).whereType<Map>().toList();
+    if (zones.isEmpty) return;
+    final cols = zones
+        .map((z) => _list(z['values']).map((v) => _num(v) ?? 0).toList())
+        .toList();
+    final n = cols.fold<int>(0, (a, c) => math.max(a, c.length));
+    if (n < 1) return;
+    final totals = List<double>.filled(n, 0);
+    for (final c in cols) {
+      for (var i = 0; i < c.length; i++) {
+        totals[i] += c[i];
+      }
+    }
+    final maxTotal = totals.reduce(math.max);
+    if (maxTotal <= 0) return;
+    const bottom = 16.0;
+    final h = size.height - bottom;
+    final bw = size.width / n * 0.6;
+    final gap = size.width / n;
+    for (var i = 0; i < n; i++) {
+      var y = h;
+      final x = gap * i + (gap - bw) / 2;
+      for (var zi = 0; zi < cols.length; zi++) {
+        final v = i < cols[zi].length ? cols[zi][i] : 0.0;
+        final segH = h * (v / maxTotal) * t;
+        final rect = Rect.fromLTWH(x, y - segH, bw, segH);
+        canvas.drawRect(rect, Paint()..color = _palette[zi % _palette.length]);
+        y -= segH;
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _StackedBarPainter o) => o.t != t || o.spec != spec;
+}
+
+// ── hypnogram (sleep stage band) ──────────────────────────────────────────────
+class _HypnogramPainter extends CustomPainter {
+  final Map<String, dynamic> spec;
+  final double t;
+  _HypnogramPainter(this.spec, this.t);
+  @override
+  void paint(Canvas canvas, Size size) {
+    final segs = _list(spec['segments']).whereType<Map>().toList();
+    if (segs.isEmpty) return;
+    final starts = segs.map((s) => _num(s['start']) ?? 0).toList();
+    final ends = segs.map((s) => _num(s['end']) ?? 0).toList();
+    final lo = starts.reduce(math.min), hi = ends.reduce(math.max);
+    if (hi <= lo) return;
+    // Stage lanes (top→bottom): wake, rem, light, deep.
+    const lanes = ['wake', 'rem', 'light', 'deep'];
+    final laneH = size.height / lanes.length;
+    final clipW = size.width * t;
+    for (final s in segs) {
+      final stage = _str(s['stage']).toLowerCase();
+      final li = lanes.indexOf(stage);
+      final lane = li < 0 ? lanes.length - 1 : li;
+      final x0 = size.width * ((_num(s['start']) ?? 0) - lo) / (hi - lo);
+      final x1 = size.width * ((_num(s['end']) ?? 0) - lo) / (hi - lo);
+      if (x0 > clipW) continue;
+      final rect = Rect.fromLTWH(x0, lane * laneH + 2,
+          math.min(x1, clipW) - x0, laneH - 4);
+      canvas.drawRRect(
+          RRect.fromRectAndRadius(rect, const Radius.circular(3)),
+          Paint()..color = _stageColor(stage));
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _HypnogramPainter o) => o.t != t || o.spec != spec;
+}
+
+// ── gauge (0–100 ring) ────────────────────────────────────────────────────────
+class _GaugePainter extends CustomPainter {
+  final Map<String, dynamic> spec;
+  final double t;
+  _GaugePainter(this.spec, this.t);
+  @override
+  void paint(Canvas canvas, Size size) {
+    final value = _num(spec['value']) ?? 0;
+    final min = _num(spec['min']) ?? 0, max = _num(spec['max']) ?? 100;
+    final frac = ((value - min) / (max - min)).clamp(0.0, 1.0) * t;
+    final center = Offset(size.width / 2, size.height * 0.62);
+    final radius = math.min(size.width, size.height) * 0.42;
+    final track = Paint()
+      ..color = AppColors.divider..style = PaintingStyle.stroke..strokeWidth = 12
+      ..strokeCap = StrokeCap.round;
+    final arc = Paint()
+      ..color = AppColors.coral..style = PaintingStyle.stroke..strokeWidth = 12
+      ..strokeCap = StrokeCap.round;
+    const start = math.pi * 0.8, sweep = math.pi * 1.4;
+    canvas.drawArc(Rect.fromCircle(center: center, radius: radius), start, sweep, false, track);
+    canvas.drawArc(Rect.fromCircle(center: center, radius: radius), start, sweep * frac, false, arc);
+    final tp = TextPainter(
+      text: TextSpan(text: value.round().toString(), style: AppText.display),
+      textDirection: TextDirection.ltr)
+      ..layout();
+    tp.paint(canvas, center - Offset(tp.width / 2, tp.height / 2));
+  }
+
+  @override
+  bool shouldRepaint(covariant _GaugePainter o) => o.t != t || o.spec != spec;
+}
+
+// ── range band (value vs target band) ─────────────────────────────────────────
+class _RangeBand extends StatelessWidget {
+  final Map<String, dynamic> spec;
+  const _RangeBand(this.spec);
+  @override
+  Widget build(BuildContext context) {
+    final value = _num(spec['value']) ?? 0;
+    final min = _num(spec['min']) ?? 0, max = _num(spec['max']) ?? 100;
+    final unit = _str(spec['unit']);
+    final lo = math.min(min, value) - (max - min).abs() * 0.2;
+    final hi = math.max(max, value) + (max - min).abs() * 0.2;
+    final span = (hi - lo) == 0 ? 1 : (hi - lo);
+    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+      Text('${value.toStringAsFixed(value % 1 == 0 ? 0 : 1)}$unit',
+          style: AppText.title.copyWith(color: AppColors.coral)),
+      const SizedBox(height: Sp.x2),
+      LayoutBuilder(builder: (_, c) {
+        final w = c.maxWidth;
+        double at(double v) => w * ((v - lo) / span);
+        return SizedBox(height: 22, child: Stack(children: [
+          Positioned(top: 9, left: 0, right: 0,
+              child: Container(height: 4, color: AppColors.divider)),
+          Positioned(top: 7, left: at(min), width: at(max) - at(min),
+              child: Container(height: 8,
+                  decoration: BoxDecoration(color: AppColors.good.withValues(alpha: 0.4),
+                      borderRadius: BorderRadius.circular(4)))),
+          Positioned(left: (at(value) - 6).clamp(0, w - 12), top: 4,
+              child: Container(width: 12, height: 12,
+                  decoration: BoxDecoration(color: AppColors.coral, shape: BoxShape.circle))),
+        ]));
+      }),
+      const SizedBox(height: Sp.x2),
+      Text('target ${min.toStringAsFixed(0)}–${max.toStringAsFixed(0)}$unit',
+          style: AppText.captionMuted),
+    ]);
+  }
+}
+
+// ── KPI grid ──────────────────────────────────────────────────────────────────
+class _KpiGrid extends StatelessWidget {
+  final Map<String, dynamic> spec;
+  const _KpiGrid(this.spec);
+  @override
+  Widget build(BuildContext context) {
+    final cards = _list(spec['cards']).whereType<Map>().toList();
+    if (cards.isEmpty) return Text('No data.', style: AppText.captionMuted);
+    return Wrap(spacing: Sp.x3, runSpacing: Sp.x3, children: [
+      for (final c in cards) _kpi(c.cast<String, dynamic>()),
+    ]);
+  }
+
+  Widget _kpi(Map<String, dynamic> c) {
+    final delta = _num(c['delta']);
+    final spark = _list(c['spark']).map(_num).whereType<double>().toList();
+    return Container(
+      width: 150,
+      padding: const EdgeInsets.all(Sp.x3),
+      decoration: BoxDecoration(
+          color: AppColors.surfaceAlt, borderRadius: BorderRadius.circular(R.card)),
+      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+        Text(_str(c['label']), style: AppText.captionMuted),
+        const SizedBox(height: 2),
+        Row(crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic, children: [
+          Text(_str(c['value']), style: AppText.title),
+          if (_str(c['unit']).isNotEmpty) ...[
+            const SizedBox(width: 3),
+            Text(_str(c['unit']), style: AppText.captionMuted),
+          ],
+        ]),
+        if (delta != null) Text(
+            '${delta >= 0 ? '▲' : '▼'} ${delta.abs().toStringAsFixed(delta % 1 == 0 ? 0 : 1)}',
+            style: AppText.caption.copyWith(
+                color: delta >= 0 ? AppColors.good : AppColors.warn)),
+        if (spark.length > 1) ...[
+          const SizedBox(height: Sp.x2),
+          SizedBox(height: 24, width: double.infinity,
+              child: CustomPaint(painter: _SparkPainter(spark))),
+        ],
+      ]),
+    );
+  }
+}
+
+class _SparkPainter extends CustomPainter {
+  final List<double> vals;
+  _SparkPainter(this.vals);
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (vals.length < 2) return;
+    var lo = vals.reduce(math.min), hi = vals.reduce(math.max);
+    if (lo == hi) { lo -= 1; hi += 1; }
+    final path = Path();
+    for (var i = 0; i < vals.length; i++) {
+      final x = size.width * i / (vals.length - 1);
+      final y = size.height * (1 - (vals[i] - lo) / (hi - lo));
+      i == 0 ? path.moveTo(x, y) : path.lineTo(x, y);
+    }
+    canvas.drawPath(path, Paint()
+      ..color = AppColors.coral..strokeWidth = 1.8..style = PaintingStyle.stroke
+      ..strokeJoin = StrokeJoin.round);
+  }
+
+  @override
+  bool shouldRepaint(covariant _SparkPainter o) => o.vals != vals;
+}
+
+// ── heatmap ───────────────────────────────────────────────────────────────────
+class _Heatmap extends StatelessWidget {
+  final Map<String, dynamic> spec;
+  const _Heatmap(this.spec);
+  @override
+  Widget build(BuildContext context) {
+    final rows = _list(spec['rows']).map(_str).toList();
+    final cols = _list(spec['cols']).map(_str).toList();
+    final values = _list(spec['values'])
+        .map((r) => _list(r).map((v) => _num(v) ?? 0).toList())
+        .toList();
+    if (values.isEmpty) return Text('No data.', style: AppText.captionMuted);
+    final flat = [for (final r in values) ...r];
+    var lo = flat.reduce(math.min), hi = flat.reduce(math.max);
+    if (lo == hi) hi = lo + 1;
+    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+      for (var ri = 0; ri < values.length; ri++)
+        Padding(
+          padding: const EdgeInsets.only(bottom: 3),
+          child: Row(children: [
+            if (rows.isNotEmpty)
+              SizedBox(width: 34, child: Text(ri < rows.length ? rows[ri] : '',
+                  style: AppText.captionMuted)),
+            for (var ci = 0; ci < values[ri].length; ci++)
+              Expanded(child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 1.5),
+                child: AspectRatio(aspectRatio: 1, child: Container(
+                  decoration: BoxDecoration(
+                    color: AppColors.coral.withValues(
+                        alpha: 0.12 + 0.78 * ((values[ri][ci] - lo) / (hi - lo))),
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                )),
+              )),
+          ]),
+        ),
+      if (cols.isNotEmpty) ...[
+        const SizedBox(height: 2),
+        Row(children: [
+          if (rows.isNotEmpty) const SizedBox(width: 34),
+          for (final c in cols)
+            Expanded(child: Text(c, textAlign: TextAlign.center, style: AppText.captionMuted)),
+        ]),
+      ],
+    ]);
+  }
+}
+
+// ── mini table ────────────────────────────────────────────────────────────────
+class _MiniTable extends StatelessWidget {
+  final Map<String, dynamic> spec;
+  const _MiniTable(this.spec);
+  @override
+  Widget build(BuildContext context) {
+    final cols = _list(spec['columns']).map(_str).toList();
+    final rows = _list(spec['rows']).map((r) => _list(r).map(_str).toList()).toList();
+    if (rows.isEmpty) return Text('No data.', style: AppText.captionMuted);
+    return Table(
+      border: TableBorder(horizontalInside: BorderSide(color: AppColors.divider)),
+      defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+      children: [
+        if (cols.isNotEmpty)
+          TableRow(children: [
+            for (final c in cols)
+              Padding(padding: const EdgeInsets.all(Sp.x2),
+                  child: Text(c, style: AppText.caption)),
+          ]),
+        for (final r in rows)
+          TableRow(children: [
+            for (final cell in r)
+              Padding(padding: const EdgeInsets.all(Sp.x2),
+                  child: Text(cell, style: AppText.body)),
+          ]),
+      ],
+    );
+  }
+}

--- a/lib/ui/screens/detail_cards.dart
+++ b/lib/ui/screens/detail_cards.dart
@@ -163,6 +163,12 @@ class HeartDayCard extends StatelessWidget {
         final illness = (d['illness'] as Map?);
         final resp = (d['resp'] as Map?);
         final spo2 = (d['spo2'] as Map?);
+        final irr24 = (d['irregular_24h'] as Map?);
+        final irr24v = (irr24?['value'] is Map)
+            ? (irr24!['value'] as Map).cast<String, dynamic>()
+            : null;
+        final hrr = _n(d['hrr']);
+        final brvHas = (d['brv'] is Map) && ((d['brv'] as Map)['value'] is Map);
         final baselines = (d['baselines'] as Map?);
         final dmap = (d['drivers'] as Map?) ?? const {};
         final heartDrivers =
@@ -370,6 +376,102 @@ class HeartDayCard extends StatelessWidget {
                         'Your typical RMSSD — recovery is measured against this.',
                     value: '${(_n(hrv['baseline']) ?? 0).round()}',
                     unit: 'ms',
+                  ),
+              ]),
+            ],
+
+            // ── 24/7 irregular-rhythm SCREEN (not a diagnosis) ──────────────
+            const SizedBox(height: Sp.x6),
+            const SectionHeader('Rhythm screen'),
+            Builder(builder: (_) {
+              if (irr24v == null) {
+                return ProCard(
+                  child: Text(
+                    'Not enough clean beats today to screen your heart rhythm.',
+                    style: AppText.captionMuted,
+                  ),
+                );
+              }
+              final flag = irr24v['flag'] == true;
+              final ratio = _n(irr24v['sd1_sd2']);
+              final pnn = _n(irr24v['pnn_pct']);
+              final accent = flag ? AppColors.coral : AppColors.good;
+              return ProCard(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(children: [
+                      AppIcon(flag ? Ic.heart : Ic.pulse,
+                          size: 18, color: accent),
+                      const SizedBox(width: Sp.x3),
+                      Expanded(
+                        child: Text(
+                          flag
+                              ? 'Irregular pattern detected today'
+                              : 'Rhythm screen: normal',
+                          style: AppText.label.copyWith(color: accent),
+                        ),
+                      ),
+                      Tag('SCREEN', color: accent),
+                    ]),
+                    const SizedBox(height: Sp.x3),
+                    Text(
+                      "A screen, not a diagnosis — wrist pulse can't see the "
+                      "heart's electrical signal. See a clinician if you have "
+                      'symptoms (palpitations, dizziness, breathlessness).',
+                      style: AppText.captionMuted,
+                    ),
+                    const SizedBox(height: Sp.x3),
+                    Row(children: [
+                      Expanded(
+                        child: Text(
+                          'SD1/SD2 ${ratio == null ? '—' : ratio.toStringAsFixed(2)}',
+                          style: AppText.captionMuted,
+                        ),
+                      ),
+                      Expanded(
+                        child: Text(
+                          'pNN ${pnn == null ? '—' : '${pnn.toStringAsFixed(0)}%'}',
+                          style: AppText.captionMuted,
+                        ),
+                      ),
+                    ]),
+                  ],
+                ),
+              );
+            }),
+
+            // ── Heart-rate recovery + breathing-rate variability trends ─────
+            if (hrr != null || brvHas) ...[
+              const SizedBox(height: Sp.x6),
+              const SectionHeader('Fitness & breathing'),
+              MetricGroup([
+                if (hrr != null)
+                  TrendMetricRow(
+                    icon: Ic.recovery,
+                    accent: AppColors.good,
+                    label: 'HR recovery',
+                    info: 'Drop in heart rate 60 s after exercise. Faster '
+                        'recovery means a fitter, better-regulated heart.',
+                    value: hrr.toStringAsFixed(0),
+                    unit: 'bpm',
+                    metric: 'hrr',
+                    trendTitle: 'Heart-rate recovery',
+                  ),
+                if (brvHas)
+                  TrendMetricRow(
+                    icon: Ic.chart,
+                    accent: AppColors.good,
+                    label: 'Breathing variability',
+                    info: 'How much your breathing rate varied overnight '
+                        '(within-user trend), tracked against your own history.',
+                    value: () {
+                      final cv =
+                          _n((((d['brv'] as Map)['value']) as Map)['cv']);
+                      return cv == null ? '—' : cv.toStringAsFixed(2);
+                    }(),
+                    metric: 'brv',
+                    trendTitle: 'Breathing-rate variability',
                   ),
               ]),
             ],

--- a/lib/ui/sleep/sleep_detail_screen.dart
+++ b/lib/ui/sleep/sleep_detail_screen.dart
@@ -151,6 +151,11 @@ class _SleepDetailScreenState extends State<SleepDetailScreen> {
   Map<String, dynamic> get _advanced => _map(_data['advanced']);
   bool get _hasAdvanced => _advanced['present'] == true;
 
+  // Low-confidence WRIST orientation (gravity-tilt) during sleep. A body-position
+  // PROXY only — the wrist moves independently of the torso, so this is NOT the
+  // sleeper's supine/side/prone body position.
+  Map<String, dynamic> get _wristOri => _map(_data['wrist_orientation']);
+
   /// Compressed hypnogram: consecutive same-stage points merged into segments.
   List<_Seg> _segments() {
     final raw = _data['hypnogram'];
@@ -327,6 +332,11 @@ class _SleepDetailScreenState extends State<SleepDetailScreen> {
         const SizedBox(height: Sp.x6),
         SectionHeader('Nocturnal heart'),
         _nocturnalCard(),
+      ],
+      if (_wristOri['dominant'] is String) ...[
+        const SizedBox(height: Sp.x6),
+        const SectionHeader('Wrist orientation (low confidence)'),
+        _wristOrientationCard(),
       ],
       // Tap any of these into its Week/Month/3M trend.
       const SizedBox(height: Sp.x6),
@@ -924,6 +934,66 @@ class _SleepDetailScreenState extends State<SleepDetailScreen> {
   }
 
   // ── 8. NOCTURNAL HEART ──────────────────────────────────────────────────────
+
+  String _prettyOrientation(String pos) {
+    switch (pos) {
+      case 'supine':
+        return 'Wrist facing up';
+      case 'prone':
+        return 'Wrist facing down';
+      case 'lateral_left':
+        return 'Wrist tilted left';
+      case 'lateral_right':
+        return 'Wrist tilted right';
+      case 'upright':
+        return 'Arm raised';
+      default:
+        return 'Mixed / unknown';
+    }
+  }
+
+  Widget _wristOrientationCard() {
+    final dominant = _wristOri['dominant']?.toString() ?? 'unknown';
+    final changes = _num(_wristOri['changes'])?.toInt() ?? 0;
+    final minsRaw = _map(_wristOri['minutes']);
+    final entries = <MapEntry<String, double>>[
+      for (final e in minsRaw.entries)
+        MapEntry(e.key, (_num(e.value) ?? 0).toDouble())
+    ]..sort((a, b) => b.value.compareTo(a.value));
+    return ProCard(
+      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+        Row(children: [
+          AppIcon(Ic.watch, size: 18, color: AppColors.inkMuted),
+          const SizedBox(width: Sp.x3),
+          Expanded(
+              child: Text(_prettyOrientation(dominant),
+                  style: AppText.label)),
+          Tag('proxy', color: AppColors.inkSoft),
+        ]),
+        const SizedBox(height: Sp.x3),
+        Text(
+          'Wrist tilt from the band\'s motion sensor — a position PROXY, NOT your '
+          'body position. Your arm moves independently of your torso, so this '
+          'can\'t tell back from side sleeping.',
+          style: AppText.captionMuted,
+        ),
+        if (entries.isNotEmpty) ...[
+          const SizedBox(height: Sp.x3),
+          for (final e in entries.take(4))
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Row(children: [
+                Expanded(child: Text(_prettyOrientation(e.key),
+                    style: AppText.captionMuted)),
+                Text(_hm(e.value.round()), style: AppText.captionMuted),
+              ]),
+            ),
+        ],
+        const SizedBox(height: 2),
+        Text('$changes orientation changes', style: AppText.captionMuted),
+      ]),
+    );
+  }
 
   Widget _nocturnalCard() {
     final avg = _num(_nocturnal['sleeping_hr_avg'])?.round();

--- a/lib/ui/workouts/workouts_screen.dart
+++ b/lib/ui/workouts/workouts_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../state/app_state.dart';
 import '../../state/prefs.dart';
+import '../../data/db.dart';
 import '../activity/live_session_screen.dart';
 import '../../theme/theme.dart';
 import '../../theme/theme_switcher.dart';
@@ -252,6 +253,7 @@ class _WorkoutsScreenState extends State<WorkoutsScreen> {
     0,
   ).clamp(0, _ranges.length - 1);
   Map<String, dynamic>? _data;
+  List<Map<String, dynamic>> _suggestions = const [];
   bool _loading = true;
 
   @override
@@ -266,9 +268,14 @@ class _WorkoutsScreenState extends State<WorkoutsScreen> {
     setState(() => _loading = true);
     try {
       final d = await api.getWorkouts(range: _rangeKey[_range]);
+      List<Map<String, dynamic>> sug = const [];
+      try {
+        sug = await LocalDb.activeWorkoutSuggestions();
+      } catch (_) {}
       if (mounted) {
         setState(() {
           _data = d;
+          _suggestions = sug;
           _loading = false;
         });
       }
@@ -277,6 +284,30 @@ class _WorkoutsScreenState extends State<WorkoutsScreen> {
         setState(() => _loading = false);
       }
     }
+  }
+
+  /// Confirm an auto-detected suggestion → create a completed session, then
+  /// drop the suggestion and refresh.
+  Future<void> _confirmSuggestion(Map<String, dynamic> s) async {
+    final start = (s['start_ts'] as num?)?.toInt() ?? 0;
+    await LocalDb.putSession({
+      'id': 'auto:$start',
+      'start_ts': start,
+      'end_ts': (s['end_ts'] as num?)?.toInt(),
+      'type': (s['sport'] as String?) ?? 'cardio',
+      'status': 'done',
+      'duration_min': (s['duration_min'] as num?)?.toInt(),
+      'max_hr': (s['peak_bpm'] as num?)?.toInt(),
+      'source': 'auto',
+      'created_at': DateTime.now().millisecondsSinceEpoch,
+    });
+    await LocalDb.dismissWorkoutSuggestion(s['id'] as String);
+    await _load();
+  }
+
+  Future<void> _dismissSuggestion(Map<String, dynamic> s) async {
+    await LocalDb.dismissWorkoutSuggestion(s['id'] as String);
+    await _load();
   }
 
   bool _isToday(int startTs) {
@@ -332,6 +363,20 @@ class _WorkoutsScreenState extends State<WorkoutsScreen> {
                 ),
               ),
               const SizedBox(height: Sp.x4),
+              if (!_loading && _suggestions.isNotEmpty) ...[
+                const SectionHeader('Suggested workouts'),
+                const SizedBox(height: Sp.x2),
+                for (final s in _suggestions)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: Sp.x3),
+                    child: _SuggestionCard(
+                      s: s,
+                      onConfirm: () => _confirmSuggestion(s),
+                      onDismiss: () => _dismissSuggestion(s),
+                    ),
+                  ),
+                const SizedBox(height: Sp.x4),
+              ],
               if (_loading)
                 const Padding(
                   padding: EdgeInsets.symmetric(vertical: Sp.x6),
@@ -496,6 +541,79 @@ class _StartButton extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// An opt-in auto-detected workout the user can confirm (→ logs a session) or
+/// dismiss. We never auto-log: this is "did you work out?", not a silent write.
+class _SuggestionCard extends StatelessWidget {
+  final Map<String, dynamic> s;
+  final VoidCallback onConfirm;
+  final VoidCallback onDismiss;
+  const _SuggestionCard(
+      {required this.s, required this.onConfirm, required this.onDismiss});
+
+  @override
+  Widget build(BuildContext context) {
+    final start = (s['start_ts'] as num?)?.toInt();
+    final dur = (s['duration_min'] as num?)?.toInt();
+    final avg = (s['avg_bpm'] as num?)?.toInt();
+    final peak = (s['peak_bpm'] as num?)?.toInt();
+    final sport = (s['sport'] as String?) ?? 'cardio';
+    return ProCard(
+      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+        Row(children: [
+          AppIcon(_typeIcon(sport), size: 18, color: AppColors.coral),
+          const SizedBox(width: Sp.x3),
+          Expanded(
+            child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+              Text('Did you work out?', style: AppText.label),
+              const SizedBox(height: 1),
+              Text(
+                '${_whenLabel(start)} · ${dur ?? '—'} min'
+                '${avg != null ? ' · avg $avg' : ''}'
+                '${peak != null ? ' · peak $peak bpm' : ''}',
+                style: AppText.captionMuted,
+              ),
+            ]),
+          ),
+        ]),
+        const SizedBox(height: Sp.x2),
+        Text('We spotted elevated activity from your heart rate.',
+            style: AppText.captionMuted),
+        const SizedBox(height: Sp.x3),
+        Row(children: [
+          Expanded(
+            child: GestureDetector(
+              onTap: onConfirm,
+              child: Container(
+                padding: const EdgeInsets.symmetric(vertical: Sp.x3),
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                    color: AppColors.coral,
+                    borderRadius: BorderRadius.circular(R.pill)),
+                child: Text('Log it',
+                    style: AppText.label.copyWith(color: Colors.white)),
+              ),
+            ),
+          ),
+          const SizedBox(width: Sp.x3),
+          GestureDetector(
+            onTap: onDismiss,
+            child: Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: Sp.x5, vertical: Sp.x3),
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                  color: AppColors.surfaceAlt,
+                  borderRadius: BorderRadius.circular(R.pill)),
+              child: Text('Dismiss',
+                  style: AppText.label.copyWith(color: AppColors.inkMuted)),
+            ),
+          ),
+        ]),
+      ]),
     );
   }
 }

--- a/test/coach_sql_guard_test.dart
+++ b/test/coach_sql_guard_test.dart
@@ -1,0 +1,59 @@
+// Coach read-only SQL guard — security-critical: derived views only, no writes,
+// no raw tables, single SELECT.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/coach/coach_db.dart';
+
+void main() {
+  group('CoachDb.guardAndPrepare', () {
+    test('accepts a plain SELECT over an allowed view + auto-LIMITs', () {
+      final out = CoachDb.guardAndPrepare(
+          "SELECT date, value FROM v_metric WHERE key='rhr'");
+      expect(out.toLowerCase(), contains('from v_metric'));
+      expect(out.toLowerCase(), contains('limit 200'));
+    });
+
+    test('respects an explicit LIMIT', () {
+      final out =
+          CoachDb.guardAndPrepare('SELECT * FROM v_daily LIMIT 7');
+      expect(RegExp(r'limit\s+200', caseSensitive: false).hasMatch(out), isFalse);
+    });
+
+    test('accepts a WITH/CTE query', () {
+      final out = CoachDb.guardAndPrepare(
+          "WITH x AS (SELECT value v FROM v_metric WHERE key='strain') "
+          'SELECT AVG(v) FROM x');
+      expect(out.toLowerCase(), startsWith('with'));
+    });
+
+    for (final bad in <String>[
+      'SELECT * FROM raw_records',
+      'SELECT * FROM decoded_onehz',
+      'SELECT * FROM decoded_rr',
+      'SELECT * FROM day_result',
+      'SELECT * FROM metric_series',
+      'SELECT * FROM sessions',
+      'SELECT * FROM sqlite_master',
+    ]) {
+      test('rejects raw/base table: $bad', () {
+        expect(() => CoachDb.guardAndPrepare(bad), throwsA(isA<SqlGuardError>()));
+      });
+    }
+
+    for (final bad in <String>[
+      'DELETE FROM v_metric',
+      'UPDATE v_daily SET hrv=0',
+      'DROP VIEW v_metric',
+      'INSERT INTO v_metric VALUES (1)',
+      'SELECT * FROM v_metric; DROP TABLE sessions',
+      'SELECT * FROM v_metric -- comment',
+      'PRAGMA table_info(sessions)',
+      'ATTACH DATABASE x AS y',
+      'SELECT * FROM main.v_metric',
+      'SELECT 1',
+    ]) {
+      test('rejects unsafe: $bad', () {
+        expect(() => CoachDb.guardAndPrepare(bad), throwsA(isA<SqlGuardError>()));
+      });
+    }
+  });
+}

--- a/test/coach_views_test.dart
+++ b/test/coach_views_test.dart
@@ -1,0 +1,69 @@
+// Coach derived-only SQL views — verify they CREATE (json1 available) and that
+// CoachDb.runCoachSql reads them through a read-only handle while rejecting raw.
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:openstrap_edge/data/db.dart';
+import 'package:openstrap_edge/coach/coach_db.dart';
+
+void main() {
+  setUpAll(() async {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+    LocalDb.dbName = 'openstrap_coach_views_test.db';
+    final dir = await databaseFactory.getDatabasesPath();
+    await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+  });
+
+  tearDownAll(() async {
+    await CoachDb.close();
+    await LocalDb.close();
+  });
+
+  test('views create + json1 unnest works; CoachDb reads, rejects raw', () async {
+    final db = await LocalDb.instance; // onCreate builds tables + views
+
+    // Seed derived data.
+    await db.insert('metric_series', {'date': '2026-06-29', 'key': 'rhr', 'value': 55.0});
+    await db.insert('metric_series', {'date': '2026-06-29', 'key': 'hrr_bpm', 'value': 31.0});
+    await db.insert('day_result', {
+      'day_id': '2026-06-29',
+      'algo_version': 25,
+      'payload_json': jsonEncode({
+        'series': {
+          'hr_curve': [
+            {'t': 0, 'v': 60},
+            {'t': 60, 'v': 62},
+          ],
+        },
+      }),
+      'window_json': '{}',
+      'computed_at': 0,
+      'finalized': 0,
+      'rhr': 55.0,
+    });
+
+    // Views via the RW handle (json1 sanity).
+    final daily = await db.rawQuery('SELECT resting_hr, hrr_bpm FROM v_daily');
+    expect((daily.first['resting_hr'] as num).toInt(), 55);
+    expect((daily.first['hrr_bpm'] as num).toInt(), 31);
+    final series = await db.rawQuery(
+        "SELECT t, v FROM v_series WHERE date='2026-06-29' AND series='hr_curve' ORDER BY t");
+    expect(series.length, 2);
+    expect((series.last['v'] as num).toInt(), 62);
+
+    // End-to-end through the read-only handle + shaping.
+    final ok = await CoachDb.runCoachSql(
+        "SELECT date, value FROM v_metric WHERE key='rhr'");
+    final decoded = jsonDecode(ok) as Map<String, dynamic>;
+    expect(decoded['row_count'], 1);
+    expect((decoded['rows'] as List).first['value'], 55.0);
+
+    // Raw access is rejected with a self-correct reason, not rows.
+    final bad = await CoachDb.runCoachSql('SELECT * FROM raw_records');
+    final badDec = jsonDecode(bad) as Map<String, dynamic>;
+    expect(badDec.containsKey('error'), isTrue);
+  });
+}


### PR DESCRIPTION
Surfaces four new on-device health features (plus one honesty-bounded extra) and rebuilds the AI coach's data reach into read-only SQL + rich rendering. Clean against `main`. `kAlgoVersion 24 → 25`, db `v18 → v19`.

## New health features
- **Irregular-rhythm 24/7 screen** — whole-day Poincaré SD1/SD2 + pNNx (`analytics#12`) → `clinical.irregular_24h` + `irregular_rhythm_flag` + opt-in notification. A screen, **not a diagnosis**.
- **Heart-rate recovery (HRR)** — per auto-detected bout + backfilled onto saved sessions → `sessions.hrr_bpm` + daily `hrr_bpm`. Workout detail + Heart trend.
- **Breathing-rate variability** — per-window RSA dispersion → `brv_cv`/`brv_slope`; Heart trend.
- **Auto-workout suggestions** — opt-in `autoDetectWorkouts` → `workout_suggestions` table + recent-day notification + Workouts "Suggested workouts" (Log it / Dismiss). Never auto-logged.
- **Wrist orientation** (low confidence) — sleep-window gravity tilt, explicitly a wrist **proxy, NOT body position** (sleep position on a wrist sensor isn't credible as supine/side/prone).

## AI coach
- **`coach_db.dart`** (new): the model now runs **read-only SQL** over 7 **derived-only** views (`v_metric`,`v_daily`,`v_series`,`v_hypnogram`,`v_sessions`,`v_baselines`,`v_insights`) on a separate `readOnly:true` handle behind a **fail-closed guard** — raw byte tables, writes, multi-statement, comments, PRAGMA, schema-qualified names all rejected.
- 13 fixed read-tools → one `run_sql`; new `render` tool + **`coach_render.dart`** with ~13 widget types. Prompt documents the views + render catalog.

## Tests
+21 edge tests (guard rejects raw/writes/injection; views create, json1 unnest, read-only end-to-end). **101 green** (`flutter test --concurrency=1`); `flutter analyze lib` clean.

## Cross-repo order + notes
- Depends on **`OpenStrap/analytics#12`** (the two new analytics modules) — merge that first so the `analytics @ main` git dependency resolves in CI.
- v25 bump won't backfill **finalized** days — existing installs need "Re-analyze data".

🤖 Generated with [Claude Code](https://claude.com/claude-code)