### PR TITLE
fix(ci): release build fails on committed path dependency_overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ android/key.properties
 # build outputs / release artifacts
 dist/
 *.apk
+
+# Local-only dependency overrides (sibling path linking); never commit.
+pubspec_overrides.yaml

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -731,16 +731,20 @@ packages:
   openstrap_analytics:
     dependency: "direct main"
     description:
-      path: "../openstrap-analytics-onehz"
-      relative: true
-    source: path
+      path: "."
+      ref: main
+      resolved-ref: c1a68a0713b3bada7d7cdd650a695fc164f7848f
+      url: "https://github.com/OpenStrap/analytics.git"
+    source: git
     version: "1.0.0"
   openstrap_protocol:
     dependency: "direct main"
     description:
-      path: "../openstrap-protocol-dart"
-      relative: true
-    source: path
+      path: "."
+      ref: main
+      resolved-ref: dc64c4e50d04ff6003843d05669bfe27c756d273
+      url: "https://github.com/OpenStrap/protocol.git"
+    source: git
     version: "1.0.0"
   ota_update:
     dependency: "direct main"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -99,15 +99,11 @@ dependencies:
   flutter_secure_storage: ^10.3.1
   gpt_markdown: ^1.1.7
 
-# LOCAL DEV OVERRIDE: build against the in-tree protocol + analytics packages
-# (the new coaching/insights work) instead of the pinned git refs above. Revert
-# (or bump the git refs) before merge — mirrors how feat/steps pointed deps back
-# to main for release.
-dependency_overrides:
-  openstrap_protocol:
-    path: ../openstrap-protocol-dart
-  openstrap_analytics:
-    path: ../openstrap-analytics-onehz
+# NOTE: to build against the in-tree sibling packages during local development,
+# create a (gitignored) pubspec_overrides.yaml — pub auto-detects it. Keeping the
+# overrides OUT of this file means CI/release resolves the pinned git refs above
+# (the siblings aren't checked out in CI, so a committed path override fails
+# `flutter pub get` with exit 66).
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The v0.6.0 tag build failed at `flutter pub get` (exit 66): `_edge depends on _analytics from path which doesn't exist`.

**Cause:** PR #25 committed a `dependency_overrides` block in `pubspec.yaml` pointing protocol/analytics at the sibling working copies (`../openstrap-*`). CI checks out only the edge repo, so those paths don't exist. v0.5.4 (last good release) had no such block.

**Fix:**
- Remove the `dependency_overrides` block from `pubspec.yaml` so CI/release resolves the pinned git refs (`OpenStrap/analytics@main`, `OpenStrap/protocol@main`).
- Move the path overrides into a gitignored `pubspec_overrides.yaml` (pub auto-detects it) so local dev still links the siblings.
- Regenerate `pubspec.lock` against the git refs (analytics c1a68a0 = #14, protocol dc64c4e = main).

`flutter pub get` verified locally both with the override (path link) and without (git refs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)