### PR TITLE
recover: restore pre-rewind local-first work

### DIFF
--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -182,7 +182,13 @@ class BleEngine {
     this.onCommitBatch,
     this.cursorReader,
     this.deriveDebouncer = const DeriveDebouncer(),
+    this.isBackgroundDrainer = false,
   });
+
+  /// True for the headless restore-drain engine (runHeadlessSync). It YIELDS the
+  /// band to a foreground engine rather than fighting it — see [_claimBand]. The
+  /// foreground app engine leaves this false and always wins.
+  final bool isBackgroundDrainer;
 
   /// Optional reader for a persisted cursor value (e.g. counter_hw) so the engine
   /// can seed its frontier from the durable store on connect — making the stuck/
@@ -190,6 +196,41 @@ class BleEngine {
   final Future<int?> Function(String name)? cursorReader;
 
   final DeviceState state = DeviceState();
+
+  // ── PROCESS-WIDE SINGLE-OWNER GUARD ─────────────────────────────────────────
+  // The strap streams its historical offload to EVERY subscribed central. If two
+  // BleEngine instances in this process are connected at once — the foreground
+  // app engine AND the headless restore-drain engine (runHeadlessSync, fired by
+  // the iOS CoreBluetooth-restoration wake) — BOTH parse the same HISTORY_END and
+  // send CONFLICTING batch-ACKs with different seq numbers. The band's flash trim
+  // cursor then races and the offload never advances (observed on-device: batch
+  // stuck at 28, duplicate ACKs, sync never completes). Enforce a single owner,
+  // FOREGROUND-PRIORITY: a background drainer yields if the band is already owned;
+  // a foreground engine preempts a background owner by dropping its link.
+  static BleEngine? _bandOwner;
+
+  /// Claim exclusive ownership of the band for this engine. Returns false only for
+  /// a background drainer when another engine already owns it (→ it must NOT touch
+  /// the band this cycle). A foreground engine always succeeds and preempts any
+  /// background owner by disconnecting it.
+  bool _claimBand() {
+    final other = _bandOwner;
+    if (other != null && !identical(other, this)) {
+      if (isBackgroundDrainer) {
+        _log('band already owned by the foreground session — background drain '
+            'yielding (avoids duplicate ACKs on the same offload).');
+        return false;
+      }
+      _log('preempting a background drain to take the foreground session.');
+      unawaited(other.disconnect());
+    }
+    _bandOwner = this;
+    return true;
+  }
+
+  void _releaseBand() {
+    if (identical(_bandOwner, this)) _bandOwner = null;
+  }
 
   // ── transport state machine ─────────────────────────────────────────────────
   BleConnState _phase = BleConnState.idle;
@@ -238,6 +279,10 @@ class BleEngine {
   ClockRef? _clockRef; // strap-RTC ↔ wall correlation (set from GET_CLOCK)
   /// Latest strap-RTC ↔ wall correlation, or null until GET_CLOCK is answered.
   ClockRef? get clockRef => _clockRef;
+  /// SET_CLOCK re-issue attempts THIS connection. setClock() reads the clock
+  /// back, and the GET_CLOCK handler re-issues on drift — so cap the retries or
+  /// a firmware that never latches either payload form would loop forever.
+  int _clockCorrectTries = 0;
   int? _sessionOldestUnix; // strap's banked-data window (GET_DATA_RANGE)
   int? _sessionNewestUnix;
   DateTime? _bondTime; // when the handshake completed (bond confirmed)
@@ -399,6 +444,10 @@ class BleEngine {
       _log('connect: already connected to ${device.remoteId.str} — reusing.');
       return true;
     }
+    // SINGLE-OWNER: a background drainer must not open a second drain against a
+    // band the foreground session already owns (duplicate ACKs corrupt the trim
+    // cursor). Foreground engines preempt instead. See [_claimBand].
+    if (!_claimBand()) return false;
     // Any prior session is dead to us now — tear it down before a new one.
     await _teardownSession(intentional: true);
     return _doConnect(device);
@@ -520,6 +569,7 @@ class BleEngine {
       // Set the strap RTC to real wall-clock time. The band ships with an unset
       // clock; SET_CLOCK is non-destructive (it's what the official app does each
       // connect). Records stamped after this carry real unix time.
+      _clockCorrectTries = 0; // fresh retry budget for this connection
       await setClock();
       // Per-connection policy reset. Marginal-radio + post-bond-loop are NOT reset
       // here — they count consecutive bad cycles across reconnects and self-reset on
@@ -1006,11 +1056,16 @@ class BleEngine {
         ),
       );
     }
-    if (f.containsKey('alarm_epoch')) {
-      final e = f['alarm_epoch'] as int;
-      state.alarmEpoch = e > 1000000000 ? e : null;
-      onState(state);
-    }
+    // GET_ALARM_TIME readback is PARKED: the response byte layout isn't confirmed
+    // (the decode assumed a leading revision byte before the epoch that the band
+    // doesn't send → it returned a plausible-but-wrong epoch, e.g. showing 21:49
+    // for an alarm set to 11:14). The band has no independent alarm source — its
+    // alarm is always exactly what the app last wrote (SET_ALARM is HW-verified) —
+    // so the locally-set/persisted value in AppState is authoritative for display.
+    // Do NOT clobber it with the unconfirmed readback. If the response format is
+    // ever captured, decode it in parseCommandResponse and re-enable here.
+    //
+    // if (f.containsKey('alarm_epoch')) { ... }
     if (f.containsKey('strap_name')) {
       // Guard with cleanDeviceLabel: a garbled name read never overwrites the
       // last good one (keeps "?*" off the UI).
@@ -1037,10 +1092,23 @@ class BleEngine {
       final wall = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       _clockRef = ClockRef(device: dev, wall: wall);
       _log('Clock correlated: device=$dev wall=$wall (drift=${wall - dev}s).');
-      // Re-issue SET_CLOCK if the strap RTC has drifted > 1 day or is unset.
+      // Re-issue SET_CLOCK if the strap RTC has drifted > 1 day or is unset —
+      // but BOUND the retries: setClock() reads the clock back, so an unbounded
+      // re-issue on a firmware that never latches either payload form would spin
+      // SET_CLOCK/GET_CLOCK forever. Historical records carry their own embedded
+      // unix time regardless, so giving up after a few tries is safe.
       if (ClockPolicy.shouldSetClock(dev, wall)) {
-        _log('Clock drift over policy — re-issuing SET_CLOCK.');
-        unawaited(setClock());
+        if (_clockCorrectTries < 3) {
+          _clockCorrectTries++;
+          _log('Clock drift over policy — re-issuing SET_CLOCK '
+              '(attempt $_clockCorrectTries/3).');
+          unawaited(setClock());
+        } else {
+          _log('Clock still off after 3 SET_CLOCK attempts — giving up; '
+              'firmware may not accept our payload length.');
+        }
+      } else {
+        _clockCorrectTries = 0; // latched — reset for the next drift episode
       }
     }
     if (f.containsKey('range_oldest') && f.containsKey('range_newest')) {
@@ -1111,9 +1179,11 @@ class BleEngine {
       final tokenHex = m.token!
           .map((b) => b.toRadixString(16).padLeft(2, '0'))
           .join();
+      final r = d.bufferedRecTsRange;
       _log(
         '[SYNC] HistoryEnd batch=${m.batchId} records=${d.records} '
-        'token=$tokenHex',
+        'token=$tokenHex '
+        'recTs=${r == null ? "none" : "${r.$1}..${r.$2}"}',
       );
       // SAFE-TRIM INVARIANT: persist decoded+raw AND the continuation cursor
       // DURABLY (one transaction) BEFORE the ACK. The band trims its flash only
@@ -1305,21 +1375,40 @@ class BleEngine {
     return report;
   }
 
-  /// Set the strap RTC to current unix time: payload = [u32 epoch LE, u32 pad].
+  /// Set the strap RTC to current time — WHOOP-EXACT payload.
+  ///
+  /// The official WHOOP app (jadx: rh0/s0.java SetClockPacket, n92/a.java) sends
+  /// an 8-byte payload of TWO little-endian u32s: whole seconds at [0:4] and
+  /// SUB-SECONDS at [4:8], where subseconds are in units of 1/32768 s (a 32768 Hz
+  /// RTC crystal): `subsec = (millis % 1000) * 32768 / 1000` (0..32767, a u16 in
+  /// the low half of the second word). We previously sent zero subseconds, which
+  /// is a protocol divergence from what the strap firmware expects. Matching WHOOP
+  /// byte-for-byte here is the safe thing. Then read the clock back (GET_CLOCK) so
+  /// the response handler can VERIFY it latched and re-issue on drift.
   Future<void> setClock() async {
-    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    await _send(Cmd.setClock, [
-      now & 0xff,
-      (now >> 8) & 0xff,
-      (now >> 16) & 0xff,
-      (now >> 24) & 0xff,
+    final ms = DateTime.now().millisecondsSinceEpoch;
+    final sec = ms ~/ 1000;
+    final subsec = ((ms % 1000) * 32768) ~/ 1000; // 0..32767, 1/32768 s units
+    final payload = <int>[
+      sec & 0xff,
+      (sec >> 8) & 0xff,
+      (sec >> 16) & 0xff,
+      (sec >> 24) & 0xff,
+      subsec & 0xff,
+      (subsec >> 8) & 0xff,
       0,
       0,
-      0,
-      0,
-    ]);
-    _log('SET_CLOCK → $now (strap RTC aligned to real time).');
+    ];
+    await _send(Cmd.setClock, payload);
+    _log('SET_CLOCK → sec=$sec subsec=$subsec (WHOOP-exact 8B).');
+    // Read the RTC back so the GET_CLOCK response handler can confirm it latched
+    // (and re-issue SET_CLOCK if the strap clock is still off — see _onDecoded).
+    await getClock();
   }
+
+  /// Read the strap RTC. The response carries `clock_epoch`, handled where we
+  /// verify drift and re-correlate the strap-RTC ↔ wall clock.
+  Future<void> getClock() => _send(Cmd.getClock, const <int>[]);
 
   /// Smart alarm. Payload (7 bytes, LE):
   /// [0]=0x01 revision, [1:5]=u32 epoch seconds, [5:7]=u16 sub-seconds (0).
@@ -1426,6 +1515,11 @@ class BleEngine {
       } catch (_) {}
     }
     await _teardownSession(intentional: true);
+    // Release the single-owner claim ONLY on an intentional disconnect (not on a
+    // link-down we intend to reconnect from) so the band is free for a background
+    // drain once we've genuinely let go. If we were already preempted by another
+    // engine, _releaseBand no-ops (it only clears when we still hold the claim).
+    _releaseBand();
     _setPhase(BleConnState.idle);
     _log('Disconnected.');
   });
@@ -1473,10 +1567,18 @@ class BleEngine {
     final payload = frame.inner.length > 3
         ? Uint8List.sublistView(frame.inner, 3)
         : Uint8List(0);
+    // We scan every byte offset for a plausible unix u32 (the field layout isn't
+    // fully pinned), so the UPPER bound must be tight: a data-range timestamp can
+    // never be in the FUTURE. The old ceiling (2100000000 ≈ year 2036) let a
+    // spurious cross-field read land as "newest" — observed 2020230636 (year
+    // 2034) — which made `history_newest` garbage, so backlogRemains was
+    // PERMANENTLY true and the offload never recognized completion (it chased a
+    // 2034 target forever). Cap at wall-clock + 1 day (clock skew slack).
+    final maxPlausible = (DateTime.now().millisecondsSinceEpoch ~/ 1000) + 86400;
     final ts = <int>[];
     for (var off = 0; off + 4 <= payload.length; off++) {
       final v = u32(payload, off);
-      if (v >= 1600000000 && v <= 2100000000) {
+      if (v >= 1600000000 && v <= maxPlausible) {
         ts.add(v);
       }
     }
@@ -1520,6 +1622,27 @@ class _DrainController {
 
   int get bufferedRecords => _raws.length;
   int get lastProgressMs => _lastProgressAt.millisecondsSinceEpoch;
+
+  /// Min/max real record time (rec_ts) currently buffered for this batch — lets
+  /// us see whether the offload is serving a FROZEN/old timestamp block (the
+  /// time-frontier can't advance) vs. genuinely newer records. Diagnostic.
+  (int, int)? get bufferedRecTsRange {
+    var lo = 0, hi = 0;
+    var any = false;
+    for (final rec in _raws) {
+      final t = rec.recTs;
+      if (t == null || t <= 0) continue;
+      if (!any) {
+        lo = t;
+        hi = t;
+        any = true;
+      } else {
+        if (t < lo) lo = t;
+        if (t > hi) hi = t;
+      }
+    }
+    return any ? (lo, hi) : null;
+  }
   // Trim-advance tracking for the stuck/continuation detectors: a HISTORY_END
   // whose 8-byte token differs from the last one means the cursor moved.
   String? _lastAckedToken;

--- a/lib/cloud/backend_client.dart
+++ b/lib/cloud/backend_client.dart
@@ -7,16 +7,21 @@
 // {email, code} → {access_jwt, refresh_token, user}. Subsequent reads send
 // `Authorization: Bearer <access_jwt>`.
 //
-// Base URL: there is ONE backend now — the companion instance. This client shares
-// `CompanionClient.effectiveBase` (build-time `COMPANION_URL` → runtime override →
-// empty); there is no separate BACKEND_URL anymore. Everything the app talks to —
-// announcements, OTA, telemetry, AND this onboarding import — lives at that URL.
+// Base URL resolution (the open-source repo must NOT bake in a specific instance):
+//   1. a RUNTIME override the user set in-app ([BackendClient.overrideUrl]), else
+//   2. the BUILD-time `BACKEND_URL` (CI writes it from a repo secret into .env →
+//      `flutter build --dart-define-from-file=.env`; see .github/workflows/build.yml),
+//   3. else empty → the existing-user cloud import shows "not configured" and the
+//      user can point it at their own instance in Settings.
 
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
-import 'companion_client.dart';
+/// Build-time backend URL (CI `BACKEND_URL` secret via --dart-define-from-file).
+/// Empty when not provided — never a hard-coded personal instance.
+const String _buildBackendUrl =
+    String.fromEnvironment('BACKEND_URL', defaultValue: '');
 
 /// A non-2xx response (or an explicit `{error}` body) from the backend.
 class BackendException implements Exception {
@@ -36,8 +41,24 @@ class CloudSession {
 }
 
 class BackendClient {
+  /// User-set runtime override (Settings → Backend URL), loaded from prefs at
+  /// startup by AppState. Takes precedence over the build-time URL.
+  static String? overrideUrl;
+
+  /// The effective backend base: runtime override → build-time `BACKEND_URL` →
+  /// '' (unconfigured).
+  static String get effectiveBase {
+    final o = overrideUrl?.trim();
+    if (o != null && o.isNotEmpty) return _normalize(o);
+    return _normalize(_buildBackendUrl);
+  }
+
+  /// Strip a trailing slash so `'$base$path'` never doubles up.
+  static String _normalize(String u) =>
+      u.endsWith('/') ? u.substring(0, u.length - 1) : u;
+
   BackendClient({String? base, http.Client? client})
-      : base = base ?? CompanionClient.effectiveBase,
+      : base = base ?? effectiveBase,
         _http = client ?? http.Client();
 
   final String base;

--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -127,7 +127,13 @@ import 'substrate.dart';
 // 'auto_fallback', low confidence); a user can type/confirm a window
 // (sleep_override table → source 'manual'/'confirmed') which force-derives even
 // a finalized day. Bump so fallback-eligible days restage.
-const int kAlgoVersion = 28;
+// v29: COUNTER-RESET RECOVERY. The decoded substrate now dedupes by timestamp
+// (rec_ts, newest-wins) instead of by the strap counter, which resets on reboot
+// and silently quarantined every post-reboot day (empty "today", strain –). The
+// DB v21 migration re-decodes the whole raw ledger back into decoded_onehz, so
+// previously-quarantined days now have data. Bump so those days (and any finalized
+// day derived while data was missing) recompute against the recovered substrate.
+const int kAlgoVersion = 30;
 
 /// Raw is kept this many days past derivation, then pruned (derived stays).
 const int rawRetentionDays = 14;
@@ -2364,14 +2370,24 @@ class DerivationEngine {
             ana.SavedWorkoutSpan(r['start_ts'] as int, r['end_ts'] as int),
       ];
       final rhr = (scMap?['rhr'] as num?)?.round();
-      final detected = ana.autoDetectWorkouts(
-        hrTs: hrTs,
-        hrBpm: hrBpm,
-        restingBpm: rhr,
-        motion: motion,
-        savedSpans: savedSpans,
-      );
-      final bouts = detected.value ?? const [];
+      // Age-predicted HRmax (Tanaka) computed by the pipeline — drives the %HRR
+      // gate in the detector. Null when age is unknown (detector falls back).
+      final maxHr = (bundle['max_hr_used'] as num?)?.round();
+      // Auto-detection needs a real resting-HR baseline. Without one the detector
+      // can't compute a trustworthy %HRR floor and ordinary daytime HR reads as a
+      // workout. If we don't have a nightly RHR for this day yet, skip detection
+      // entirely (HRR for already-saved sessions below still runs).
+      final bouts = rhr == null
+          ? const <ana.DetectedWorkout>[]
+          : (ana.autoDetectWorkouts(
+                hrTs: hrTs,
+                hrBpm: hrBpm,
+                restingBpm: rhr,
+                maxBpm: maxHr,
+                motion: motion,
+                savedSpans: savedSpans,
+              ).value ??
+              const <ana.DetectedWorkout>[]);
 
       // HRR per bout from the per-second HR tail bracketing each bout end.
       final drops = <double>[];
@@ -2426,17 +2442,26 @@ class DerivationEngine {
             'created_at': DateTime.now().millisecondsSinceEpoch,
           });
         }
-        final first = bouts.first;
-        await NotificationCenter.instance.emit(NotificationEvent(
-          dedupeKey: '${day.date}:auto_workout',
-          category: NotifCategory.recovery,
-          priority: NotifPriority.normal,
-          title: 'Did you work out?',
-          body: 'We spotted ~${first.durationMin} min of elevated activity. '
-              'Tap to log it.',
-          date: day.date,
-          route: '/workouts',
-        ));
+        // Notify ONLY for a bout that ended in the last ~2 h (a near-real-time
+        // detection). Draining a backlog (e.g. an overnight gap) re-derives a whole
+        // day at once; without this every hours-old bout would fire a "did you work
+        // out?" prompt → a wall of notifications. Suggestions are still persisted
+        // above so they surface in the Workouts screen; we just don't ping for them.
+        final newest =
+            bouts.reduce((a, b) => a.endSec >= b.endSec ? a : b);
+        final freshlyEnded = (dataNowSec - newest.endSec) < 2 * 3600;
+        if (freshlyEnded) {
+          await NotificationCenter.instance.emit(NotificationEvent(
+            dedupeKey: '${day.date}:auto_workout',
+            category: NotifCategory.recovery,
+            priority: NotifPriority.normal,
+            title: 'Did you work out?',
+            body: 'We spotted ~${newest.durationMin} min of elevated activity. '
+                'Tap to log it.',
+            date: day.date,
+            route: '/workouts',
+          ));
+        }
       }
     } catch (e) {
       _log('auto-workout/HRR FAILED/skipped: $e');

--- a/lib/compute/derive_scheduler.dart
+++ b/lib/compute/derive_scheduler.dart
@@ -25,6 +25,15 @@ class DeriveScheduler {
   final Duration heavySettle;
 
   bool _offloadActive = false;
+  // While the app is backgrounded we must NOT run derivation: a derive pass
+  // decodes the whole retained substrate + runs the metric compute, and doing
+  // that on a short background BLE wake trips iOS's CPU watchdog
+  // (cpu_resource_fatal) or memory jetsam → the app gets terminated. Capture
+  // (persist + ACK) is lightweight and keeps running; the derive intent is
+  // durable in compute_jobs, so it simply waits and drains on foreground return
+  // (Android WorkManager / iOS BGProcessingTask still handle heavy passes with a
+  // proper OS budget). Held exactly like _offloadActive.
+  bool _background = false;
   bool _running = false;
   bool _pendingLight = false;
   bool _pendingHeavy = false;
@@ -44,6 +53,7 @@ class DeriveScheduler {
 
   Map<String, dynamic> snapshot() => {
         'offload_active': _offloadActive,
+        'background': _background,
         'running': _running,
         'pending_light': _pendingLight,
         'pending_heavy': _pendingHeavy,
@@ -72,6 +82,24 @@ class DeriveScheduler {
     _arm();
   }
 
+  /// Foreground/background gate. While backgrounded, derivation is held (heavy
+  /// compute on a background BLE wake gets the app killed by the OS). Queued jobs
+  /// stay durable and drain when we come back to the foreground.
+  void setBackground(bool background) {
+    if (_background == background) return;
+    _background = background;
+    if (background) {
+      _timer?.cancel();
+      _timer = null;
+      log('[derive-scheduler] backgrounded — deferring derive to foreground');
+      onChanged();
+      return;
+    }
+    log('[derive-scheduler] foregrounded — draining deferred derive work');
+    onChanged();
+    _arm();
+  }
+
   void dispose() {
     _timer?.cancel();
     _timer = null;
@@ -87,7 +115,7 @@ class DeriveScheduler {
   }
 
   void _arm() {
-    if (_running || _offloadActive) return;
+    if (_running || _offloadActive || _background) return;
     if (!_pendingLight && !_pendingHeavy) {
       unawaited(_refreshSnapshot());
       return;
@@ -100,7 +128,7 @@ class DeriveScheduler {
   }
 
   Future<void> _drain() async {
-    if (_running || _offloadActive) return;
+    if (_running || _offloadActive || _background) return;
     _timer?.cancel();
     _timer = null;
     final job = await LocalDb.takeNextComputeJob();

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -41,6 +41,38 @@ class LocalDb {
     final path = p.join(dir, dbName);
     return openDatabase(
       path,
+      onConfigure: (db) async {
+        // WRITE PERFORMANCE. The default rollback journal (journal_mode=delete)
+        // with synchronous=FULL fsyncs the whole DB on every commit — brutal for
+        // the high-volume sync-ingest and the raw re-decode migration on a large
+        // ledger. WAL + synchronous=NORMAL is the standard mobile config: writers
+        // append to a -wal file and don't block readers, with one fsync per
+        // checkpoint instead of per commit. journal_mode is persistent per-file;
+        // synchronous/cache_size are per-connection so we set them every open.
+        // Durability trade-off under NORMAL: a crash/power-loss can lose only the
+        // last uncheckpointed transactions, never corrupt the DB — fine here since
+        // raw is re-syncable from the band and derived is recomputable.
+        //
+        // CRITICAL: a perf PRAGMA must NEVER prevent the DB from opening (a throw
+        // here fails openDatabase → the app is stuck on the loading screen). And
+        // `PRAGMA journal_mode=WAL` RETURNS A ROW ("wal"), so on the iOS sqflite
+        // Darwin backend it MUST be issued via rawQuery — `execute()` on a
+        // value-returning pragma throws DatabaseException("not an error") and
+        // bricks the open (confirmed on device). So: rawQuery + try/catch.
+        try {
+          await db.rawQuery('PRAGMA journal_mode=WAL');
+        } catch (_) {
+          /* keep the default journal — this is a perf tweak, not a requirement */
+        }
+        try {
+          await db.execute('PRAGMA synchronous=NORMAL');
+          // ~40 MB page cache (negative = KiB) so hot b-tree pages stay resident
+          // on a 150 MB+ DB instead of being re-read from disk each query.
+          await db.execute('PRAGMA cache_size=-40000');
+        } catch (_) {
+          /* non-fatal */
+        }
+      },
       onCreate: (db, version) async {
         await _createRaw(db);
         await _createSamples(db);
@@ -210,6 +242,17 @@ class LocalDb {
           // "is this right?" confirm). Additive table; survives algo bumps.
           await _createSleepOverride(db);
         }
+        // NOTE (counter-reset recovery): we deliberately do NOT re-decode the raw
+        // ledger here. onUpgrade runs synchronously inside openDatabase, so a
+        // full 500k-row re-decode would burn tens of seconds of CPU on the launch
+        // path and iOS would CPU-watchdog-kill the app → stuck on loading. It is
+        // also unnecessary: the write path now dedupes by rec_ts with REPLACE
+        // (see _queueDecodedOneHz), and the derivation coordinator already FALLS
+        // BACK to decoding raw_records directly for any day-range whose decoded
+        // rows are absent (see _loadSubstrateRange). So the reboot-quarantined
+        // days recover on the next re-derive (triggered by the kAlgoVersion bump),
+        // which runs paged + in a worker isolate AFTER the app is up — never on
+        // the openDatabase critical path.
       },
       onOpen: (db) async {
         await _repairOpenSchema(db);
@@ -234,6 +277,21 @@ class LocalDb {
     await _createComputeState(db);
     await _createPrimitiveArtifacts(db);
     await _createDecodedStore(db);
+    // Drop leftover DUPLICATE indexes from an old canonical-store rebuild. When
+    // `_rebuildCanonicalDecodedStore` renamed `_decoded_*_new` → `decoded_*`, the
+    // temp `_new`-named indexes rode along and now shadow the canonical ones on
+    // the SAME columns — so every decoded insert (the hottest write path) updated
+    // twice as many b-trees as needed. The canonical indexes are (re)created by
+    // _createDecodedStore just above; these `_new` duplicates are pure write tax.
+    for (final ix in const [
+      'idx_decoded_onehz_new_rects',
+      'idx_decoded_onehz_new_rec_ts_unique',
+      'idx_decoded_rr_new_counter',
+      'idx_decoded_rr_new_ts',
+      'idx_decoded_rr_new_ts_beat_unique',
+    ]) {
+      await db.execute('DROP INDEX IF EXISTS $ix');
+    }
     await _createLiveCoverage(db);
     await _createCycleSymptom(db);
     await _ensureRawRecordSchema(db);
@@ -755,10 +813,21 @@ class LocalDb {
     if (!names.contains('rec_ts')) {
       await _addRecTsColumn(db);
       await _backfillRecTs(db);
-      await db.execute(
-        'CREATE INDEX IF NOT EXISTS idx_raw_rects ON raw_records(rec_ts)',
-      );
     }
+    // ALWAYS ensure the rec_ts index exists — NOT only when the column was just
+    // added. The v8 rebuild (RENAME + recreate) ran with an older _createRaw that
+    // did not recreate this index, so DBs upgraded through v8 have the rec_ts
+    // COLUMN but NO index. Every DerivationEngine pass filters/orders
+    // raw_records by rec_ts, so without it a large ledger (100k+ rows) does a
+    // full table SCAN + temp-b-tree sort on every derive → the app crawls.
+    // CREATE INDEX IF NOT EXISTS is a cheap no-op once it's present.
+    await db.execute(
+      'CREATE INDEX IF NOT EXISTS idx_raw_rects ON raw_records(rec_ts)',
+    );
+    await db.execute(
+      'CREATE INDEX IF NOT EXISTS idx_raw_unuploaded '
+      'ON raw_records(uploaded, captured_at) WHERE uploaded = 0',
+    );
   }
 
   static Future<void> _ensureSessionSchema(Database db) async {
@@ -1351,6 +1420,15 @@ class LocalDb {
     final decoded = _decodeOneHzSample(raw, preferred: sample);
     if (decoded == null) return;
     final recTs = raw.recTs ?? decoded.tsEpoch;
+    // TIME-KEYED, NEWEST-WINS (noop/WHOOP-4 model: dedupe records by their
+    // embedded timestamp, not by a counter). decoded_onehz has a UNIQUE(rec_ts)
+    // index and decoded_rr a UNIQUE(rr_ts_ms, beat_index). We use REPLACE, not
+    // IGNORE: the strap's record `counter` RESETS to ~0 on every reboot, so a
+    // post-reboot record whose second already had a row would be SILENTLY DROPPED
+    // under IGNORE — quarantining everything after a reboot (observed: whole days
+    // present in raw_records but absent from the decoded substrate the engine
+    // reads → "not worn / metrics still computing / strain –"). REPLACE lets the
+    // freshly-offloaded record for a given second win, which is what we want.
     batch.insert('decoded_onehz', {
       'counter': raw.counter,
       'rec_ts': recTs,
@@ -1361,7 +1439,7 @@ class LocalDb {
       'spo2_red_raw': decoded.spo2RedRaw ?? 0,
       'spo2_ir_raw': decoded.spo2IrRaw ?? 0,
       'skin_temp_raw': decoded.skinTempRaw ?? 0,
-    }, conflictAlgorithm: ConflictAlgorithm.ignore);
+    }, conflictAlgorithm: ConflictAlgorithm.replace);
     for (var i = 0; i < decoded.rrIntervalsMs.length; i++) {
       final rr = decoded.rrIntervalsMs[i];
       if (rr <= 0) continue;
@@ -1370,7 +1448,7 @@ class LocalDb {
         'beat_index': i,
         'rr_ts_ms': recTs * 1000,
         'rr_ms': rr,
-      }, conflictAlgorithm: ConflictAlgorithm.ignore);
+      }, conflictAlgorithm: ConflictAlgorithm.replace);
     }
   }
 

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -354,11 +354,18 @@ class LocalRepositoryImpl extends LocalRepository {
       (getProfileMap()?['step_goal'] as num?)?.toInt() ?? 10000;
 
   num? _wearMin(Map<String, dynamic> b) {
+    // Wear = RECORD presence (the band logs 1 Hz to flash ONLY while worn), NOT
+    // hr_valid/60. HR only locks when still (mostly sleep), so hr_valid collapsed
+    // wear to ~half a day — the "wore it all day, shows half" bug, on BOTH
+    // platforms. Prefer the engine wear block's record-presence worn_min; fall
+    // back to the TOTAL record count (hr_samples, not hr_valid); never hr_valid.
+    // Mirrors getDayWear so the summary tile and the wear detail agree.
+    final w = b['wear'] is Map ? (b['wear'] as Map).cast<String, dynamic>() : null;
+    final fromBlock = (w?['worn_min'] as num?);
+    if (fromBlock != null) return fromBlock;
     final cov = _sub(b, 'coverage');
-    final hr = (cov?['hr_valid'] as num?)?.toInt();
-    return hr == null
-        ? null
-        : (hr / 60).round(); // 1 Hz valid samples → minutes
+    final total = (cov?['hr_samples'] as num?)?.toInt();
+    return total == null ? null : (total / 60).round();
   }
 
   Map<String, dynamic> _sleepSummary(Map<String, dynamic> b) {

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1012,6 +1012,10 @@ class AppState extends ChangeNotifier {
   /// On Android the Edge Tracking foreground service keeps the process + connection alive.
   Future<void> pauseForBackground() async {
     _background = true;
+    // Defer derivation while backgrounded — running the heavy derive pass on a
+    // short background BLE wake gets the app killed (iOS CPU watchdog / jetsam).
+    // Capture keeps running; queued derive jobs drain on foreground return.
+    _deriveScheduler.setBackground(true);
     if (Platform.isAndroid) {
       // Android: ensure the Edge Tracking foreground service is up (idempotent) so the
       // process + live connection survive backgrounding. The service IS the keep-alive.
@@ -1055,9 +1059,12 @@ class AppState extends ChangeNotifier {
   // taps the RR-bearing frames (0x28 compact HR, 0x2B R10) into the in-memory
   // scan buffer. Cheap-bounded; cleared at each scan start.
   void _onLiveFrame(int pt, String hex, int? recTs) {
-    if (recTs != null && recTs > 0 && recTs > (_lastRecTs ?? 0)) {
-      _lastRecTs = recTs;
-    }
+    // NOTE: deliberately do NOT advance _lastRecTs from live frames. Live frames
+    // (0x28/0x2B/0x33) are ephemeral and NEVER persisted, and they carry the
+    // CURRENT wall-clock time — so bumping _lastRecTs here pinned the "last data"
+    // label to "now" while the app was connected, hiding whether the overnight
+    // HISTORICAL backlog had actually synced. "Last data" must reflect the newest
+    // STORED record (the data edge), which only _onRecord advances.
     if (spotActive && (pt == 0x28 || pt == 0x2B)) {
       if (_spotFrames.length < 8000) _spotFrames.add(hex);
     }
@@ -1312,7 +1319,13 @@ class AppState extends ChangeNotifier {
 
   Future<SyncReport> _runSyncBurst({
     required bool kickFirst,
-    int maxSessions = 6,
+    // A band that hasn't synced for days can hold a HUGE flash backlog (observed:
+    // ~2 weeks / hundreds of thousands of records), and an RTC-loss can leave a
+    // large frozen-timestamp block the drain must grind THROUGH to reach newer
+    // data. 6 sessions wasn't enough to catch up; 20 lets a big backlog drain in
+    // one foreground burst. Each session still early-exits on completion / no
+    // real progress, so this only runs long when there's genuinely a lot to pull.
+    int maxSessions = 20,
   }) async {
     var last = SyncReport(0, 0, false);
     for (var i = 0; i < maxSessions && engine.isConnected; i++) {
@@ -1350,11 +1363,29 @@ class AppState extends ChangeNotifier {
         _log('Backfill stop — no batch ACKs; trim did not advance.');
         break;
       }
-      if (!frontierAdvanced) {
+      if (!frontierAdvanced && !backlogRemains) {
+        // Frontier didn't advance AND the strap reports nothing newer than what
+        // we already hold → genuinely nothing more to pull (or a pure re-send).
         _log(
-          'Backfill stop — batch ACKed but persisted frontier did not advance.',
+          'Backfill stop — frontier did not advance and no backlog remains '
+          '(strap newest=$strapNewest, frontier=$frontierAfter).',
         );
         break;
+      }
+      if (!frontierAdvanced) {
+        // Frontier stuck but the strap says it HAS newer data. This happens when
+        // a stretch of flash carries STALE/duplicate timestamps — e.g. the band
+        // rebooted, lost its RTC, and recorded for a while with a frozen clock
+        // before SET_CLOCK re-latched. The rec_ts frontier can't advance across
+        // that block, but the flash read cursor IS walking forward (batches>0),
+        // so DON'T stop — drain through the stale block to reach the newer,
+        // correctly-stamped records behind it. Bounded by maxSessions.
+        _log(
+          'Backfill continuation ${i + 1}/$maxSessions — frontier stuck on a '
+          'stale-timestamp block but strap reports backlog '
+          '(newest=$strapNewest > frontier=$frontierAfter); draining through.',
+        );
+        continue;
       }
       if (!backlogRemains) break;
       _log(
@@ -1418,8 +1449,11 @@ class AppState extends ChangeNotifier {
 
   // ── alarm + strap name (require a live connection) ──────────────────────────
   bool get isConnected => device.connection == 'connected';
-  // Prefer a value read back from the band; else the one we last set (persisted),
-  // since the band's GET_ALARM echo format isn't fully confirmed.
+  // The locally-set value is authoritative: the band has no independent alarm
+  // source (its alarm is always what the app last wrote, and SET_ALARM is
+  // HW-verified), while the GET_ALARM readback format is unconfirmed and was
+  // clobbering the display (see the parked block in ble_engine._onDecoded).
+  // device.alarmEpoch = this-session optimistic set; _savedAlarm = persisted.
   int? get alarmEpoch => device.alarmEpoch ?? _savedAlarm;
   String? get strapName => device.strapName;
   int? _savedAlarm;
@@ -1462,6 +1496,9 @@ class AppState extends ChangeNotifier {
     // background): don't tear it down and reconnect — just reclaim ownership.
     final wasBackground = _background;
     _background = false;
+    // Back in the foreground with an OS CPU/memory budget again — let the
+    // scheduler drain any derive jobs that queued (durably) while backgrounded.
+    _deriveScheduler.setBackground(false);
     if (wasBackground && engine.isConnected) {
       IosBleRestore.foregroundActive = true;
       await IosBleRestore.setOwnsBand(true);
@@ -1474,13 +1511,14 @@ class AppState extends ChangeNotifier {
       // re-subscribes (the only place setNotifyValue runs) and drains the gap.
       if (engine.sinceLastRx < const Duration(seconds: 30)) {
         // Healthy link → fast reclaim. But the fast path skips the band polls the full
-        // connect path runs, so the cached battery %/charging/strap-name/alarm go stale.
+        // connect path runs, so the cached battery %/charging/strap-name go stale.
         // Re-poll them in the background so the UI stays current. Non-blocking.
+        // (Alarm is NOT re-polled: the readback format is unconfirmed and the local
+        // set value is authoritative — see the parked block in ble_engine._onDecoded.)
         unawaited(() async {
           try {
             await engine.getBattery();
             await engine.getStrapName();
-            await engine.getAlarm();
           } catch (_) {}
         }());
         _startBackfillTimer();
@@ -1514,14 +1552,21 @@ class AppState extends ChangeNotifier {
             '(official WHOOP app force-quit)?';
         return;
       }
-      await engine.enableLiveStreams();
-      _resetLivePedometer(); // fresh live step count for this connected session
       await engine.getBattery();
-      await engine
-          .getStrapName(); // populate strap name + alarm for the Profile UI
-      await engine.getAlarm();
-      _log('Listening (history + live).');
-      // Block until the band's backlog is fully handed over (HISTORY_COMPLETE) —
+      await engine.getStrapName(); // populate strap name for the Profile UI
+      // Alarm is displayed from the locally-set/persisted value (authoritative);
+      // the GET_ALARM readback is parked (unconfirmed format) — see ble_engine.
+      _log('Listening (history first, live after catch-up).');
+      // Drain the backlog BEFORE enabling the high-rate live flood. A fresh connect
+      // after a long gap can hold hours of flash (observed: an overnight ~11h block
+      // that re-drains from the bottom on every offload until it fully lands). The
+      // R10/R11 + IMU + optical flood competes with the historical offload for the
+      // radio and stalls it (60s mid-offload silences → abandon/re-send), so the
+      // big first drain never finishes and "last data" appears frozen. Dedicate the
+      // link to the offload first, exactly as the reconnect path already does, then
+      // turn on live streams once we've caught up.
+      //
+      // Blocks until the band's backlog is fully handed over (HISTORY_COMPLETE) —
       // does NOT abort or end the listen. Per-batch derives already fired via the
       // debounced onDataStored; once the WHOLE backlog has landed we run the heavy
       // foreground finalize (full sleep staging + 24-h spectra over every stale day).
@@ -1530,6 +1575,8 @@ class AppState extends ChangeNotifier {
         'Backlog drained: ${report.records} records in ${report.batches} '
         'batches (${report.complete ? "complete" : "stopped early"}).',
       );
+      await engine.enableLiveStreams();
+      _resetLivePedometer(); // fresh live step count for this connected session
       dbCounts = await LocalDb.counts();
       _deriveScheduler.requestHeavy();
       _startBackfillTimer();

--- a/lib/sync/background_sync.dart
+++ b/lib/sync/background_sync.dart
@@ -55,6 +55,11 @@ Future<bool> runHeadlessSync() async {
       onCommitBatch: (raws, samples, trimTokenHex) =>
           LocalDb.commitSyncBatch(raws, samples, trimToken: trimTokenHex),
       cursorReader: LocalDb.getCursorInt,
+      // Mark this as the background drainer: if the foreground app engine already
+      // owns the band (same process — iOS restore-wake OR Android headless boot /
+      // foreground service), this engine YIELDS instead of opening a second drain
+      // that would double-ACK the same offload and stall the trim cursor.
+      isBackgroundDrainer: true,
     );
 
     // connect() subscribes → SET_CLOCK → INIT, so the historical offload is already

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -731,20 +731,16 @@ packages:
   openstrap_analytics:
     dependency: "direct main"
     description:
-      path: "."
-      ref: main
-      resolved-ref: c1a68a0713b3bada7d7cdd650a695fc164f7848f
-      url: "https://github.com/OpenStrap/analytics.git"
-    source: git
+      path: "../openstrap-analytics-onehz"
+      relative: true
+    source: path
     version: "1.0.0"
   openstrap_protocol:
     dependency: "direct main"
     description:
-      path: "."
-      ref: main
-      resolved-ref: dc64c4e50d04ff6003843d05669bfe27c756d273
-      url: "https://github.com/OpenStrap/protocol.git"
-    source: git
+      path: "../openstrap-protocol-dart"
+      relative: true
+    source: path
     version: "1.0.0"
   ota_update:
     dependency: "direct main"

--- a/test/local_persistence_test.dart
+++ b/test/local_persistence_test.dart
@@ -282,6 +282,103 @@ void main() {
   );
 
   test(
+    'counter reset does not quarantine the decoded second (newest-wins by rec_ts)',
+    () async {
+      // Reproduce the reboot bug: the strap counter RESETS to ~0 on reboot, so a
+      // post-reboot record can land on a second that a pre-reboot (high-counter)
+      // record already wrote. The decoded store dedupes by rec_ts; the OLD
+      // INSERT-OR-IGNORE dropped the newcomer → everything after a reboot became
+      // invisible to analytics. It must now REPLACE (newest-wins) so the fresh
+      // record is kept.
+      final sec = DateTime(2026, 6, 30, 2, 0).millisecondsSinceEpoch ~/ 1000;
+
+      // Pre-reboot record: high counter, this second.
+      await LocalDb.insertRecord(
+        RawRecord(
+          counter: 34000000,
+          packetType: 47,
+          hex: 'pre-reboot',
+          capturedAt: sec * 1000,
+          recTs: sec,
+        ),
+        Sample(
+          tsEpoch: sec,
+          counter: 34000000,
+          hr: 61,
+          ax: 0.0,
+          ay: 0.0,
+          az: 1.0,
+          spo2RedRaw: 1,
+          spo2IrRaw: 1,
+          skinTempRaw: 1,
+        ),
+      );
+
+      // Post-reboot record: counter has reset to a low value, SAME second, but a
+      // fresher reading (hr=77). Under the old IGNORE this was dropped.
+      await LocalDb.insertRecord(
+        RawRecord(
+          counter: 42,
+          packetType: 47,
+          hex: 'post-reboot',
+          capturedAt: (sec + 3600) * 1000,
+          recTs: sec,
+        ),
+        Sample(
+          tsEpoch: sec,
+          counter: 42,
+          hr: 77,
+          ax: 0.0,
+          ay: 0.0,
+          az: 1.0,
+          spo2RedRaw: 2,
+          spo2IrRaw: 2,
+          skinTempRaw: 2,
+        ),
+      );
+
+      final frames = await LocalDb.decodedOneHzBatchByRecTsRange(
+        limit: 10,
+        fromRecTs: sec - 1,
+        toRecTs: sec + 1,
+      );
+      // Exactly one row for the second, and it is the POST-reboot reading.
+      expect(frames, hasLength(1));
+      expect(frames.first['hr'], 77);
+      expect(frames.first['counter'], 42);
+
+      // A post-reboot record on a brand-new second is also stored (not gated by
+      // any stale counter high-water).
+      await LocalDb.insertRecord(
+        RawRecord(
+          counter: 43,
+          packetType: 47,
+          hex: 'post-reboot-2',
+          capturedAt: (sec + 3601) * 1000,
+          recTs: sec + 1,
+        ),
+        Sample(
+          tsEpoch: sec + 1,
+          counter: 43,
+          hr: 78,
+          ax: 0.0,
+          ay: 0.0,
+          az: 1.0,
+          spo2RedRaw: 3,
+          spo2IrRaw: 3,
+          skinTempRaw: 3,
+        ),
+      );
+      final after = await LocalDb.decodedOneHzBatchByRecTsRange(
+        limit: 10,
+        fromRecTs: sec - 1,
+        toRecTs: sec + 2,
+      );
+      expect(after, hasLength(2));
+    },
+  );
+
+  test(
     'structured band signals persist event history and battery samples',
     () async {
       const eventHex = '3000070000105e5f';


### PR DESCRIPTION
Restore uncommitted work reverted by an editor rewind, recovered from Claude Code file-history snapshots (pre-15:23 versions). Verified: edge analyze 0 errors + 103 tests pass; analytics 258 tests pass; protocol analyze clean.

Deltas over HEAD: unified BLE connector + offload-frame pipeline (ble_engine), compute_jobs durable derive queue (db), DeriveScheduler ingest/derive decoupling, derivation_engine, local_repository_impl, background_sync, backend_client.