### PR TITLE
release: v0.8.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openstrap_edge
 description: "OpenStrap — open-source WHOOP 4.0 companion. BLE drain → raw-first local store → cloud sync."
 publish_to: 'none'
-version: 0.7.1+18
+version: 0.8.0+19
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
Version bump for the v0.8.0 release (build 18 -> 19): local-first revamp (design system, AI briefings, custom icons, splash), GPS workout routes, and the iOS BLE background-reliability + icon-wiring fixes merged in PR #38.