### PR TITLE
fix: pubspec.lock resolves openstrap_icons via git ref, not stale local path

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -859,23 +859,29 @@ packages:
   openstrap_analytics:
     dependency: "direct main"
     description:
-      path: "../openstrap-analytics-onehz"
-      relative: true
-    source: path
+      path: "."
+      ref: main
+      resolved-ref: "743c3d7a1b511c016c86c14c8981ae1fdb46a98c"
+      url: "https://github.com/OpenStrap/analytics.git"
+    source: git
     version: "1.0.0"
   openstrap_icons:
     dependency: "direct main"
     description:
-      path: "../openstrap_icons"
-      relative: true
-    source: path
+      path: "."
+      ref: main
+      resolved-ref: "91f0309a4f1dcd36df2c504b5170f76c6e5ce767"
+      url: "https://github.com/OpenStrap/icons.git"
+    source: git
     version: "0.1.0"
   openstrap_protocol:
     dependency: "direct main"
     description:
-      path: "../openstrap-protocol-dart"
-      relative: true
-    source: path
+      path: "."
+      ref: main
+      resolved-ref: d2a4fa51693a8d1d790d0f3281c7e2c5db27eac7
+      url: "https://github.com/OpenStrap/protocol.git"
+    source: git
     version: "1.0.0"
   ota_update:
     dependency: "direct main"


### PR DESCRIPTION
Fixes the actual cause of v0.8.0's failed APK/IPA build: pubspec.lock had a local path: resolution for openstrap_icons baked in from a dev-only pubspec_overrides.yaml, instead of the git ref pubspec.yaml declares. CI resolves the real ref and was missing 25+ OsIcon members (fixed upstream in OpenStrap/icons#2). Regenerated the lock with the override removed; verified both `flutter build apk --release` and `flutter build ios --release --no-codesign` locally.