### PR TITLE
release: v0.8.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openstrap_edge
 description: "OpenStrap — open-source WHOOP 4.0 companion. BLE drain → raw-first local store → cloud sync."
 publish_to: 'none'
-version: 0.8.0+19
+version: 0.8.1+20
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
Version bump for the v0.8.1 release, following PR #44 (BLE connection/sync
redundancy, derivation-engine concurrency, platform-standards compliance,
CI/Xcode signing fixes).

Bump build 19 -> 20.