### PR TITLE
fix: foreground-aware derive-debounce so results are ready when the app opens

### DIFF
--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -359,9 +359,11 @@ class BleEngine {
 
   /// Tunable debounce window for [onDataStored]. Default coalesces a burst once the
   /// stream goes quiet. The debouncer can run in a fast stale mode or a calmer
-  /// fresh mode depending on [deriveDataStaleness].
+  /// fresh mode depending on [deriveDataStaleness] — or a fast foreground mode
+  /// depending on [isForegroundActive], which takes priority over both.
   final DeriveDebouncer deriveDebouncer;
   final Duration Function() deriveDataStaleness;
+  final bool Function() isForegroundActive;
 
   BleEngine({
     required this.onRecord,
@@ -378,6 +380,7 @@ class BleEngine {
     this.deriveDebouncer = const DeriveDebouncer(),
     this.isBackgroundDrainer = false,
     this.deriveDataStaleness = _defaultDeriveDataStaleness,
+    this.isForegroundActive = _defaultIsForegroundActive,
   });
 
   /// True for the headless restore-drain engine (runHeadlessSync). It YIELDS the
@@ -386,6 +389,10 @@ class BleEngine {
   final bool isBackgroundDrainer;
 
   static Duration _defaultDeriveDataStaleness() => const Duration(days: 3650);
+  // Callers that never wire this (e.g. the headless background drainer, which
+  // has no concept of foreground at all) correctly default to false — the
+  // fresh/stale staleness tiers still apply, unaffected.
+  static bool _defaultIsForegroundActive() => false;
 
   /// Optional reader for a persisted cursor value (e.g. counter_hw) so the engine
   /// can seed its frontier from the durable store on connect — making the stuck/
@@ -750,6 +757,7 @@ class BleEngine {
         sinceLastRecord: DateTime.now().difference(_lastStored),
         sinceFirstPending: DateTime.now().difference(fp),
         dataStaleness: deriveDataStaleness(),
+        isForeground: isForegroundActive(),
       );
       if (fire) {
         _firstPending = null;

--- a/lib/ble/ble_state.dart
+++ b/lib/ble/ble_state.dart
@@ -348,6 +348,8 @@ class DeriveDebouncer {
   final Duration freshQuietPeriod;
   final Duration freshMaxWait;
   final Duration staleThreshold;
+  final Duration foregroundQuietPeriod;
+  final Duration foregroundMaxWait;
 
   const DeriveDebouncer({
     this.staleQuietPeriod = const Duration(seconds: 12),
@@ -355,22 +357,45 @@ class DeriveDebouncer {
     this.freshQuietPeriod = const Duration(minutes: 1),
     this.freshMaxWait = const Duration(minutes: 5),
     this.staleThreshold = const Duration(minutes: 30),
+    // A THIRD tier, independent of data staleness: while the app is in the
+    // foreground, a human is plausibly staring at the screen waiting for
+    // their just-synced number. The fresh-mode tier's whole rationale (avoid
+    // paying compute/battery cost for every trickle of ambient live data) is
+    // moot when the screen is already on — the cost of deriving sooner is
+    // the same either way, only the WAIT changes. Without this, the exact
+    // moment a catch-up sync's data staleness drops below staleThreshold
+    // (i.e. records finally reach "now" — precisely what the user is
+    // waiting on) is also the moment the debounce flips to its SLOWEST
+    // tier. This tier takes priority over fresh/stale whenever foreground.
+    this.foregroundQuietPeriod = const Duration(seconds: 5),
+    this.foregroundMaxWait = const Duration(seconds: 15),
   });
 
   /// Should we derive now, given the pending-record bookkeeping?
   ///   [hasPending]       — records persisted since the last derive
   ///   [sinceLastRecord]  — how long since the most recent persisted record
   ///   [sinceFirstPending]— how long since the first record of the current dirty run
+  ///   [isForeground]     — the app is actively in the foreground right now;
+  ///                        takes priority over the fresh/stale staleness
+  ///                        tiers when true (see foregroundQuietPeriod doc)
   bool shouldDerive({
     required bool hasPending,
     required Duration sinceLastRecord,
     required Duration sinceFirstPending,
     required Duration dataStaleness,
+    bool isForeground = false,
   }) {
     if (!hasPending) return false;
-    final staleMode = dataStaleness >= staleThreshold;
-    final quietPeriod = staleMode ? staleQuietPeriod : freshQuietPeriod;
-    final maxWait = staleMode ? staleMaxWait : freshMaxWait;
+    Duration quietPeriod;
+    Duration maxWait;
+    if (isForeground) {
+      quietPeriod = foregroundQuietPeriod;
+      maxWait = foregroundMaxWait;
+    } else {
+      final staleMode = dataStaleness >= staleThreshold;
+      quietPeriod = staleMode ? staleQuietPeriod : freshQuietPeriod;
+      maxWait = staleMode ? staleMaxWait : freshMaxWait;
+    }
     if (sinceLastRecord >= quietPeriod) return true; // stream went quiet
     if (sinceFirstPending >= maxWait) return true; // never-quiet floor
     return false;

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -624,6 +624,15 @@ class AppState extends ChangeNotifier {
         final at = DateTime.fromMillisecondsSinceEpoch(ts * 1000);
         return DateTime.now().difference(at);
       },
+      // Foreground-aware debounce tier (see DeriveDebouncer's doc): without
+      // this, a catch-up sync's data staleness dropping below the fresh/stale
+      // threshold — i.e. records finally reaching "now", exactly what the
+      // user is watching for — flips the debounce into its SLOWEST tier
+      // (60s quiet / 5min floor) at precisely the worst moment. `_background`
+      // already exists for the derive-scheduler's own foreground/background
+      // gate (see pauseForBackground/openSession); reusing it here costs
+      // nothing new and keeps both signals consistent with each other.
+      isForegroundActive: () => !_background,
     );
     repo = LocalRepositoryImpl(getProfileMap: () => user);
     // iOS BGProcessing/BGAppRefresh wakes while the FOREGROUND app owns the band

--- a/test/ble_state_test.dart
+++ b/test/ble_state_test.dart
@@ -455,5 +455,88 @@ void main() {
         );
       },
     );
+
+    test(
+        'foreground mode fires MUCH sooner than fresh mode at the exact same '
+        '(short) staleness — the case that used to hit the slowest tier right '
+        'when the user is watching', () {
+      // dataStaleness has just dropped below staleThreshold (a catch-up sync
+      // reaching "now") — without isForeground this would be fresh mode
+      // (1min quiet / 5min floor). With isForeground it must NOT wait that
+      // long: the foreground tier (5s quiet / 15s floor) takes priority.
+      expect(
+        d.shouldDerive(
+          hasPending: true,
+          sinceLastRecord: const Duration(seconds: 6),
+          sinceFirstPending: const Duration(seconds: 10),
+          dataStaleness: const Duration(minutes: 5),
+          isForeground: true,
+        ),
+        isTrue, // 6s quiet >= the 5s foreground quiet period
+      );
+      // The SAME inputs without isForeground must NOT fire yet (fresh mode).
+      expect(
+        d.shouldDerive(
+          hasPending: true,
+          sinceLastRecord: const Duration(seconds: 6),
+          sinceFirstPending: const Duration(seconds: 10),
+          dataStaleness: const Duration(minutes: 5),
+          isForeground: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('foreground mode still respects its own (short) floor', () {
+      expect(
+        d.shouldDerive(
+          hasPending: true,
+          sinceLastRecord: const Duration(seconds: 2), // stream still active
+          sinceFirstPending: const Duration(seconds: 14),
+          dataStaleness: const Duration(hours: 2),
+          isForeground: true,
+        ),
+        isFalse, // under both the 5s quiet and the 15s floor
+      );
+      expect(
+        d.shouldDerive(
+          hasPending: true,
+          sinceLastRecord: const Duration(seconds: 2),
+          sinceFirstPending: const Duration(seconds: 15),
+          dataStaleness: const Duration(hours: 2),
+          isForeground: true,
+        ),
+        isTrue, // hits the 15s floor even though the stream never went quiet
+      );
+    });
+
+    test('foreground mode overrides stale mode too (still just the fastest '
+        'reasonable tier, not slower)', () {
+      // Even in stale mode's territory (dataStaleness >= 30min), foreground
+      // is at least as fast — same fixture, both should fire promptly.
+      expect(
+        d.shouldDerive(
+          hasPending: true,
+          sinceLastRecord: const Duration(seconds: 5),
+          sinceFirstPending: const Duration(seconds: 5),
+          dataStaleness: const Duration(hours: 2),
+          isForeground: true,
+        ),
+        isTrue, // 5s quiet >= the 5s foreground quiet period
+      );
+    });
+
+    test('isForeground defaults to false (existing callers unaffected)', () {
+      // No isForeground arg at all — must behave exactly like before.
+      expect(
+        d.shouldDerive(
+          hasPending: true,
+          sinceLastRecord: const Duration(seconds: 6),
+          sinceFirstPending: const Duration(seconds: 10),
+          dataStaleness: const Duration(minutes: 5),
+        ),
+        isFalse, // fresh mode, unchanged
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

`DeriveDebouncer` picked its wait window purely from data staleness — a
catch-up sync's incoming records approaching "now" (exactly the moment the
user is watching for) flipped the debounce into its SLOWEST tier (60s
quiet / 5min floor), since neither this layer nor `DeriveScheduler`'s own
8s settle knew whether a human was actively looking at the screen. The
"Analyze now" button felt instant only because it calls
`DerivationEngine.run()` directly, skipping both debounce layers.

Adds a third, foreground-aware tier (5s quiet / 15s floor) that takes
priority over the staleness-based tiers whenever the app is in the
foreground — reusing the `_background` flag `AppState` already tracks for
the derive-scheduler's own gate, no new state introduced. Background
behavior is unchanged.

## Test plan
- [x] 5 new `DeriveDebouncer` tests (foreground tier priority, its own
      floor, overriding stale mode, and a regression test proving existing
      callers with no `isForeground` arg are unaffected)
- [x] `flutter test --concurrency=1` — all green
- [x] `flutter analyze` — no new issues