### PR TITLE
release: v0.8.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openstrap_edge
 description: "OpenStrap — open-source WHOOP 4.0 companion. BLE drain → raw-first local store → cloud sync."
 publish_to: 'none'
-version: 0.8.1+20
+version: 0.8.2+21
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
Version bump for v0.8.2, following PR #46 (foreground-aware derive-debounce).

Bump build 20 -> 21.