### PR TITLE
Firmware-aware decoder wiring, UI dedup, and a batch of real bug fixes

### DIFF
--- a/lib/ai/briefing_engine.dart
+++ b/lib/ai/briefing_engine.dart
@@ -149,8 +149,9 @@ String briefingSystemPrompt(BriefingPeriod period) {
       'Line 1: one plain-text sentence, max 140 characters — the whole story '
       'at a glance. No markdown.\n'
       'Line 2: ---\n'
-      'Then 3-5 short markdown bullet points (each starting with "- "), one '
-      'glanceable fact or gentle nudge per bullet, grounded in the numbers.';
+      'Then 3-5 markdown bullet points (each starting with "- "), max 14 words '
+      'each, one glanceable fact or gentle nudge per bullet, grounded in the '
+      'numbers. No filler openers ("It\'s worth noting", "Additionally").';
 }
 
 String buildBriefingUserPrompt(

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -653,6 +653,14 @@ class BleEngine {
   // doc). Re-seeded from the durable counter_hw cursor on each connect, same
   // pattern as _recordGate's frontierTs seed below.
   CounterRegressionDetector _counterRegression = CounterRegressionDetector();
+  // Firmware-aware R24 decoder (see openstrap_protocol's
+  // FirmwareAwareR24Decoder doc): tries the original hardware-validated
+  // decoder first, falls back to newer-firmware layouts only if that fails,
+  // and remembers per-version which one actually worked so a long offload
+  // doesn't re-probe every record. Reset alongside _recordGate/
+  // _counterRegression on each (re)connect — a re-pair shouldn't carry a
+  // stale detection from a different physical band.
+  FirmwareAwareR24Decoder _firmwareDecoder = FirmwareAwareR24Decoder();
   // Snapshot of `_recordGate.dropped` at the last HISTORY_START — lets the
   // HISTORY_END validator (below) tell "the band sent fewer packets than it
   // said" apart from "we correctly, silently rejected some as implausible
@@ -1096,6 +1104,7 @@ class BleEngine {
       _counterRegression = CounterRegressionDetector(
         seedCounter: await cursorReader?.call('counter_hw'),
       );
+      _firmwareDecoder = FirmwareAwareR24Decoder();
 
       // Heartbeat: keep the link alive (~10s LINK_VALID). Owned by the session, so a
       // disconnect cancels it — no zombie timer firing into a dead characteristic.
@@ -1669,7 +1678,9 @@ class BleEngine {
     // buckets instead of collapsing into one "today".
     Sample? sample;
     if (recType == Record.r24) {
-      final r = parseR24(frame.inner);
+      // Legacy decoder first, firmware-fallback chain second, undecodable
+      // archive last — see FirmwareAwareR24Decoder.
+      final r = _firmwareDecoder.decode(frame.inner);
       if (r != null) {
         _logHistoricalOptics(frame.inner, r);
         sample = Sample(

--- a/lib/coach/coach_engine.dart
+++ b/lib/coach/coach_engine.dart
@@ -378,14 +378,14 @@ class CoachEngine {
       final content = (reply['content'] as String?)?.trim();
 
       if (toolCalls.isEmpty) {
-        if (content != null && content.isNotEmpty) emit(CoachItem.assistant(content));
+        if (content != null && content.isNotEmpty) _emitAssistantText(content, emit);
         _history.add({'role': 'assistant', 'content': content ?? ''});
         onStatus(null);
         return;
       }
 
       // Assistant turn that requested tools (echo any interim text).
-      if (content != null && content.isNotEmpty) emit(CoachItem.assistant(content));
+      if (content != null && content.isNotEmpty) _emitAssistantText(content, emit);
       _history.add({'role': 'assistant', 'content': content ?? '', 'tool_calls': toolCalls});
 
       for (final tcRaw in toolCalls) {
@@ -410,6 +410,42 @@ class CoachEngine {
     }
     emit(CoachItem.assistant('I dug through several steps but couldn’t wrap that up — try narrowing the question.'));
     onStatus(null);
+  }
+
+  // Some providers (esp. ones with shaky tool-calling) sometimes answer with a
+  // fenced JSON code block instead of actually calling plot_chart/render — that
+  // renders as an unexplained grey code block in the UI (GptMarkdown's default
+  // code-field styling), not a chart. Detect a chart/render JSON payload inside
+  // any fence and draw it as a real figure instead; leave real code fences (rare,
+  // the coach is told never to write code) or non-figure JSON untouched.
+  static void _emitAssistantText(String content, void Function(CoachItem) emit) {
+    final fence = RegExp(r'```[a-zA-Z0-9_-]*\n([\s\S]*?)```');
+    final figures = <CoachItem>[];
+    final cleaned = content.replaceAllMapped(fence, (m) {
+      try {
+        final decoded = jsonDecode((m.group(1) ?? '').trim());
+        if (decoded is Map && decoded['type'] != null) {
+          final j = decoded.cast<String, dynamic>();
+          final type = j['type'].toString().toLowerCase();
+          if ((type == 'bar' || type == 'line' || type == 'area') && j['series'] != null) {
+            final spec = ChartSpec.tryParse(j);
+            if (spec != null) {
+              figures.add(CoachItem.chart(spec));
+              return '';
+            }
+          }
+          figures.add(CoachItem.render(j));
+          return '';
+        }
+      } catch (_) {
+        // not JSON / not a figure — leave the fence as-is.
+      }
+      return m.group(0) ?? '';
+    }).trim();
+    if (cleaned.isNotEmpty) emit(CoachItem.assistant(cleaned));
+    for (final f in figures) {
+      emit(f);
+    }
   }
 
   // ── provider call ────────────────────────────────────────────────────────────

--- a/lib/coach/coach_prompt.dart
+++ b/lib/coach/coach_prompt.dart
@@ -76,6 +76,8 @@ rejected, read the error and fix it. Examples:
     • range_band — {label, value, min, max, unit?}  (a value against a target band)
     • table — {columns:[…], rows:[[…]]}
   Build figures ONLY from data you fetched via run_sql.
+- NEVER print a chart/figure as raw JSON or inside a ``` code fence in your reply — that renders
+  as an ugly grey unreadable block to the user, not a chart. ALWAYS call plot_chart/render instead.
 
 Action tools — the app ASKS THE USER TO CONFIRM before any write. Only when clearly requested:
 - log_journal(date, tags, note), log_period(date), start_workout(type), end_workout(workout_id),

--- a/lib/compute/substrate.dart
+++ b/lib/compute/substrate.dart
@@ -207,10 +207,15 @@ Substrate decodeSubstrate(List<String> hexes) {
   // Collect per-record tuples, then sort by ts to guarantee monotonicity.
   final recs = <_Rec>[];
   final looseRr = <_Beat>[]; // RR-only live frames
+  // One shared decoder for the whole page: legacy decoder first, firmware-
+  // fallback chain second (see FirmwareAwareR24Decoder) — sharing it across
+  // the batch means a firmware quirk detected on the first record isn't
+  // re-probed for every subsequent one in this page.
+  final decoder = proto.FirmwareAwareR24Decoder();
   for (final hex in hexes) {
     proto.R24? r;
     try {
-      r = proto.parseR24(proto.hexToBytes(hex));
+      r = decoder.decode(proto.hexToBytes(hex));
     } catch (_) {
       r = null;
     }

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -1454,7 +1454,13 @@ class LocalDb {
   static Sample? _decodeOneHzSample(RawRecord raw, {Sample? preferred}) {
     if (preferred != null && preferred.hasDecodedOneHz) return preferred;
     try {
-      final r = proto.parseR24(proto.hexToBytes(raw.hex));
+      // Legacy decoder first, firmware-fallback chain second — see
+      // FirmwareAwareR24Decoder. This path only runs when no pre-decoded
+      // `preferred` sample was supplied (e.g. a raw-hex import/merge), so a
+      // fresh per-call instance is fine — no session state to preserve.
+      final r = proto.FirmwareAwareR24Decoder().decode(
+        proto.hexToBytes(raw.hex),
+      );
       if (r == null || r.tsEpoch <= 0) return null;
       return Sample(
         tsEpoch: r.tsEpoch,

--- a/lib/ui/activity/strain_detail_screen.dart
+++ b/lib/ui/activity/strain_detail_screen.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../data/day_label.dart';
 import '../../data/local_repository.dart';
 import '../../state/app_state.dart';
 import '../../theme/theme.dart';
@@ -304,7 +305,16 @@ class _StrainDetailScreenState extends State<StrainDetailScreen> {
     final load = _map(_data['load']);
     final fitness = _data['fitness_trend']?.toString();
     final cals = _num(_data['calories']);
-    final steps = _num(_data['steps']);
+    // Same steps figure as Today + the Steps screen: finalized day estimate
+    // + today's in-flight live fold-in, so all three never disagree.
+    final rawSteps = _num(_data['steps']);
+    final isToday = widget.date == todayLabel();
+    final liveSteps = isToday
+        ? context.select<AppState, int>((a) => a.liveSteps)
+        : 0;
+    final steps = (rawSteps == null && liveSteps == 0)
+        ? null
+        : (rawSteps?.toDouble() ?? 0) + liveSteps;
     final effort = _num(_data['effort']);
     final hasLoad =
         load.isNotEmpty ||

--- a/lib/ui/coach/coach_screen.dart
+++ b/lib/ui/coach/coach_screen.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 
 import '../../models/payloads.dart';
 import '../design/design.dart';
-import '../kit/os_icons.dart';
 
 class CoachScreen extends StatelessWidget {
   final CoachData coach;
@@ -37,7 +36,7 @@ class CoachScreen extends StatelessWidget {
 /// The pure plan board — testable with a sample /coach payload.
 class CoachPlanContent extends StatelessWidget {
   final CoachData coach;
-  CoachPlanContent({super.key, required this.coach});
+  const CoachPlanContent({super.key, required this.coach});
 
   // Severity → colour: 3 urgent, 2 caution, 1 nudge, 0 affirming.
   Color _sevColor(int s) => switch (s) {

--- a/lib/ui/design/ai_hero.dart
+++ b/lib/ui/design/ai_hero.dart
@@ -16,7 +16,7 @@ import 'package:flutter/material.dart';
 
 import '../../theme/theme.dart';
 import '../../theme/tokens.dart';
-import '../kit/kit.dart' show AppIcon, Ic, OsAppIcon, OsIcon;
+import '../kit/kit.dart' show AppIcon, OsAppIcon, OsIcon;
 import 'pressable.dart';
 
 class AiHero extends StatelessWidget {

--- a/lib/ui/design/app_scaffold.dart
+++ b/lib/ui/design/app_scaffold.dart
@@ -18,7 +18,6 @@ import 'package:flutter/services.dart';
 
 import '../../theme/theme.dart';
 import '../../theme/tokens.dart';
-import '../kit/kit.dart' show AppIcon, Ic;
 import 'pressable.dart';
 
 /// The standard circular back button (also usable stand-alone in custom

--- a/lib/ui/design/nav_pill.dart
+++ b/lib/ui/design/nav_pill.dart
@@ -159,25 +159,8 @@ class NavPillAction extends StatelessWidget {
         // Pressable fires the selection haptic itself.
         pressedScale: 0.9,
         onTap: onTap,
-        child: true
-            // The illustrated coin IS the button — same 46px footprint.
-            ? SizedBox(
-                width: 46,
-                height: 46,
-                child: OsAppIcon(icon!, size: 46),
-              )
-            : Container(
-                width: 46,
-                height: 46,
-                decoration: BoxDecoration(
-                  color: AppColors.accent,
-                  shape: BoxShape.circle,
-                  boxShadow: AppColors.isDark ? const [] : Shadows.coral,
-                ),
-                // Plain Icon (not the kit AppIcon): the center glyph may be a
-                // Material icon (▶), not just a HugeIcons stroke.
-                child: Center(child: OsAppIcon(icon!, size: 24)),
-              ),
+        // The illustrated coin IS the button — same 46px footprint.
+        child: SizedBox(width: 46, height: 46, child: OsAppIcon(icon!, size: 46)),
       ),
     );
   }

--- a/lib/ui/design/orbit_score.dart
+++ b/lib/ui/design/orbit_score.dart
@@ -21,7 +21,7 @@ import 'package:flutter/material.dart';
 
 import '../../theme/theme.dart';
 import '../../theme/tokens.dart';
-import '../kit/kit.dart' show AppIcon, OsAppIcon, OsIcon;
+import '../kit/kit.dart' show OsAppIcon, OsIcon;
 import 'arc_gauge.dart';
 import 'motion.dart';
 import 'pressable.dart';
@@ -212,7 +212,6 @@ class _SatelliteChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final c = s.color ?? AppColors.accent;
     return Pressable(
       pressedScale: 0.92,
       onTap: s.onTap,

--- a/lib/ui/design/recap_card.dart
+++ b/lib/ui/design/recap_card.dart
@@ -12,7 +12,7 @@ import 'package:flutter/material.dart';
 import '../../theme/theme.dart';
 import '../../theme/tokens.dart';
 import '../kit/charts.dart' show MiniBars;
-import '../kit/kit.dart' show AppIcon, Ic, OsIcon;
+import '../kit/kit.dart' show AppIcon, OsIcon;
 import 'bento.dart';
 import 'big_stat.dart';
 

--- a/lib/ui/design/rows.dart
+++ b/lib/ui/design/rows.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 import '../../theme/theme.dart';
 import '../../theme/tokens.dart';
-import '../kit/kit.dart' show AppIcon, Ic;
+import '../kit/kit.dart' show AppIcon;
 import '../kit/os_icons.dart';
 import 'pressable.dart';
 

--- a/lib/ui/insights/coach_cards.dart
+++ b/lib/ui/insights/coach_cards.dart
@@ -89,35 +89,18 @@ class _SleepCoachCardState extends State<SleepCoachCard> {
     }
   }
 
-  Future<void> _testBuzz() async {
-    final app = context.read<AppState>();
-    if (!app.isConnected) {
-      _snack('Connect your strap to test the alarm buzz.');
-      return;
-    }
-    try {
-      await app.testAlarmBuzz();
-      _snack('Sent a test buzz to your strap.');
-    } catch (e) {
-      _snack("Couldn't buzz the strap: $e");
-    }
-  }
-
   void _snack(String s) {
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(s)));
   }
 
   /// Live alarm-status caption driven by the strap's own confirmation events.
-  String _alarmCaption(AppState app) {
-    const base = 'Your strap buzzes at this time — set on the band, so it works '
-        'even with the app closed. Aligned to a ~90-min cycle so it lands near '
-        'light sleep.';
-    if (app.alarmEpoch == null) return base;
-    if (app.alarmConfirmed) return 'Alarm set ✓ — $base';
-    if (app.alarmPending) return 'Setting alarm… — $base';
-    return 'Alarm sent, but the strap hasn\'t confirmed it yet. '
-        'Tap "Test buzz" to check it fires, and keep a backup alarm.';
+  /// Null when no alarm has been set yet — nothing to say.
+  String? _alarmCaption(AppState app) {
+    if (app.alarmEpoch == null) return null;
+    if (app.alarmConfirmed) return 'Alarm set ✓';
+    if (app.alarmPending) return 'Setting alarm…';
+    return 'Alarm sent, waiting for the strap to confirm.';
   }
 
   @override
@@ -184,18 +167,11 @@ class _SleepCoachCardState extends State<SleepCoachCard> {
               label: Text('Set band alarm for ${_hhmm(wakeMin)}'),
             ),
           ),
-          const SizedBox(height: Sp.x2),
-          Row(children: [
-            Expanded(
-              child: Text(_alarmCaption(context.watch<AppState>()),
-                  style: AppText.captionMuted),
-            ),
-            const SizedBox(width: Sp.x2),
-            TextButton(
-              onPressed: _testBuzz,
-              child: const Text('Test buzz'),
-            ),
-          ]),
+          if (_alarmCaption(context.watch<AppState>()) != null) ...[
+            const SizedBox(height: Sp.x2),
+            Text(_alarmCaption(context.watch<AppState>())!,
+                style: AppText.captionMuted),
+          ],
         ],
       ]),
     );

--- a/lib/ui/kit/route_map.dart
+++ b/lib/ui/kit/route_map.dart
@@ -1,19 +1,29 @@
 // RouteMapView — the shared map widget for GPS workout routes.
 //
-// OUR OWN LOOK, not stock OpenStreetMap: raw OSM raster tiles are the only
-// source that needs no API key / no Google-Mapbox account, but their default
-// light, busy, multicoloured style clashes with the app's warm-dark ember
-// design language and doesn't read as "OpenStrap" — so every tile is passed
-// through a fixed ColorFilter (see [_kMapTileMatrix]) that desaturates the
-// whole basemap to a warm charcoal-to-cream monochrome (inverted luminance,
-// tinted toward AppColors.night / onNight — the SAME invariant dark hero
-// surface the live-workout screen itself uses). The map reads as ONE
-// consistent dark, branded surface everywhere it appears — live session,
-// finish card, workout detail — regardless of the surrounding screen's light/
-// dark theme. Against that quiet monochrome base, the route line (vivid,
-// HR-zone-coloured, glow-backed) and the coral position dot are the only
-// colour — a deliberate one-accent-colour map style (Nike Run Club / Strava's
-// minimal map, not a busy street atlas).
+// TILE SOURCE: CARTO's free "Positron" raster basemap, NOT raw
+// tile.openstreetmap.org. The OSM Foundation's tile-usage policy explicitly
+// forbids "heavy use (e.g. distributing an app that uses tiles from
+// openstreetmap.org)" — an app built against tile.openstreetmap.org directly
+// gets silently rate-limited / blocked once real usage shows up, which reads
+// to a user as "the map doesn't work" with zero error surfaced (flutter_map
+// just renders a blank/grey tile on a failed fetch). CARTO's basemap CDN
+// (basemaps.cartocdn.com) is the standard production-safe alternative: same
+// OSM-derived data, no API key, explicitly permitted for embedding in apps.
+// Still requires OSM data attribution (+ CARTO credit), rendered below.
+//
+// OUR OWN LOOK, not stock CARTO either: the default light, busy,
+// multicoloured basemap style clashes with the app's warm-dark ember design
+// language and doesn't read as "OpenStrap" — so every tile is passed through
+// a fixed ColorFilter (see [_kMapTileMatrix]) that desaturates the whole
+// basemap to a warm charcoal-to-cream monochrome (inverted luminance, tinted
+// toward AppColors.night / onNight — the SAME invariant dark hero surface the
+// live-workout screen itself uses). The map reads as ONE consistent dark,
+// branded surface everywhere it appears — live session, finish card, workout
+// detail — regardless of the surrounding screen's light/dark theme. Against
+// that quiet monochrome base, the route line (vivid, HR-zone-coloured,
+// glow-backed) and the coral position dot are the only colour — a deliberate
+// one-accent-colour map style (Nike Run Club / Strava's minimal map, not a
+// busy street atlas).
 //
 // Renders the route polyline SEGMENTED and COLOURED BY HR ZONE
 // (AppColors.zone), plus an optional pulsing current-position marker. Two
@@ -22,10 +32,12 @@
 //   • thumbnail:   non-interactive, fit-to-bounds (finish card + workout
 //     detail card).
 //
-// LOCAL-FIRST: tiles come straight from OpenStreetMap (no API key, no Google /
-// Mapbox); the route points are on-device only. A minimal "© OSM" credit is
-// always shown (required by the OSM tile-usage policy) as a small tucked-away
-// text badge, not the stock flutter_map attribution box.
+// LOCAL-FIRST: the route points themselves are on-device only, never
+// uploaded. Basemap tiles are fetched on demand (no account, no tracking of
+// the athlete — the tile CDN only ever sees anonymous {z,x,y} requests, never
+// route data). A minimal "© OSM · CARTO" credit is always shown (required by
+// both providers' attribution terms) as a small tucked-away text badge, not
+// the stock flutter_map attribution box.
 
 import 'package:flutter/material.dart' hide Split;
 import 'package:flutter_map/flutter_map.dart';
@@ -40,7 +52,12 @@ import '../../theme/theme.dart';
 import '../../theme/tokens.dart';
 import 'kit.dart';
 
-const String _kOsmTileUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+// CARTO Positron ("light_all") — a minimal light basemap, the closest
+// production-safe equivalent to plain OSM carto for our ColorFilter to
+// desaturate. `{r}` is the retina-tile suffix flutter_map fills in itself.
+const String _kOsmTileUrl =
+    'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png';
+const List<String> _kTileSubdomains = ['a', 'b', 'c', 'd'];
 const String _kUserAgent = 'wtf.openstrap.edge';
 
 /// Desaturate + invert-luminance + warm-tint every tile pixel in one pass:
@@ -174,6 +191,7 @@ class RouteMapView extends StatelessWidget {
           colorFilter: const ColorFilter.matrix(_kMapTileMatrix),
           child: TileLayer(
             urlTemplate: _kOsmTileUrl,
+            subdomains: _kTileSubdomains,
             userAgentPackageName: _kUserAgent,
             maxZoom: 19,
           ),
@@ -205,9 +223,10 @@ class RouteMapView extends StatelessWidget {
     return height == null ? clipped : SizedBox(height: height, child: clipped);
   }
 
-  /// A minimal, tucked-away credit — required by the OSM tile-usage policy,
-  /// but styled as a small text badge that blends into our own dark map
-  /// rather than flutter_map's stock boxed attribution widget.
+  /// A minimal, tucked-away credit — required by both the OSM data licence
+  /// and CARTO's basemap terms, but styled as a small text badge that blends
+  /// into our own dark map rather than flutter_map's stock boxed attribution
+  /// widget.
   Widget _attribution() => Positioned(
         right: 6,
         bottom: 6,
@@ -217,7 +236,7 @@ class RouteMapView extends StatelessWidget {
             mode: LaunchMode.externalApplication,
           ),
           child: Text(
-            '© OpenStreetMap',
+            '© OpenStreetMap · CARTO',
             style: AppText.captionMuted.copyWith(
               color: AppColors.onNightSoft,
               fontSize: 9,

--- a/lib/ui/profile/profile_screen.dart
+++ b/lib/ui/profile/profile_screen.dart
@@ -433,39 +433,6 @@ class ProfileScreen extends StatelessWidget {
             ),
           ]),
 
-          const SizedBox(height: Sp.x6),
-
-          // ── Honesty note ─────────────────────────────────────────────
-          SurfaceCard(
-            level: 0,
-            color: AppColors.surfaceAlt,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    AppIcon(OsIcon.shield, size: 18, color: AppColors.inkSoft),
-                    const SizedBox(width: Sp.x2),
-                    Text('How your metrics are made', style: AppText.label),
-                  ],
-                ),
-                const SizedBox(height: Sp.x3),
-                Text(
-                  'Metrics are computed on this phone from published algorithms '
-                  'over your strap\'s raw sensor data. We show only what the '
-                  'hardware can honestly measure — estimates are labelled, and '
-                  'a metric without enough data stays blank instead of guessed.',
-                  style: AppText.bodySoft,
-                ),
-                const SizedBox(height: Sp.x3),
-                Text(
-                  'OpenStrap • MIT • the analytics source is public.',
-                  style: AppText.captionMuted,
-                ),
-              ],
-            ),
-          ),
-
           const SizedBox(height: 110),
       ],
     );

--- a/lib/ui/records/records_screen.dart
+++ b/lib/ui/records/records_screen.dart
@@ -289,7 +289,7 @@ class RecordsContent extends StatelessWidget {
 
   Widget _recordsBento({String? medalKey}) {
     final tiles = <Widget>[];
-    for (final (key, label, icon, osIcon) in _recordDefs) {
+    for (final (key, label, icon, _) in _recordDefs) {
       if (key == medalKey) continue; // already the medal
       final rec = r.record(key);
       if (rec == null) continue;

--- a/lib/ui/screens/detail_cards.dart
+++ b/lib/ui/screens/detail_cards.dart
@@ -931,17 +931,19 @@ class OxygenNightContent extends StatelessWidget {
     final sleepStart = (sleepWindow?['start'] as num?)?.toDouble();
     final sleepEnd = (sleepWindow?['end'] as num?)?.toDouble();
     final odiPerHour = (spo2?['odi_per_hour'] as num?)?.toDouble();
+    final dipCount = (spo2?['dip_count'] as num?)?.toInt() ?? events.length;
     final verdict = _oxygenVerdict({
       'trusted_coverage': trustedCoverage,
       'signal_coverage': signalCoverage,
       'reject_total': rejectTotal,
-      'dip_count': (spo2?['dip_count'] as num?)?.toInt() ?? events.length,
+      'dip_count': dipCount,
     });
     final severity = _oxygenSeverity(
       odiPerHour: odiPerHour,
       maxDipPct: maxDipPct,
       burdenPct: burdenPct,
       trustedCoverage: trustedCoverage,
+      dipCount: dipCount,
     );
 
     if (spo2 == null) {
@@ -951,6 +953,15 @@ class OxygenNightContent extends StatelessWidget {
         message:
             'Wear the strap through the night — the red/IR channels need a '
             'full night of stable contact to read.',
+      );
+    }
+    if (spo2['disabled'] == true) {
+      return const _QuietState(
+        icon: OsIcon.hydration,
+        title: 'Overnight oxygen tracking is off',
+        message:
+            'This screen is temporarily disabled pending hardware-verified '
+            'decoding — it will come back once that lands.',
       );
     }
 
@@ -1408,6 +1419,7 @@ Widget _legendPill(String label, Color color) {
   required double? maxDipPct,
   required double? burdenPct,
   required double? trustedCoverage,
+  required int dipCount,
 }) {
   final trusted = trustedCoverage ?? 0;
   if (trusted < 0.6) {
@@ -1440,7 +1452,10 @@ Widget _legendPill(String label, Color color) {
           'Tonight has a noticeable oxygen-dip load, but not an extreme one.',
     );
   }
-  if (odi > 0 || maxDip > 0 || burden > 0) {
+  // Require a repeated pattern (>=2 dips) plus a real per-hour rate/burden
+  // before calling anything out — a single stray dip is common PPG/motion
+  // noise, not a finding, and used to fire "Mild" on almost every night.
+  if (dipCount >= 2 && (odi >= 1 || maxDip >= 2 || burden >= 0.5)) {
     return (
       label: 'Mild',
       color: AppColors.good,

--- a/lib/ui/screens/metric_row.dart
+++ b/lib/ui/screens/metric_row.dart
@@ -40,10 +40,8 @@ const Map<String, String> kMetricInfo = {
       'How far your heart rate falls in sleep — a bigger dip is better.',
   'sleeping_hr': 'Average heart rate while you slept.',
   'resp': 'Breaths per minute, derived from heart-rate variability.',
-  'spo2':
-      'TODO. Blood O₂ is temporarily disabled while the packet decode is re-validated from raw captures.',
-  'skin_temp':
-      'Skin temperature vs your personal overnight baseline. Relative (Δ), not an absolute thermometer.',
+  'spo2': 'Relative blood-oxygen dip signal from your PPG — not an absolute reading.',
+  'skin_temp': 'Skin temperature vs your personal overnight baseline — relative, not absolute.',
   'hrr60':
       'How fast your HR drops a minute after peak effort — fitness marker.',
   'illness':

--- a/lib/ui/screens/screens.dart
+++ b/lib/ui/screens/screens.dart
@@ -5,7 +5,7 @@
 //
 //   Sleep → indigo, the redesigned night board (sleep_detail_screen)
 //   Heart → coral, recovery/RHR BigStat hero (detail_cards.HeartDayContent)
-//   Body  → amber, week-load RadialHeatmap hero over the strain detail
+//   Body  → amber, the rich strain detail (no duplicate week-load hero)
 //   Steps → teal, goal ArcGauge + RingWeek week strip
 //   Oxygen→ slate, ODI + signal-coverage gauge (detail_cards)
 //   Wear  → coverage gauge + hourly bars (detail_cards)
@@ -27,7 +27,6 @@ import '../spotcheck/spot_check_screen.dart';
 import '../today/step_calibration_screen.dart';
 import '../today/step_goal_screen.dart';
 import 'detail_cards.dart';
-import 'metric_row.dart' show infoFor;
 import 'metric_screen.dart';
 
 class SleepScreen extends StatelessWidget {
@@ -105,9 +104,9 @@ class WearScreen extends StatelessWidget {
 }
 
 /// Body — strain / training load / calories / steps / activity. Bars track
-/// daily strain (amber); the Today leaf opens with the week-load radial hero,
-/// then the rich strain detail. (Respiratory rate + SpO₂ live under Sleep +
-/// Heart; Lungs is no longer a tab.)
+/// daily strain (amber); the Today leaf opens straight into the rich strain
+/// detail. (Respiratory rate + SpO₂ live under Sleep + Heart; Lungs is no
+/// longer a tab.)
 class BodyScreen extends StatelessWidget {
   const BodyScreen({super.key});
   @override
@@ -147,8 +146,6 @@ class BodyScreen extends StatelessWidget {
       children: [
         const StrainCoachCard(),
         const SizedBox(height: Sp.x3),
-        const BodyWeekLoadHero(),
-        const SizedBox(height: Sp.x3),
         StrainDetailScreen(date: todayLabel(), embedded: true),
         const SizedBox(height: Sp.x3),
         const WhoopAgeCard(),
@@ -159,145 +156,6 @@ class BodyScreen extends StatelessWidget {
       ],
     ),
     dayDetail: (ctx, date) => StrainDetailScreen(date: date, embedded: true),
-  );
-}
-
-/// BodyWeekLoadHero — the Body domain's hero visual: the CURRENT week's
-/// training load (Mon→Sun) as a RadialHeatmap, one labelled segment per day
-/// filled by strain/21; missing/future days stay honest empties. Deliberately
-/// number-free — the day's strain figure lives exactly once on the Body
-/// screen, in the strain detail hero below. Hides itself until at least one
-/// day this week has loaded (no fake wheel).
-class BodyWeekLoadHero extends StatefulWidget {
-  const BodyWeekLoadHero({super.key});
-  @override
-  State<BodyWeekLoadHero> createState() => _BodyWeekLoadHeroState();
-}
-
-class _BodyWeekLoadHeroState extends State<BodyWeekLoadHero> {
-  Map<String, dynamic>? _trend;
-
-  @override
-  void initState() {
-    super.initState();
-    _load();
-  }
-
-  Future<void> _load() async {
-    final api = context.read<AppState>().repo;
-    if (api == null) return;
-    try {
-      // Anchor the 7-day trend window on this week's Sunday so the wheel is
-      // always the current Mon→Sun calendar week. The unanchored default ends
-      // at the LAST DATA DAY, i.e. a rolling window whose segments drift
-      // around the wheel — which is what rendered as a lone mislabelled day.
-      final now = DateTime.now();
-      final sunday = DateTime(
-        now.year,
-        now.month,
-        now.day + (DateTime.daysPerWeek - now.weekday),
-      );
-      final t = await api.getTrend(
-        'strain',
-        scale: 'week',
-        anchor: dayLabelOf(sunday),
-      );
-      if (mounted) setState(() => _trend = t);
-    } catch (_) {}
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final wheel = weekLoadWheelData(_trend);
-    if (wheel.values.whereType<double>().isEmpty) {
-      return const SizedBox.shrink();
-    }
-    return WeekLoadWheelTile(
-      values: wheel.values,
-      labels: wheel.labels,
-    ).dsEnter();
-  }
-}
-
-/// Pure mapper for the week-load wheel: a /trend week payload → one segment
-/// per bucket (strain/21, null = no data) plus its weekday label derived from
-/// the bucket's own `t_start` (so labels can never drift from the data).
-@visibleForTesting
-({List<double?> values, List<String> labels}) weekLoadWheelData(
-  Map<String, dynamic>? trend,
-) {
-  const wd = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-  final buckets = ((trend?['buckets'] as List?) ?? const [])
-      .whereType<Map>()
-      .toList();
-  final values = <double?>[];
-  final labels = <String>[];
-  for (final b in buckets) {
-    values.add(
-      b['has'] == true
-          ? (((b['value'] as num?)?.toDouble() ?? 0) / 21).clamp(0.0, 1.0)
-          : null,
-    );
-    final ts = (b['t_start'] as num?)?.toInt();
-    labels.add(
-      ts == null
-          ? ''
-          : wd[(DateTime.fromMillisecondsSinceEpoch(
-                      ts * 1000,
-                      isUtc: true,
-                    ).weekday -
-                    1) %
-                7],
-    );
-  }
-  return (values: values, labels: labels);
-}
-
-/// Pure presentation of the week-load wheel: the RadialHeatmap alone with all
-/// day segments labelled — no strain BigStat here, so the Body screen keeps
-/// exactly one strain figure (the strain detail hero).
-@visibleForTesting
-class WeekLoadWheelTile extends StatelessWidget {
-  final List<double?> values;
-  final List<String> labels;
-  const WeekLoadWheelTile({
-    super.key,
-    required this.values,
-    required this.labels,
-  });
-
-  @override
-  Widget build(BuildContext context) => BentoTile(
-    accent: DomainAccent.strain,
-    padding: const EdgeInsets.all(Sp.x5),
-    child: Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        TileHeader(
-          'Week load',
-          trailing: InfoDot(
-            title: 'Week load',
-            body:
-                'Each spoke is one day of this week, Monday through Sunday, '
-                'filled by its strain (0–21). A balanced wheel means steady '
-                'training; one hot spoke is a spike day; empty spokes have '
-                'no data yet.',
-            methodNote: infoFor('strain'),
-          ),
-        ),
-        const SizedBox(height: Sp.x3),
-        Center(
-          child: RadialHeatmap(
-            values: values,
-            rings: 3,
-            color: DomainAccent.strain,
-            size: 176,
-            labels: labels,
-          ),
-        ),
-      ],
-    ),
   );
 }
 

--- a/lib/ui/today/today_screen.dart
+++ b/lib/ui/today/today_screen.dart
@@ -53,10 +53,6 @@ class _TodayScreenState extends State<TodayScreen>
   /// null = no data that day (incl. future days), best-effort.
   List<double?> _stepsWeek = const [];
 
-  /// Last night's stage minutes + hypnogram, best-effort (nulls hide them).
-  ({int? awakeMin, int? remMin, int? lightMin, int? deepMin})? _stageMin;
-  List<HypnoSeg> _hypno = const [];
-
   /// Show the once-a-morning recovery story: only with a real readiness score,
   /// and only if it hasn't already been shown for today's date.
   bool _showStory(TodayData t) {
@@ -122,24 +118,6 @@ class _TodayScreenState extends State<TodayScreen>
           b['has'] == true ? ((b['value'] as num?)?.toDouble()) : null,
       ];
       if (mounted) setState(() => _stepsWeek = week);
-    } catch (_) {}
-    try {
-      final st = TodayData.fromJson(today).status;
-      final s = await repo.getDaySleep(st?.overnightDay ?? _todayStr());
-      if (s['has_sleep'] == true && mounted) {
-        int? mi(Object? v) => (v as num?)?.toInt();
-        setState(() {
-          _stageMin = (
-            awakeMin: mi(s['awake_min']),
-            remMin: mi(s['rem_min']),
-            lightMin: mi(s['light_min']),
-            deepMin: mi(s['deep_min']),
-          );
-          _hypno = hypnoSegmentsFromPoints(
-            (s['hypnogram'] as List?) ?? const [],
-          );
-        });
-      }
     } catch (_) {}
     return today;
   }
@@ -361,8 +339,6 @@ class _TodayScreenState extends State<TodayScreen>
           sparks: _sparks,
           stepsWeek: _stepsWeek,
           liveSteps: context.read<AppState>().liveSteps,
-          stageMin: _stageMin,
-          hypno: _hypno,
           onOpen: _open,
         ),
       ),
@@ -677,12 +653,6 @@ class TodayVitals extends StatelessWidget {
   /// Steps from the in-flight live session, not yet folded into the day metric.
   final int liveSteps;
 
-  /// Last night's stage minutes (nulls hide the stage bar).
-  final ({int? awakeMin, int? remMin, int? lightMin, int? deepMin})? stageMin;
-
-  /// Last night's hypnogram segments (empty hides the mini timeline).
-  final List<HypnoSeg> hypno;
-
   /// Tap-through router: readiness | sleep | heart | body | activity | wear |
   /// stress | oxygen | records.
   final void Function(String id) onOpen;
@@ -693,8 +663,6 @@ class TodayVitals extends StatelessWidget {
     this.sparks = const {},
     this.stepsWeek = const [],
     this.liveSteps = 0,
-    this.stageMin,
-    this.hypno = const [],
     required this.onOpen,
   });
 
@@ -742,13 +710,10 @@ class TodayVitals extends StatelessWidget {
         BentoColumns(
           left: [
             _hrvTile(context),
-            _sleepTile(),
             _caloriesTile(),
-            _stressTile(),
           ],
           right: [
             _rhrTile(),
-            _strainTile(),
             _stepsTile(),
             _oxygenTile(),
           ],
@@ -994,91 +959,6 @@ class TodayVitals extends StatelessWidget {
     );
   }
 
-  Widget _sleepTile() {
-    final sm = stageMin;
-    final hasStages =
-        sm != null &&
-        ((sm.remMin ?? 0) + (sm.lightMin ?? 0) + (sm.deepMin ?? 0)) > 0;
-    return BentoTile(
-      tone: BentoTone.soft,
-      accent: DomainAccent.sleep,
-      minHeight: _statTileMinHeight,
-      onTap: () => onOpen('sleep'),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const TileHeader('Sleep'),
-          const SizedBox(height: Sp.x2),
-          BigStat(
-            value: _hm(t.sleepDuration),
-            caption: t.sleepNeed.isEmpty
-                ? null
-                : 'of ${_hm(t.sleepNeed)} need',
-          ),
-          if (hypno.isNotEmpty) ...[
-            const SizedBox(height: Sp.x3),
-            Hypnogram(hypno, height: 64, labels: false),
-          ],
-          if (hasStages) ...[
-            const SizedBox(height: Sp.x3),
-            StageBars(
-              awakeMin: sm.awakeMin,
-              remMin: sm.remMin,
-              lightMin: sm.lightMin,
-              deepMin: sm.deepMin,
-              legend: !(hypno.isNotEmpty), // timeline already tells the story
-            ),
-          ] else if (!t.sleepDuration.isEmpty && !t.sleepNeed.isEmpty) ...[
-            const SizedBox(height: Sp.x3),
-            ProgressPill(
-              (t.sleepDuration.value! / t.sleepNeed.value!).clamp(0.0, 1.0),
-              color: DomainAccent.sleep,
-              height: 8,
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
-  Widget _strainTile() {
-    final v = t.strain;
-    return BentoTile(
-      accent: DomainAccent.strain,
-      minHeight: _statTileMinHeight,
-      onTap: () => onOpen('body'),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const TileHeader('Strain'),
-          const SizedBox(height: Sp.x2),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Expanded(
-                child: BigStat(
-                  value: v.isEmpty ? null : v.value!.toStringAsFixed(1),
-                  caption: 'of 21',
-                ),
-              ),
-              ArcGauge(
-                value: v.isEmpty
-                    ? double.nan
-                    : (v.value! / 21).clamp(0.0, 1.0),
-                color: DomainAccent.strain,
-                size: 52,
-                stroke: 6,
-                sweepFraction: 0.75,
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-
   Widget _stepsTile() {
     final base = t.steps.isEmpty ? 0 : t.steps.value!.round();
     final steps = base + liveSteps;
@@ -1127,29 +1007,6 @@ class TodayVitals extends StatelessWidget {
             value: _int(t.calories),
             unit: 'kcal',
             caption: t.calories.isEmpty ? null : 'active burn · est',
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _stressTile() {
-    final stress = t.stress;
-    return BentoTile(
-      accent: DomainAccent.stress,
-      minHeight: _statTileMinHeight,
-      onTap: () => onOpen('stress'),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const TileHeader('Stress', icon: OsIcon.stress, trailing: Tag('est')),
-          const SizedBox(height: Sp.x2),
-          BigStat(
-            value: stress?.score?.toString(),
-            unit: '/100',
-            caption: stress?.band,
-            captionAccent: true,
           ),
         ],
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -859,29 +859,23 @@ packages:
   openstrap_analytics:
     dependency: "direct main"
     description:
-      path: "."
-      ref: main
-      resolved-ref: "743c3d7a1b511c016c86c14c8981ae1fdb46a98c"
-      url: "https://github.com/OpenStrap/analytics.git"
-    source: git
+      path: "../openstrap-analytics-onehz"
+      relative: true
+    source: path
     version: "1.0.0"
   openstrap_icons:
     dependency: "direct main"
     description:
-      path: "."
-      ref: main
-      resolved-ref: "91f0309a4f1dcd36df2c504b5170f76c6e5ce767"
-      url: "https://github.com/OpenStrap/icons.git"
-    source: git
+      path: "../openstrap_icons"
+      relative: true
+    source: path
     version: "0.1.0"
   openstrap_protocol:
     dependency: "direct main"
     description:
-      path: "."
-      ref: main
-      resolved-ref: d2a4fa51693a8d1d790d0f3281c7e2c5db27eac7
-      url: "https://github.com/OpenStrap/protocol.git"
-    source: git
+      path: "../openstrap-protocol-dart"
+      relative: true
+    source: path
     version: "1.0.0"
   ota_update:
     dependency: "direct main"

--- a/test/core_screens_test.dart
+++ b/test/core_screens_test.dart
@@ -114,8 +114,8 @@ void main() {
       expect(find.text('Primed'), findsOneWidget); // 82 → primed
       expect(find.text('48'), findsWidgets); // HRV value
       expect(find.text('52'), findsWidgets); // RHR value
-      expect(find.text('12.4'), findsWidgets); // strain — tile + orbit satellite
-      expect(find.text('7h 42m'), findsWidgets); // sleep — tile + orbit satellite
+      expect(find.text('12.4'), findsOneWidget); // strain — orbit satellite
+      expect(find.text('7h 42m'), findsOneWidget); // sleep — orbit satellite
       expect(find.text('8412'), findsOneWidget); // steps
       expect(find.text('Records & streaks'), findsOneWidget);
       expect(t.takeException(), isNull);
@@ -125,22 +125,21 @@ void main() {
       expect(opened, contains('readiness'));
     });
 
-    testWidgets('Stress + Sleep tiles show their numeric value', (t) async {
+    testWidgets('Stress + Sleep orbit satellites show their numeric value', (
+      t,
+    ) async {
       await t.pumpWidget(
         _host(
           TodayVitals(
             t: TodayData.fromJson(_sampleToday()),
-            stageMin: (awakeMin: 24, remMin: 96, lightMin: 258, deepMin: 84),
             onOpen: (_) {},
           ),
         ),
       );
       await t.pump(const Duration(milliseconds: 1200));
-      // Stress pill shows its 0–100 score (was rendering blank).
-      expect(find.text('Stress'.toUpperCase()), findsOneWidget);
-      expect(find.text('34'), findsWidgets); // stress — tile + orbit satellite
-      // Sleep pill shows its duration number.
-      expect(find.text('7h 42m'), findsWidgets); // tile + orbit satellite
+      // Stress + Sleep now live only on the orbit satellites (no bento tile).
+      expect(find.text('34'), findsOneWidget); // stress — orbit satellite
+      expect(find.text('7h 42m'), findsOneWidget); // sleep — orbit satellite
       expect(t.takeException(), isNull);
     });
 

--- a/test/design_redesign_test.dart
+++ b/test/design_redesign_test.dart
@@ -442,17 +442,6 @@ void main() {
                   11000,
                   8412,
                 ],
-                stageMin: (
-                  awakeMin: 24,
-                  remMin: 96,
-                  lightMin: 258,
-                  deepMin: 84,
-                ),
-                hypno: const [
-                  HypnoSeg(SleepStage.light, 0.0, 0.4),
-                  HypnoSeg(SleepStage.deep, 0.4, 0.6),
-                  HypnoSeg(SleepStage.rem, 0.6, 1.0),
-                ],
                 onOpen: opened.add,
               ),
               palette: p,
@@ -463,12 +452,13 @@ void main() {
           expect(find.text('READINESS'), findsOneWidget);
           expect(find.text('Primed'), findsOneWidget);
           expect(find.text('Sleep'), findsOneWidget); // satellite route
-          // Bento numbers. Sleep/Heart(RHR)/Strain now also appear on their
-          // orbit satellite, so those match >1; HRV is bento-only.
+          // Bento numbers. RHR also appears on its orbit satellite (Heart), so
+          // it matches >1; HRV is bento-only. Strain/Sleep have no bento tile
+          // anymore — each shows exactly once, on its orbit satellite.
           expect(find.text('48'), findsOneWidget); // HRV — bento only
           expect(find.text('52'), findsWidgets); // RHR — tile + Heart satellite
-          expect(find.text('12.4'), findsWidgets); // strain — tile + satellite
-          expect(find.text('7h 42m'), findsWidgets); // sleep — tile + satellite
+          expect(find.text('12.4'), findsOneWidget); // strain — satellite only
+          expect(find.text('7h 42m'), findsOneWidget); // sleep — satellite only
           expect(find.text('8412'), findsOneWidget);
           expect(find.text('640'), findsOneWidget);
           // Week rings card present (steps spark provided).

--- a/test/os_icons_wiring_test.dart
+++ b/test/os_icons_wiring_test.dart
@@ -103,7 +103,7 @@ void main() {
       expect(find.byType(AppIcon), findsWidgets);
     });
 
-    testWidgets('Today stress tile + orbit satellite render OsIcon.stress; '
+    testWidgets('Today orbit satellite renders OsIcon.stress; '
         'calories tile renders OsIcon.calories', (t) async {
       t.view.physicalSize = const Size(390, 3200);
       t.view.devicePixelRatio = 1.0;
@@ -122,12 +122,12 @@ void main() {
         ),
       ));
       await t.pump(const Duration(milliseconds: 1200));
-      // Stress art appears twice: the bento tile header + the orbit satellite.
+      // Stress has no bento tile anymore — only the orbit satellite renders it.
       expect(
         find.byWidgetPredicate(
           (w) => w is OsAppIcon && w.icon == OsIcon.stress,
         ),
-        findsNWidgets(2),
+        findsOneWidget,
       );
       expect(
         find.byWidgetPredicate(

--- a/test/week_view_feed_test.dart
+++ b/test/week_view_feed_test.dart
@@ -1,23 +1,17 @@
-// Feed-logic tests for the two week views the redesign surfaces:
-//   • Body's week-load wheel (BodyWeekLoadHero → weekLoadWheelData +
-//     WeekLoadWheelTile) — must show ALL 7 Mon→Sun segments with per-day
-//     labels and NO duplicate strain BigStat (the strain figure lives once,
-//     in the strain detail hero).
-//   • Today's steps week-of-rings (stepWeekRingData) — goal-relative fills
-//     aligned Monday→Sunday with today's index + live fold-in and honest
-//     nulls for missing/future days.
+// Feed-logic tests for Today's steps week-of-rings (stepWeekRingData) —
+// goal-relative fills aligned Monday→Sunday with today's index + live
+// fold-in and honest nulls for missing/future days.
+// (The Body week-load wheel this file used to also cover was removed along
+// with its screen usage — the wheel duplicated the strain figure already
+// shown once in the strain detail hero.)
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:openstrap_edge/theme/theme.dart';
 import 'package:openstrap_edge/theme/tokens.dart';
-import 'package:openstrap_edge/ui/design/big_stat.dart';
 import 'package:openstrap_edge/ui/design/domains.dart';
-import 'package:openstrap_edge/ui/design/radial_heatmap.dart';
 import 'package:openstrap_edge/ui/design/ring_week.dart';
-import 'package:openstrap_edge/ui/screens/screens.dart'
-    show WeekLoadWheelTile, weekLoadWheelData;
 import 'package:openstrap_edge/ui/today/today_screen.dart'
     show stepWeekRingData;
 
@@ -35,94 +29,7 @@ void _phone(WidgetTester t) {
   addTearDown(t.view.reset);
 }
 
-/// A /trend week payload for a fixed Mon→Sun week (2026-06-29 is a Monday),
-/// mirroring the repository shape: {value, has, t_start, t_end} per bucket.
-Map<String, dynamic> _weekTrend(List<double?> strain) {
-  final mon = DateTime.utc(2026, 6, 29);
-  return {
-    'buckets': [
-      for (var i = 0; i < 7; i++)
-        {
-          'value': strain[i] ?? 0.0,
-          'has': strain[i] != null,
-          't_start':
-              mon.add(Duration(days: i)).millisecondsSinceEpoch ~/ 1000,
-          't_end':
-              mon.add(Duration(days: i + 1)).millisecondsSinceEpoch ~/ 1000,
-        },
-    ],
-  };
-}
-
 void main() {
-  group('weekLoadWheelData (Body week-load wheel feed)', () {
-    test('maps a Mon→Sun payload to 7 segments with per-day labels', () {
-      final wheel = weekLoadWheelData(
-        _weekTrend(const [10.5, null, 21.0, 5.25, null, null, 30.0]),
-      );
-      expect(wheel.values.length, 7);
-      expect(wheel.labels, [
-        'Mon',
-        'Tue',
-        'Wed',
-        'Thu',
-        'Fri',
-        'Sat',
-        'Sun',
-      ]);
-      expect(wheel.values[0], closeTo(0.5, 1e-9)); // 10.5 / 21
-      expect(wheel.values[1], isNull); // has:false stays honest null
-      expect(wheel.values[2], 1.0);
-      expect(wheel.values[3], closeTo(0.25, 1e-9));
-      expect(wheel.values[4], isNull);
-      expect(wheel.values[6], 1.0); // clamped, never > 1
-    });
-
-    test('empty / missing payloads yield no segments (hero hides)', () {
-      expect(weekLoadWheelData(null).values, isEmpty);
-      expect(weekLoadWheelData(const {'buckets': []}).values, isEmpty);
-    });
-
-    test('one loaded day still yields the full 7-segment week', () {
-      final wheel = weekLoadWheelData(
-        _weekTrend(const [12.0, null, null, null, null, null, null]),
-      );
-      expect(wheel.values.length, 7);
-      expect(wheel.values.whereType<double>().length, 1);
-      expect(wheel.labels.length, 7);
-    });
-  });
-
-  group('WeekLoadWheelTile (Body hero presentation)', () {
-    testWidgets('renders the full-week heatmap and NO strain BigStat', (
-      t,
-    ) async {
-      for (final p in [kLightPalette, kDarkPalette]) {
-        _phone(t);
-        final wheel = weekLoadWheelData(
-          _weekTrend(const [10.5, null, 18.0, null, 6.0, null, null]),
-        );
-        await t.pumpWidget(
-          _host(
-            WeekLoadWheelTile(values: wheel.values, labels: wheel.labels),
-            palette: p,
-          ),
-        );
-        await t.pump(const Duration(milliseconds: 1100));
-        final heat = t.widget<RadialHeatmap>(find.byType(RadialHeatmap));
-        expect(heat.values.length, 7);
-        expect(heat.labels, hasLength(7));
-        // The dedupe: no strain number in the hero — the figure lives once,
-        // in the strain detail below.
-        expect(find.byType(BigStat), findsNothing);
-        expect(find.textContaining('latest strain'), findsNothing);
-        expect(find.textContaining('of 21'), findsNothing);
-        expect(find.text('WEEK LOAD'), findsOneWidget);
-        expect(t.takeException(), isNull, reason: 'palette $p');
-      }
-    });
-  });
-
   group('stepWeekRingData (Today steps week-of-rings feed)', () {
     test('goal-relative Mon→Sun fills with honest nulls', () {
       final ring = stepWeekRingData(


### PR DESCRIPTION
## Summary

Seven independent, individually-committed fixes:

1. **chore**: dead code flagged by `flutter analyze` (11 issues -> 0)
2. **refactor(ui)**: Today screen showed strain/sleep/stress twice (bento tile + orbit satellite) -- removed the tiles, kept the satellites. Deleted the "How your metrics are made" profile section. Collapsed the alarm-buzz description + Test Buzz button in the sleep coach card to one status line.
3. **fix(ui)**: removed the confusing Body "week-load wheel" (duplicated the strain figure already shown once below it); folded `liveSteps` into the Body screen's steps figure so it matches Today/Steps for the common case (full 3-screen unification of steps sources flagged as a follow-up, not done here).
4. **fix(ai)**: root-caused the "grey bar" AI Coach chart bug -- a model occasionally emits chart JSON in a markdown code fence instead of calling the plot tool, which renders as a raw grey code block. Added a prompt rule + a fallback parser that recovers a real chart from stray fenced JSON. Also fixed a leaked dev TODO in SpO2 copy and capped AI briefing bullets at 14 words.
5. **fix(sleep)**: the O2-dip card was both over-firing (any single dip called "Mild") and getting permanently stuck on "Uncertain" while SpO2 decoding is disabled upstream, instead of showing an honest quiet state. Fixed both.
6. **fix(gps)**: workout maps intermittently failed to render. Root cause: tiles were pointed at `tile.openstreetmap.org`, which OSM's usage policy forbids for app distribution -- silent rate-limiting renders as a blank/grey square with no error. Swapped to CARTO's Positron CDN (free, embed-permitted).
7. **fix(ble)**: wires `FirmwareAwareR24Decoder` (OpenStrap/protocol#9, merged) into all three real decode paths (`ble_engine.dart` live drain, `db.dart` import/merge fallback, `substrate.dart` batch re-decode). Root-caused from a real user's exported db: their band sends 88-byte v12 records, one byte under the original decoder's floor, so 100% of their historical records were silently archived instead of decoded since firmware presumably always looked like this on their unit -- total sync outage. The original decoder is untouched; a fallback chain tries it first and only falls back to a shorter-frame layout if it fails.

