### PR TITLE
release: v0.8.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openstrap_edge
 description: "OpenStrap — open-source WHOOP 4.0 companion. BLE drain → raw-first local store → cloud sync."
 publish_to: 'none'
-version: 0.8.2+21
+version: 0.8.3+22
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
release: v0.8.3

Firmware-aware R24 decoder (fixes a real total-sync-outage on at least one
user's device), workout maps tile-source fix, Today/Profile/alarm UI
dedup, AI Coach chart-render fix, O2-dip card fix, Body week-load wheel
removal, and a dead-code cleanup pass (#48). Bump build 21 -> 22.