### PR TITLE
Sleep-stage + steps fixes: wire the analytics fix, unify steps source, fix a broken lockfile

### DIFF
--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -137,7 +137,27 @@ import 'substrate.dart';
 // rows are absent — so previously-quarantined days now have data. Bump so those
 // days (and any finalized day derived while data was missing) recompute against
 // the recovered substrate.
-const int kAlgoVersion = 31;
+// v32: SLEEP-STAGE fix — the REM detector depended on a respiration signal
+// (`resp`) that no real caller ever supplied (WHOOP 4's R24 record has no
+// respiration-ADC channel), so it was unconditionally NaN and the primary
+// REM rule could never fire — nights collapsed to almost-all-light. Also
+// resolved a three-implementation ambiguity (`cardioStager` vs
+// `AdvancedSleepStager` v1/v2 — only v1 was ever actually wired, despite
+// `cardioStager` being the one documented as fixing Walch 2019's WAKE-bias)
+// via a head-to-head comparison; `cardioStager` (StagingMethod.cardio) is now
+// the wired default. ALSO in this same (unshipped) bump: `dailyStepEstimate`'s
+// doc had always promised a "run of >= minBoutMin consecutive ambulatory
+// minutes" bout gate that was never actually implemented — every minute that
+// individually passed the ENMO+HR gate summed directly into steps, so a
+// handful of scattered, non-contiguous minutes overnight (a brief HR lift
+// during a turn-over) could report several thousand phantom steps the moment
+// someone woke up having never walked. `minBoutMin` (default 3) is now a real
+// gate. Bumping re-derives non-finalized days so past nights/days restage;
+// ALREADY-FINALIZED history needs "Re-analyze data" to pick up BOTH corrected
+// staging and corrected steps — this is the one bump so far where that's
+// worth actually telling users about, since it affects months of history,
+// not just going forward.
+const int kAlgoVersion = 33;
 
 /// Raw is kept this many days past derivation, then pruned (derived stays).
 const int rawRetentionDays = 3;

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -741,6 +741,22 @@ class LocalRepositoryImpl extends LocalRepository {
     // EWMA-ACWR training load lives in the cross-day rollup (acute/chronic over a
     // history window); the strain detail's "Training load (ACWR)" row reads it.
     final cd = await _crossDay();
+    // STEPS is a live-accumulating count, not a "show last settled day" metric —
+    // unlike strain/zones/HR/curve above (where falling back to yesterday's
+    // finished bundle via _bundleForDate is the correct "still settling" UX),
+    // showing yesterday's step count as "today's steps" is actively wrong, not
+    // just stale. When today's own row hasn't been derived yet, use today's
+    // interim wake_day_features estimate instead of whatever _bundleForDate
+    // fell back to (same source getToday() uses for the Today screen) — the
+    // caller (strain_detail_screen.dart) folds AppState.liveSteps on top of
+    // this, matching Today's base+live composition exactly.
+    num? stepsBase;
+    if (_isTodayLabel(date) && await _bundle(date) == null) {
+      final wf = await _wakeFeatures(date);
+      stepsBase = wf?['steps'] as num?;
+    } else {
+      stepsBase = _scalar(b, 'steps');
+    }
     return {
       // Headline 0–21 strain (the detail screen clamps to 0..21). Raw Banister
       // TRIMP is kept as the secondary "training load" figure.
@@ -767,7 +783,7 @@ class LocalRepositoryImpl extends LocalRepository {
       'calories': _scalar(b, 'calories')?.round(),
       // Total daily energy (TDEE) + 24/7 step ESTIMATE (live pedometer tunes it).
       'calories_total': _scalar(b, 'calories_total')?.round(),
-      'steps': _scalar(b, 'steps')?.round(),
+      'steps': stepsBase?.round(),
       'hr': {
         'max': (hrStats?['max'] as num?)?.toInt(),
         'avg': (hrStats?['avg'] as num?)?.toInt(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -859,23 +859,29 @@ packages:
   openstrap_analytics:
     dependency: "direct main"
     description:
-      path: "../openstrap-analytics-onehz"
-      relative: true
-    source: path
+      path: "."
+      ref: main
+      resolved-ref: "184d14da07b013329d86e366778252b376b50d56"
+      url: "https://github.com/OpenStrap/analytics.git"
+    source: git
     version: "1.0.0"
   openstrap_icons:
     dependency: "direct main"
     description:
-      path: "../openstrap_icons"
-      relative: true
-    source: path
+      path: "."
+      ref: main
+      resolved-ref: "91f0309a4f1dcd36df2c504b5170f76c6e5ce767"
+      url: "https://github.com/OpenStrap/icons.git"
+    source: git
     version: "0.1.0"
   openstrap_protocol:
     dependency: "direct main"
     description:
-      path: "../openstrap-protocol-dart"
-      relative: true
-    source: path
+      path: "."
+      ref: main
+      resolved-ref: eb07a9aa2b46594a69efc852e1599e32f54dccb2
+      url: "https://github.com/OpenStrap/protocol.git"
+    source: git
     version: "1.0.0"
   ota_update:
     dependency: "direct main"

--- a/test/day_strain_steps_source_test.dart
+++ b/test/day_strain_steps_source_test.dart
@@ -1,0 +1,103 @@
+// Regression coverage for the "steps mismatch" bug: getDayStrain (the Body/
+// strain-detail screen's data source) used to route steps through the SAME
+// _bundleForDate fallback as strain/zones/HR — which, for TODAY specifically,
+// falls back to the latest COMPLETE day's bundle when today's own row hasn't
+// been derived yet. That's the right UX for strain/sleep/HRV ("show last
+// night's finished result while today settles"), but it's actively wrong for
+// steps: it silently showed a DIFFERENT day's step count as "today's steps"
+// instead of today's own in-progress estimate.
+//
+// Fix: getDayStrain now sources steps from wake_day_features (today's interim
+// estimate — same source getToday() uses for the Today screen) whenever
+// today's own day_result row doesn't exist yet, instead of falling through to
+// whatever _bundleForDate happened to return.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:openstrap_edge/compute/derivation_engine.dart' show kAlgoVersion;
+import 'package:openstrap_edge/data/db.dart';
+import 'package:openstrap_edge/data/day_label.dart';
+import 'package:openstrap_edge/data/local_repository_impl.dart';
+
+void main() {
+  setUpAll(() async {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+    LocalDb.dbName = 'openstrap_day_strain_steps_test.db';
+    final dir = await databaseFactory.getDatabasesPath();
+    await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+  });
+
+  tearDownAll(() async {
+    await LocalDb.close();
+    final dir = await databaseFactory.getDatabasesPath();
+    await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+  });
+
+  final repo = LocalRepositoryImpl(getProfileMap: () => null);
+  final today = todayLabel();
+  final yesterday = dayLabelOf(DateTime.now().subtract(const Duration(days: 1)));
+
+  test(
+      "when today's own day_result is missing, getDayStrain's steps come "
+      'from wake_day_features, NOT a fallback to a prior complete day', () async {
+    // Yesterday's finalized bundle exists and has a real (different) steps
+    // figure — this is what the old code would have silently surfaced as
+    // "today's steps" via _bundleForDate's latest-complete-day fallback.
+    await LocalDb.putDayResult(
+      dayId: yesterday,
+      algoVersion: kAlgoVersion,
+      payloadJson: jsonEncode({
+        'scalars': {'strain': 8.0, 'steps': 9999},
+      }),
+      windowJson: '{}',
+      finalized: true,
+    );
+
+    // Today has NO day_result row yet (derivation hasn't run), but DOES have
+    // an interim wake_day_features estimate — the honest "so far today" number.
+    await LocalDb.putWakeDayFeatures(
+      dayId: today,
+      algoVersion: kAlgoVersion,
+      payloadJson: jsonEncode({'steps': 321}),
+    );
+
+    final strain = await repo.getDayStrain(today);
+
+    expect(
+      strain['steps'],
+      321,
+      reason: 'must use today\'s own interim estimate (wake_day_features), '
+          'never a different day\'s finalized step count',
+    );
+    expect(strain['steps'], isNot(9999));
+  });
+
+  test(
+      "once today's own day_result exists, getDayStrain's steps come from "
+      "today's own bundle again (the fallback path is bypassed)", () async {
+    await LocalDb.putDayResult(
+      dayId: today,
+      algoVersion: kAlgoVersion,
+      payloadJson: jsonEncode({
+        'scalars': {'strain': 5.0, 'steps': 4321},
+      }),
+      windowJson: '{}',
+      finalized: true,
+    );
+
+    final strain = await repo.getDayStrain(today);
+    expect(strain['steps'], 4321);
+  });
+
+  test(
+      'a genuine historical date with no bundle at all returns an honest '
+      'empty shape (no fallback, no wake_day_features substitution)', () async {
+    final strain = await repo.getDayStrain('2020-01-01');
+    expect(strain, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- Bumps `kAlgoVersion` 31 -> 33 to pick up two real analytics fixes now merged in OpenStrap/analytics#18:
  - Sleep staging: the REM detector depended on a respiration signal WHOOP 4 never provides, permanently dead -- nights collapsed to almost-all-light. `cardioStager` is now the wired default (won a head-to-head comparison against the two `AdvancedSleepStager` variants).
  - Steps: `dailyStepEstimate`'s documented bout-length gate was never actually implemented -- isolated overnight motion+HR minutes could each count individually, summing into thousands of phantom steps. Real user report ("woke up, never walked, saw 4000+ steps"). Now gated on a real >=3-minute contiguous bout.
- `getDayStrain` (Body/strain-detail screen): closes the remaining piece of an earlier steps-unification fix -- when today's own `day_result` hasn't been derived yet, it now sources steps from `wake_day_features` (today's own interim estimate) instead of `_bundleForDate`'s fallback, which could silently substitute a **different day's** step count.
- **Also fixes a real bug in the previously-merged #48**: the committed `pubspec.lock` had regressed to local path entries for all three git dependencies instead of pinned refs (a process bug on my end -- restoring `pubspec_overrides.yaml` for local dev and then running `flutter pub get` silently rewrites the lock back to path sources). Regenerated correctly this time and verified the full suite green against the real remote-resolved dependencies, the same state CI builds against.

## Test plan
- [x] `flutter analyze` -- 1 issue (documented, pre-existing, intentional)
- [x] `flutter test --concurrency=1` -- 437/437, run twice: once against local sibling repos, once against the real git-resolved remote dependencies (matching what CI will actually build)