### PR TITLE
release: v0.8.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openstrap_edge
 description: "OpenStrap — open-source WHOOP 4.0 companion. BLE drain → raw-first local store → cloud sync."
 publish_to: 'none'
-version: 0.8.3+22
+version: 0.8.4+23
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
release: v0.8.4

Sleep-stage fix (dead REM path resurrected, cardioStager now the default)
and a real steps-overcounting bug fix (missing bout-length gate let
scattered overnight motion+HR minutes sum into thousands of phantom steps),
via OpenStrap/analytics#18 (#50). Plus the steps-source unification
follow-up in getDayStrain, and a pubspec.lock fix (the prior release had
regressed to unpinned local-path dependency entries). Bump build 22 -> 23.