### PR TITLE
chore: bump kAlgoVersion 36->37 for cardio_stager wake/REM fix

### DIFF
--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -159,7 +159,28 @@ import 'substrate.dart';
 // staging and corrected steps — this is the one bump so far where that's
 // worth actually telling users about, since it affects months of history,
 // not just going forward.
-const int kAlgoVersion = 36;
+// v37: SLEEP-STAGE fix #2 (real-device root cause, not synthetic) — v32 fixed
+// the dead REM path but a real overnight capture showed cardioStager still
+// massively over-called WAKE (~6h on a night truth was ~3min) and under-
+// called REM (~40min vs a ~2h42m truth). Root cause: BOTH the motion
+// ("gravity 1 g reference") and HR ("sleeping HR baseline") features were
+// single WHOLE-NIGHT scalars. This real device's decoded gravity-vector
+// magnitude is NOT perfectly orientation-invariant — different STATIC sleep
+// postures read up to ~13% apart in |accel| despite near-zero within-epoch
+// variance (i.e. genuinely still), so 389/421 "big move" epochs that night
+// were this artifact, not real movement, and produced WAKE blocks too long
+// for Webster rescore to bridge back. Separately, the whole-night HR arousal
+// threshold misread the sleep-onset HR-decay transient (elevated HR for the
+// first ~60-90 min while settling) as sustained arousal. `cardio_stager.dart`
+// now computes both references as LOCALLY-ADAPTIVE rolling windows, plus a
+// local p25 (not median) floor specifically for the REM gate — REM recurs on
+// ~90 min ultradian cycles and is a minority of any local window, so a local
+// MEDIAN self-dilutes from REM's own periodic elevation. Verified on the real
+// capture: wake 294->1 min, light 173->337 min, deep 26->58 min, rem 41->139
+// min, against an Apple Watch Ultra ground truth of wake=3 light=330 deep=38
+// rem=162 min for the same night. Bump so this genuinely different (much more
+// accurate) staging recomputes; "Re-analyze data" needed for finalized nights.
+const int kAlgoVersion = 37;
 
 /// Raw is kept this many days past derivation, then pruned (derived stays).
 const int rawRetentionDays = 3;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -957,7 +957,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "160f07380153b4d6e26248d91f9e83e00c2b9503"
+      resolved-ref: "8d2d697e0a56356b33b75f30727e52b5eda0c743"
       url: "https://github.com/OpenStrap/analytics.git"
     source: git
     version: "1.0.0"


### PR DESCRIPTION
## Summary
Depends on **OpenStrap/analytics#21** (cardio_stager whole-night thresholds over-called WAKE, starved REM).

Bumps `kAlgoVersion` 36→37 so finalized sleep nights re-derive under the fixed staging instead of continuing to serve stale pre-fix output when the user hits "Re-analyze data".

## Merge order
1. Merge OpenStrap/analytics#21 first
2. Run `flutter pub upgrade openstrap_analytics` here to move `pubspec.lock`'s resolved-ref onto the merged fix commit (currently still pointing at pre-fix analytics main, `8d2d697`, since #21 wasn't merged when this lock was generated)
3. Merge this PR

## Test plan
- [x] `flutter test --concurrency=1` — same 7 pre-existing failures as clean `main` (confirmed via stash: `hypnogram.dart` RenderFlex overflow + `workout_sleep_redesign_test.dart` null-checks), unrelated to this change, nothing newly broken
- [x] `dart analyze` on touched files — clean (pre-existing unrelated warnings only)
- [x] Built and installed locally (release build on a real device) with the analytics fix wired in via local path override — confirmed the fix actually resolves the sleep-stage bug end-to-end before this PR was opened