### PR TITLE
chore: pin analytics fix commit + bump to v0.9.6+39

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -957,7 +957,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "8d2d697e0a56356b33b75f30727e52b5eda0c743"
+      resolved-ref: "168d97677570cbb97a2d1504d80df7029476f327"
       url: "https://github.com/OpenStrap/analytics.git"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openstrap_edge
 description: "OpenStrap — open-source WHOOP 4.0 companion. BLE drain → raw-first local store → cloud sync."
 publish_to: 'none'
-version: 0.9.5+38
+version: 0.9.6+39
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
## Summary
Required follow-up to #59 before tagging a release — without this, the release would ship `kAlgoVersion=37` (triggering re-derivation) but still run the **pre-fix** `cardio_stager.dart`, since #59's `pubspec.lock` was generated before OpenStrap/analytics#21 merged.

- Pins `openstrap_analytics` to `168d976` (the merged cardio_stager wake/REM fix)
- Bumps version 0.9.5+38 → 0.9.6+39 for release

## Test plan
- [x] `flutter test --concurrency=1` — 425/432, same 7 pre-existing unrelated failures as clean main