### PR TITLE
fix: reset foregroundActive on failed background-launch connect

### DIFF
--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1224,9 +1224,22 @@ class AppState extends ChangeNotifier {
           if (await engine.connectToRemoteId(paired!.remoteId)) {
             _maybeDowngradeLiveForBackground();
             _startBackfillTimer();
+          } else {
+            // Connect attempt didn't succeed on this background cold-launch —
+            // fall back to the recovery arm so `foregroundActive` resets and
+            // native re-arms a fresh pending connect. Without this, a single
+            // failed connect here permanently wedges every future
+            // restore-wake for this process's lifetime: foregroundActive was
+            // already set true above, and it's the master gate on the native
+            // wake handler (ios_ble_restore.dart) — stuck true with no live
+            // connection means every subsequent wake silently no-ops forever,
+            // and the only way back is the user manually opening the app.
+            _log('[init] bg connect returned false — arming recovery');
+            await _armRecovery();
           }
         } catch (e) {
-          _log('[init] bg connect failed: $e');
+          _log('[init] bg connect failed: $e — arming recovery');
+          await _armRecovery();
         }
       } else {
         openSession();


### PR DESCRIPTION
## Summary
Fixes the reported "background BLE connection not maintained — only reconnects when the app is manually opened, no charging notification" bug.

## Root cause
`lib/state/app_state.dart`'s `AppState()` constructor background-bootstrap path (added in #55-ish, "resolve background sync and analyze isolate collisions by removing WorkManager") sets `IosBleRestore.foregroundActive = true` unconditionally before attempting `engine.connectToRemoteId()`, then only logs on failure.

`foregroundActive` is the master gate on the native wake handler (`ios_ble_restore.dart`'s `MethodCallHandler`): while true, every `'wake'` call from native immediately no-ops (`_done()` → tells native `syncDone`, never runs `runHeadlessSync()`). The only two places that ever reset it back to `false` are `unpair()` and `armRecoveryNow()` (via `_armRecovery()`) — neither was reachable from this failure path.

**Net effect**: a single failed connect attempt on a background cold-launch (iOS relaunching the process via restore-wake or a BGTask — the normal way this app's background BLE works) permanently wedges every future background wake for that process's entire lifetime. The only way back was manually opening the app, which runs the unrelated `openSession()` foreground path.

Corroborating evidence: the reporting user's own db export showed `sync_ledger` recording a single manual historical capture pulling ~14 days of backlog off the band (June 27 → July 11) in one go — consistent with background sync having been effectively dead for a long stretch.

## Fix
Fall back to `_armRecovery()` (resets `foregroundActive` **and** re-arms the native restore central) both when `connectToRemoteId()` returns `false` and in the catch block, instead of just logging.

## Test plan
- [x] `dart analyze lib/state/app_state.dart` — clean (2 pre-existing unrelated warnings)
- [x] `flutter test --concurrency=1` — 425/432, same 7 pre-existing unrelated failures as clean main
- [ ] **Needs real-device confirmation** — no existing test seam covers `AppState`'s background bootstrap path (tight coupling to a real `BleEngine`, platform channels, `WidgetsBinding` lifecycle state, nothing currently mockable), and this is fundamentally an iOS background-relaunch timing issue that can't be fully exercised in a unit test. Verify by leaving the app backgrounded for an extended period and confirming the connection is maintained / reconnects without manually opening the app.