### PR TITLE
chore: release v0.9.7+40

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openstrap_edge
 description: "OpenStrap — open-source WHOOP 4.0 companion. BLE drain → raw-first local store → cloud sync."
 publish_to: 'none'
-version: 0.9.6+39
+version: 0.9.7+40
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
## Summary
Release PR for #61 (iOS background-wake permanently-wedged fix, confirmed working on real device by user).

## Test plan
- [x] Confirmed working on real device (user-reported)