### PR TITLE
feat: wire real cardiac-coherence into the guided-breathing screen

### DIFF
--- a/lib/data/local_repository.dart
+++ b/lib/data/local_repository.dart
@@ -131,4 +131,14 @@ abstract class LocalRepository {
   /// computes this on-device via openstrap_protocol.realtimeRr + openstrap_analytics.
   Future<Map<String, dynamic>> spotCheck(List<String> records) =>
       throw UnimplementedError('re-layer: spotCheck');
+
+  // ── guided-breathing cardiac coherence ────────────────────────────────────────
+  /// Decode live RR frames collected during a guided-breathing session and
+  /// compute McCraty & Zayas 2014 cardiac coherence on-device. [pacedHz] is
+  /// the guided pacing frequency (e.g. 5.5 breaths/min == 0.0917 Hz).
+  Future<Map<String, dynamic>> breathingCoherence(
+    List<String> records, {
+    double? pacedHz,
+  }) =>
+      throw UnimplementedError('re-layer: breathingCoherence');
 }

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -2398,6 +2398,46 @@ class LocalRepositoryImpl extends LocalRepository {
     };
   }
 
+  @override
+  Future<Map<String, dynamic>> breathingCoherence(
+    List<String> records, {
+    double? pacedHz,
+  }) async {
+    // Decode RR from the live RR-bearing frames (0x28 / R10) — same seam
+    // spotCheck uses — then run McCraty & Zayas 2014 cardiac coherence.
+    final rrMs = <double>[];
+    for (final hex in records) {
+      final rr = proto.realtimeRr(hex);
+      if (rr != null) {
+        for (final v in rr.rrMs) {
+          if (v > 0) rrMs.add(v.toDouble());
+        }
+      }
+    }
+    if (rrMs.length < 20) {
+      return {'ok': false, 'n_beats': rrMs.length};
+    }
+    final cleaned = ana.correctRr(rrMs);
+    final m = ana.cardiacCoherence(cleaned.nn, cleaned.nnTimesMs, pacedHz: pacedHz);
+    if (!m.present) {
+      return {
+        'ok': false,
+        'n_beats': cleaned.nn.length,
+        'note': m.note,
+      };
+    }
+    return {
+      'ok': true,
+      'ratio': m.value!.ratio,
+      'score': m.value!.score.round(),
+      'peak_hz': m.value!.peakHz,
+      'n_beats': cleaned.nn.length,
+      'confidence': m.confidence,
+      'tier': m.tier,
+      'note': m.note,
+    };
+  }
+
   // ── small series helpers ─────────────────────────────────────────────────────
 
   Future<double?> _seriesMean(String key) async {

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1375,9 +1375,9 @@ class AppState extends ChangeNotifier {
   }
 
   /// True while some foreground feature is actively consuming the live streams
-  /// (workout coach, HRV spot check, step-calibration walk).
+  /// (workout coach, HRV spot check, step-calibration walk, breathing session).
   bool get _hasLiveConsumer =>
-      activeWorkout != null || spotActive || _stepCalActive;
+      activeWorkout != null || spotActive || _stepCalActive || breathingActive;
 
   /// Downgrade live to HR-only when backgrounded with no live consumer. The
   /// keep-alive re-arm respects the HR-only mode, so the downgrade sticks until
@@ -1423,6 +1423,9 @@ class AppState extends ChangeNotifier {
     // STORED record (the data edge), which only _onRecord advances.
     if (spotActive && (pt == 0x28 || pt == 0x2B)) {
       if (_spotFrames.length < 8000) _spotFrames.add(hex);
+    }
+    if (breathingActive && (pt == 0x28 || pt == 0x2B)) {
+      if (_breathingFrames.length < 8000) _breathingFrames.add(hex);
     }
     // LIVE STEP COUNTER. The dedicated 0x33 IMU stream is the high-rate live
     // accel — it arrives ~10 frames/s (10 samples each), so it drives a smooth,
@@ -2571,6 +2574,93 @@ class AppState extends ChangeNotifier {
       unawaited(engine.disableLiveStreams());
     }
     _spotEnabledStreams = false;
+  }
+
+  // ── guided-breathing cardiac coherence ──────────────────────────────────────
+  // User taps "begin breathing session": enable live RR-bearing streams,
+  // collect frames continuously in _breathingFrames (tapped from _onLiveFrame,
+  // same seam spot-check uses), and periodically recompute McCraty & Zayas
+  // 2014 coherence over the FULL accumulated series so far — not a sliding
+  // window, so the score stabilizes as more clean data comes in rather than
+  // jittering on a short recent slice. Replaces the screen's old
+  // Random()-fabricated score. Ephemeral — nothing persisted.
+  //
+  // 5.5 breaths/min == CalmBreathingScreen's 5450ms inhale/exhale half-cycle
+  // (10900ms per full breath).
+  static const double breathingPacedHz = 1000.0 / 10900.0;
+  static const Duration _breathingRecomputeInterval = Duration(seconds: 20);
+  bool breathingActive = false;
+  Map<String, dynamic>?
+  breathingResult; // last {ok, ratio, score, peak_hz, n_beats, confidence, tier, note}
+  String? breathingError;
+  final List<String> _breathingFrames = [];
+  Timer? _breathingRecomputeTimer;
+  bool _breathingEnabledStreams = false;
+
+  /// Begin a guided-breathing session. Requires a connected band.
+  Future<void> startBreathingSession() async {
+    if (breathingActive) return;
+    if (!isConnected) {
+      breathingError = 'Connect your band first.';
+      notifyListeners();
+      return;
+    }
+    breathingActive = true;
+    breathingResult = null;
+    breathingError = null;
+    _breathingFrames.clear();
+    notifyListeners();
+    try {
+      // OWNERSHIP: same rule as spot-check — only claim "we enabled it" when
+      // live was actually OFF, so ending the session can never turn off
+      // streams the open session still expects on.
+      if (!engine.liveEnabled) {
+        await engine.enableLiveStreams();
+        _breathingEnabledStreams = true;
+      } else if (engine.liveHrOnly) {
+        await engine.enableLiveStreams();
+      }
+    } catch (_) {
+      /* best-effort; we still collect whatever arrives */
+    }
+    _breathingRecomputeTimer?.cancel();
+    _breathingRecomputeTimer = Timer.periodic(_breathingRecomputeInterval, (_) {
+      unawaited(_recomputeBreathingCoherence());
+    });
+  }
+
+  /// End the guided-breathing session.
+  Future<void> stopBreathingSession() async {
+    if (!breathingActive) return;
+    _breathingRecomputeTimer?.cancel();
+    _breathingRecomputeTimer = null;
+    breathingActive = false;
+    _stopBreathingStreams();
+    notifyListeners();
+  }
+
+  Future<void> _recomputeBreathingCoherence() async {
+    if (!breathingActive || repo == null) return;
+    final frames = List<String>.from(_breathingFrames);
+    if (frames.isEmpty) return;
+    try {
+      final res = await repo!.breathingCoherence(
+        frames,
+        pacedHz: breathingPacedHz,
+      );
+      if (!breathingActive) return; // session ended while we awaited
+      breathingResult = res;
+      notifyListeners();
+    } catch (_) {
+      /* best-effort; keep the last good result on screen rather than erroring */
+    }
+  }
+
+  void _stopBreathingStreams() {
+    if (_breathingEnabledStreams && activeWorkout == null) {
+      unawaited(engine.disableLiveStreams());
+    }
+    _breathingEnabledStreams = false;
   }
 
   // ── guided step calibration (open-road walk) ────────────────────────────────

--- a/lib/ui/stress/calm_breathing_screen.dart
+++ b/lib/ui/stress/calm_breathing_screen.dart
@@ -1,21 +1,72 @@
-import 'package:flutter/material.dart';
-import 'dart:math' as math;
+// Guided resonance breathing — a paced-breathing circle (5.5 breaths/min,
+// the classic HRV-resonance pace) with a REAL cardiac-coherence readout.
+//
+// The coherence score is computed on-device from live beat-to-beat RR
+// (McCraty & Zayas 2014 — see openstrap_analytics's cardiacCoherence) via
+// AppState.startBreathingSession/breathingResult — never fabricated. Before
+// enough clean live data has accumulated, the screen honestly says so
+// ("Calibrating…") instead of showing a placeholder number.
+//
+// Container (this file's CalmBreathingScreen) wires Provider; CalmBreathingView
+// is the pure, testable presentation — the breathing-circle animation is
+// local UI state (just paces the visual), the score is a prop.
 
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../state/app_state.dart';
 import '../design/design.dart';
 
-class CalmBreathingScreen extends StatefulWidget {
+class CalmBreathingScreen extends StatelessWidget {
   const CalmBreathingScreen({super.key});
 
   @override
-  State<CalmBreathingScreen> createState() => _CalmBreathingScreenState();
+  Widget build(BuildContext context) {
+    final app = context.watch<AppState>();
+    return CalmBreathingView(
+      connected: app.isConnected,
+      active: app.breathingActive,
+      result: app.breathingResult,
+      error: app.breathingError,
+      onStart: app.startBreathingSession,
+      onStop: app.stopBreathingSession,
+      onBack: () {
+        if (app.breathingActive) app.stopBreathingSession();
+        Navigator.of(context).maybePop();
+      },
+    );
+  }
 }
 
-class _CalmBreathingScreenState extends State<CalmBreathingScreen>
+/// The pure breathing board — testable with plain values, no AppState.
+class CalmBreathingView extends StatefulWidget {
+  final bool connected;
+  final bool active;
+  final Map? result;
+  final String? error;
+  final VoidCallback? onStart;
+  final VoidCallback? onStop;
+  final VoidCallback? onBack;
+
+  const CalmBreathingView({
+    super.key,
+    required this.connected,
+    required this.active,
+    this.result,
+    this.error,
+    this.onStart,
+    this.onStop,
+    this.onBack,
+  });
+
+  @override
+  State<CalmBreathingView> createState() => _CalmBreathingViewState();
+}
+
+class _CalmBreathingViewState extends State<CalmBreathingView>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
   String _phaseText = "Inhale";
-  double _coherenceScore = 0.0;
-  bool _isActive = false;
 
   @override
   void initState() {
@@ -34,16 +85,21 @@ class _CalmBreathingScreenState extends State<CalmBreathingScreen>
         _controller.reverse();
       } else if (status == AnimationStatus.dismissed) {
         setState(() => _phaseText = "Inhale");
-        // Simulate increasing coherence as they breathe
-        if (_isActive && _coherenceScore < 95.0) {
-          setState(() {
-            _coherenceScore += 5.0 + (math.Random().nextDouble() * 5);
-            if (_coherenceScore > 100) _coherenceScore = 100.0;
-          });
-        }
         _controller.forward();
       }
     });
+  }
+
+  @override
+  void didUpdateWidget(covariant CalmBreathingView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.active && !oldWidget.active) {
+      _controller.forward();
+    } else if (!widget.active && oldWidget.active) {
+      _controller.stop();
+      _controller.value = 0.0;
+      setState(() => _phaseText = "Inhale");
+    }
   }
 
   @override
@@ -52,22 +108,10 @@ class _CalmBreathingScreenState extends State<CalmBreathingScreen>
     super.dispose();
   }
 
-  void _startBreathing() {
-    setState(() {
-      _isActive = true;
-      _coherenceScore = 40.0; // Starting baseline
-    });
-    _controller.forward();
-  }
-
-  void _stopBreathing() {
-    setState(() {
-      _isActive = false;
-    });
-    _controller.stop();
-    _controller.value = 0.0;
-    setState(() => _phaseText = "Inhale");
-  }
+  bool get _hasResult => widget.result?['ok'] == true;
+  // Coherence isn't a published 0-100 scale (see cardiacCoherence's own
+  // honesty note) — this threshold is a display choice, not a cited boundary.
+  bool _isGood(num score) => score > 60;
 
   @override
   Widget build(BuildContext context) {
@@ -78,7 +122,7 @@ class _CalmBreathingScreenState extends State<CalmBreathingScreen>
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.close, size: 24),
-          onPressed: () => Navigator.pop(context),
+          onPressed: widget.onBack,
         ),
       ),
       body: Column(
@@ -121,7 +165,7 @@ class _CalmBreathingScreenState extends State<CalmBreathingScreen>
                     child: Transform.scale(
                       scale: 1.0 / scale, // keep text unscaled
                       child: Text(
-                        _isActive ? _phaseText : "Ready",
+                        widget.active ? _phaseText : "Ready",
                         style: AppText.h2.copyWith(
                           color: DomainAccent.recovery,
                         ),
@@ -133,28 +177,48 @@ class _CalmBreathingScreenState extends State<CalmBreathingScreen>
             ),
           ),
           const SizedBox(height: 64),
-          if (_isActive) ...[
+          if (widget.active) ...[
             Text(
               'Coherence Score',
               style: AppText.caption,
             ),
             const SizedBox(height: Sp.x2),
-            Text(
-              '${_coherenceScore.toInt()}%',
-              style: AppText.h1.copyWith(
-                color: _coherenceScore > 80 ? AppColors.good : AppColors.warn,
+            if (_hasResult)
+              Text(
+                '${(widget.result!['score'] as num).round()}%',
+                style: AppText.h1.copyWith(
+                  color: _isGood(widget.result!['score'] as num)
+                      ? AppColors.good
+                      : AppColors.warn,
+                ),
+              )
+            else
+              // Honest: no fabricated number until enough clean live RR has
+              // accumulated (first recompute lands ~20s in — see AppState's
+              // _breathingRecomputeInterval).
+              Text(
+                'Calibrating…',
+                style: AppText.h2.copyWith(color: AppColors.inkMuted),
               ),
-            ),
             const SizedBox(height: Sp.x8),
             OutlinedButton(
-              onPressed: _stopBreathing,
+              onPressed: widget.onStop,
               child: const Text('Stop Session'),
             ),
-          ] else
+          ] else ...[
             FilledButton(
-              onPressed: _startBreathing,
+              onPressed: widget.connected ? widget.onStart : null,
               child: const Text('Begin 2-Minute Session'),
             ),
+            if (!widget.connected || widget.error != null) ...[
+              const SizedBox(height: Sp.x3),
+              Text(
+                widget.error ?? 'Connect your band to start a session.',
+                style: AppText.captionMuted,
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ],
         ],
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -957,7 +957,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "168d97677570cbb97a2d1504d80df7029476f327"
+      resolved-ref: "56acd93a00f56bc6244f396b33bc4c20e98f6cc8"
       url: "https://github.com/OpenStrap/analytics.git"
     source: git
     version: "1.0.0"

--- a/test/calm_breathing_view_test.dart
+++ b/test/calm_breathing_view_test.dart
@@ -1,0 +1,89 @@
+// CalmBreathingView — the guided-breathing screen's pure presentation layer.
+// Regression coverage for replacing the old Random()-fabricated "coherence
+// score" with real data: before a real result exists, the screen must show
+// an honest "Calibrating…" state, never a placeholder number.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:openstrap_edge/theme/theme.dart';
+import 'package:openstrap_edge/theme/tokens.dart';
+import 'package:openstrap_edge/ui/stress/calm_breathing_screen.dart';
+
+Widget _host(Widget child) {
+  AppColors.active = kLightPalette;
+  return MaterialApp(
+    theme: buildOpenStrapTheme(kLightPalette),
+    home: child,
+  );
+}
+
+void main() {
+  testWidgets('not connected: start button disabled, shows connect prompt',
+      (tester) async {
+    await tester.pumpWidget(_host(const CalmBreathingView(
+      connected: false,
+      active: false,
+    )));
+    final button = tester.widget<FilledButton>(find.byType(FilledButton));
+    expect(button.onPressed, isNull);
+    expect(find.text('Connect your band to start a session.'), findsOneWidget);
+  });
+
+  testWidgets('connected, not active: tapping start calls onStart',
+      (tester) async {
+    var started = false;
+    await tester.pumpWidget(_host(CalmBreathingView(
+      connected: true,
+      active: false,
+      onStart: () => started = true,
+    )));
+    await tester.tap(find.byType(FilledButton));
+    expect(started, isTrue);
+  });
+
+  testWidgets(
+      'active with no result yet shows an HONEST calibrating state, never a fabricated number',
+      (tester) async {
+    await tester.pumpWidget(_host(const CalmBreathingView(
+      connected: true,
+      active: true,
+      result: null,
+    )));
+    expect(find.text('Calibrating…'), findsOneWidget);
+    expect(find.textContaining('%'), findsNothing);
+  });
+
+  testWidgets('active with a not-ok result still shows calibrating, not a fake score',
+      (tester) async {
+    await tester.pumpWidget(_host(const CalmBreathingView(
+      connected: true,
+      active: true,
+      result: {'ok': false, 'n_beats': 5},
+    )));
+    expect(find.text('Calibrating…'), findsOneWidget);
+  });
+
+  testWidgets('active with a real ok result shows the real score',
+      (tester) async {
+    await tester.pumpWidget(_host(const CalmBreathingView(
+      connected: true,
+      active: true,
+      result: {'ok': true, 'score': 82, 'ratio': 4.5, 'peak_hz': 0.09},
+    )));
+    expect(find.text('82%'), findsOneWidget);
+    expect(find.text('Calibrating…'), findsNothing);
+  });
+
+  testWidgets('tapping Stop Session calls onStop', (tester) async {
+    var stopped = false;
+    await tester.pumpWidget(_host(CalmBreathingView(
+      connected: true,
+      active: true,
+      result: const {'ok': true, 'score': 70},
+      onStop: () => stopped = true,
+    )));
+    await tester.tap(find.text('Stop Session'));
+    expect(stopped, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
Depends on **OpenStrap/analytics#22** (real `cardiacCoherence` — McCraty & Zayas 2014). Replaces `calm_breathing_screen.dart`'s fabricated `Random()`-based "coherence score" with a real computation from live RR collected during the guided-breathing session.

## Changes
- `local_repository{,_impl}.dart`: new `breathingCoherence(records, {pacedHz})` seam, mirroring `spotCheck`'s decode path (`realtimeRr` → `correctRr` → `ana.cardiacCoherence`) — on-device, ephemeral, nothing persisted.
- `app_state.dart`: new `startBreathingSession`/`stopBreathingSession`, following the same live-stream-ownership pattern as `startSpotCheck`. Collects live `0x28`/`0x2B` frames continuously, recomputes coherence over the **full** accumulated series every 20s (not a sliding window) so the score stabilizes as more clean data arrives. `breathingActive` added to `_hasLiveConsumer` so backgrounding mid-session doesn't downgrade live to HR-only underneath it.
- `calm_breathing_screen.dart`: split into a container (Provider wiring) + `CalmBreathingView` (pure, testable) — matches the spot-check screen's established pattern. Before a real result exists, shows an honest **"Calibrating…"** state instead of a fabricated number.

## Merge order
1. Merge OpenStrap/analytics#22 first
2. Run `flutter pub upgrade openstrap_analytics` here to move `pubspec.lock`'s resolved-ref onto the merged commit (same two-step sequence used for the sleep-stage fix's #59/#60 — **this branch will not compile as-is until that lands**, since `pubspec.lock` currently still pins pre-feature analytics `168d976`)
3. Merge this PR

## Test plan
- [x] Verified locally via a temporary `dependency_overrides` pointing at the local analytics checkout (gitignored, never committed): `dart analyze` clean, `flutter test --concurrency=1` 438/445 (432 + 6 new), same 7 pre-existing unrelated failures as clean main
- [x] New widget tests for `CalmBreathingView`: disabled/connect-prompt when not connected; tapping start/stop calls the right callbacks; **honest "Calibrating…" state both when no result exists yet and when a result exists but isn't `ok`** (never a fabricated number); real score renders once a result is `ok`