### PR TITLE
chore: release v0.9.8+41

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openstrap_edge
 description: "OpenStrap — open-source WHOOP 4.0 companion. BLE drain → raw-first local store → cloud sync."
 publish_to: 'none'
-version: 0.9.7+40
+version: 0.9.8+41
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
## Summary
Release PR for #63 (real cardiac-coherence metric for the guided-breathing screen, replacing the Random()-fabricated score).

## Test plan
- [x] flutter test --concurrency=1 — 438/445, same 7 pre-existing unrelated failures as clean main