### PR TITLE
feat: on-demand wear-location check (GET_BODY_LOCATION_AND_STATUS)

### DIFF
--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -1817,11 +1817,20 @@ class BleEngine {
     }
     if (f.containsKey('body_location_status')) {
       final b = f['body_location_status'] as BodyLocationStatusResponse;
+      state.bodyLocationRevision = b.revision;
       state.bodyLocationRaw = b.locationRaw;
       state.bodyLocationConfidence = b.confidence;
       state.bodyLocationStatus = b.status;
       state.bodyLocationCheckedAt =
           DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      // Logged unconditionally (not just on an unmapped value) — this command
+      // is new and user-triggered rarely, so a real-world raw-byte trail is
+      // worth keeping regardless of whether GarmentDeviceLocation resolves it.
+      _log(
+        'GET_BODY_LOCATION_AND_STATUS: rev=${b.revision} '
+        'locationRaw=${b.locationRaw} (${b.location?.name ?? "UNMAPPED"}) '
+        'confidence=${b.confidence} status=${b.status}',
+      );
       onState(state);
     }
     if (f.containsKey('clock_epoch')) {

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -1815,6 +1815,15 @@ class BleEngine {
       state.wristOn = f['on_wrist'] as bool;
       onState(state);
     }
+    if (f.containsKey('body_location_status')) {
+      final b = f['body_location_status'] as BodyLocationStatusResponse;
+      state.bodyLocationRaw = b.locationRaw;
+      state.bodyLocationConfidence = b.confidence;
+      state.bodyLocationStatus = b.status;
+      state.bodyLocationCheckedAt =
+          DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      onState(state);
+    }
     if (f.containsKey('clock_epoch')) {
       final dev = f['clock_epoch'] as int;
       final wall = DateTime.now().millisecondsSinceEpoch ~/ 1000;
@@ -2412,6 +2421,17 @@ class BleEngine {
   /// Read the strap RTC. The response carries `clock_epoch`, handled where we
   /// verify drift and re-correlate the strap-RTC ↔ wall clock.
   Future<void> getClock() => _send(Cmd.getClock, const <int>[]);
+
+  /// On-demand wear-location check (GET_BODY_LOCATION_AND_STATUS = 0x54,
+  /// non-dangerous). WHOOP garments beyond the wrist strap (bicep band,
+  /// apparel pocket) mean the band itself classifies which body location
+  /// it's currently docked in — response carries `body_location_status`,
+  /// handled in _absorbState. Deliberately NOT sent automatically on every
+  /// connect/handshake — this project's own BLE discipline is to never add
+  /// anything to the sync-critical connect path that doesn't need to be
+  /// there; this is a user-triggered diagnostic only.
+  Future<void> getBodyLocationAndStatus() =>
+      _send(Cmd.getBodyLocationAndStatus, const <int>[]);
 
   /// On-device wake alarm (SET_ALARM_TIME = 0x42) — the RICH 20-byte form that
   /// actually FIRES on WHOOP 4.0:

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -93,6 +93,7 @@ class LocalDb {
         await _createWorkoutSuggestions(db);
         await _createSleepOverride(db);
         await _createWorkoutRoute(db);
+        await _createBodyLocationChecks(db);
         await _ensureCoachViews(db);
       },
       onUpgrade: (db, oldV, newV) async {
@@ -268,11 +269,18 @@ class LocalDb {
           // speed was ever recorded for them) — never backfilled/guessed.
           await _ensureWorkoutRouteSpeed(db);
         }
+        if (oldV < 24) {
+          // GET_BODY_LOCATION_AND_STATUS (0x54) raw-byte history — additive,
+          // user-triggered only. Kept so real device captures of the raw
+          // confidence/status bytes (whose exact scale isn't confirmed yet)
+          // can be exported and used to correct the decode later.
+          await _createBodyLocationChecks(db);
+        }
       },
       onOpen: (db) async {
         await _repairOpenSchema(db);
       },
-      version: 23,
+      version: 24,
     );
   }
 
@@ -316,6 +324,7 @@ class LocalDb {
     await _ensureSessionSchema(db);
     await _ensureSyncStateSchema(db);
     await _createWorkoutSuggestions(db);
+    await _createBodyLocationChecks(db);
     await _createSleepOverride(db);
     await _createWorkoutRoute(db);
     await _ensureWorkoutRouteSpeed(db);
@@ -1605,6 +1614,51 @@ class LocalDb {
     );
   }
 
+  /// GET_BODY_LOCATION_AND_STATUS (0x54) raw-byte history. `confidence`/
+  /// `status` are unconfirmed-scale firmware bytes — APK ground-truth only
+  /// surfaced the command + field layout, not their exact semantics. Stored
+  /// RAW (never re-interpreted) specifically so real device captures can be
+  /// exported and the enum/scale corrected later if a raw byte doesn't match
+  /// GarmentDeviceLocation. Every check kept (not just latest) — a small,
+  /// rarely-written, user-triggered-only table.
+  static Future<void> _createBodyLocationChecks(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS body_location_checks (
+        ts INTEGER PRIMARY KEY,
+        revision INTEGER,
+        location_raw INTEGER,
+        confidence INTEGER,
+        status INTEGER
+      )
+    ''');
+  }
+
+  static Future<void> insertBodyLocationCheck({
+    required int ts,
+    required int revision,
+    required int locationRaw,
+    required int confidence,
+    required int status,
+  }) async {
+    final db = await instance;
+    await db.insert('body_location_checks', {
+      'ts': ts,
+      'revision': revision,
+      'location_raw': locationRaw,
+      'confidence': confidence,
+      'status': status,
+    }, conflictAlgorithm: ConflictAlgorithm.replace);
+  }
+
+  /// Full raw history (newest first) — for export/inspection while the
+  /// confidence/status byte semantics are still unconfirmed.
+  static Future<List<Map<String, dynamic>>> recentBodyLocationChecks({
+    int limit = 100,
+  }) async {
+    final db = await instance;
+    return db.query('body_location_checks', orderBy: 'ts DESC', limit: limit);
+  }
+
   /// Additive: add the `millivolts` column to an existing band_battery table.
   /// Guarded — the column already exists on fresh installs (see _createBandSignals)
   /// and ALTER … ADD COLUMN throws if it's already there.
@@ -2802,6 +2856,7 @@ class LocalDb {
       'wake_day_features',
       'live_coverage',
       'workout_route',
+      'body_location_checks',
     ];
 
     final missingTables = <String>[];

--- a/lib/data/models.dart
+++ b/lib/data/models.dart
@@ -169,6 +169,7 @@ class DeviceState {
   /// status are raw firmware bytes with no confirmed scale/enum yet (APK
   /// ground-truth only surfaced the command + field layout, not their exact
   /// semantics) — shown as-is, never re-interpreted into a fabricated label.
+  int? bodyLocationRevision;
   int? bodyLocationRaw;
   int? bodyLocationConfidence;
   int? bodyLocationStatus;

--- a/lib/data/models.dart
+++ b/lib/data/models.dart
@@ -163,5 +163,16 @@ class DeviceState {
   int? dataRangeOldest;
   int? dataRangeNewest;
 
+  /// Last GET_BODY_LOCATION_AND_STATUS (0x54) response, user-triggered only
+  /// (never sent automatically). Raw ints — the UI resolves [bodyLocationRaw]
+  /// via openstrap_protocol's GarmentDeviceLocation.fromValue. Confidence and
+  /// status are raw firmware bytes with no confirmed scale/enum yet (APK
+  /// ground-truth only surfaced the command + field layout, not their exact
+  /// semantics) — shown as-is, never re-interpreted into a fabricated label.
+  int? bodyLocationRaw;
+  int? bodyLocationConfidence;
+  int? bodyLocationStatus;
+  int? bodyLocationCheckedAt; // epoch sec of the last successful read
+
   DeviceState({this.connection = 'disconnected'});
 }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2011,6 +2011,42 @@ class AppState extends ChangeNotifier {
   /// [disableAlarm] (the DISABLE_ALARM opcode).
   Future<void> clearAlarm() => disableAlarm();
 
+  /// User-triggered wear-location check (GET_BODY_LOCATION_AND_STATUS = 0x54).
+  /// Deliberately not sent automatically on connect — see engine docs. Result
+  /// lands on `device.bodyLocation*` via the normal engine-state flow.
+  Future<void> checkBodyLocation() async {
+    if (!isConnected) throw Exception('Connect to your strap first');
+    await engine.getBodyLocationAndStatus();
+  }
+
+  /// Friendly label for the last wear-location check. Never fabricates: if we
+  /// haven't checked yet, says so plainly rather than guessing "Wrist" (the
+  /// only garment most users own, but not something we've actually verified).
+  String get bodyLocationLabel {
+    if (device.bodyLocationCheckedAt == null) return 'Not checked';
+    final loc = proto.GarmentDeviceLocation.fromValue(
+      device.bodyLocationRaw ?? -1,
+    );
+    switch (loc) {
+      case proto.GarmentDeviceLocation.wrist:
+        return 'Wrist';
+      case proto.GarmentDeviceLocation.bicep:
+        return 'Bicep';
+      case proto.GarmentDeviceLocation.calf:
+        return 'Calf';
+      case proto.GarmentDeviceLocation.sideTorso:
+        return 'Side torso';
+      case proto.GarmentDeviceLocation.glute:
+        return 'Glute';
+      case proto.GarmentDeviceLocation.ankle:
+        return 'Ankle';
+      default:
+        // unknown / notConclusive / unknownGarment / unmapped raw byte —
+        // the firmware itself couldn't confidently classify it.
+        return 'Not conclusive';
+    }
+  }
+
   /// Strap alarm-lifecycle events (56 set / 57–58 fired / 59 disabled). This is
   /// the authoritative confirmation the SET write actually took. The edge DOES see
   /// the protocol EventId names (strapDrivenAlarmSet == 56, …); the pure state

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -151,6 +151,7 @@ class AppState extends ChangeNotifier {
   int? _storedBatteryPct;
   bool? _storedBatteryCharging;
   bool? _storedBatteryWristOn;
+  int? _storedBodyLocationCheckedAt;
   bool initialized = false;
 
   /// True while the app is backgrounded. On iOS we KEEP the BLE connection alive in
@@ -1638,6 +1639,25 @@ class AppState extends ChangeNotifier {
         ),
       );
     }
+    // Persist every GET_BODY_LOCATION_AND_STATUS raw byte trail (not just on
+    // change — each check is its own user-triggered event, and confidence/
+    // status semantics aren't confirmed yet, so keeping the full history lets
+    // real device captures correct the decode later if it's wrong). Guarded
+    // on checkedAt so we don't re-insert the same response if _onEngineState
+    // fires again for an unrelated field change.
+    if (s.bodyLocationCheckedAt != null &&
+        s.bodyLocationCheckedAt != _storedBodyLocationCheckedAt) {
+      _storedBodyLocationCheckedAt = s.bodyLocationCheckedAt;
+      unawaited(
+        LocalDb.insertBodyLocationCheck(
+          ts: s.bodyLocationCheckedAt!,
+          revision: s.bodyLocationRevision ?? -1,
+          locationRaw: s.bodyLocationRaw ?? -1,
+          confidence: s.bodyLocationConfidence ?? -1,
+          status: s.bodyLocationStatus ?? -1,
+        ),
+      );
+    }
     // Heal a stale/garbled persisted serial: once the band reports a clean serial
     // (HELLO body, fixed offset), persist it so the disconnected display stops
     // showing any old "?*" junk left by a previous build.
@@ -2022,11 +2042,20 @@ class AppState extends ChangeNotifier {
   /// Friendly label for the last wear-location check. Never fabricates: if we
   /// haven't checked yet, says so plainly rather than guessing "Wrist" (the
   /// only garment most users own, but not something we've actually verified).
+  ///
+  /// IMPORTANT: does NOT collapse every non-wrist case into one bucket. Raw
+  /// byte 0 ("unknown"), 128 ("notConclusive"), 160 ("unknownGarment"), and a
+  /// byte that matches NONE of the reverse-engineered enum values are four
+  /// DIFFERENT situations — the last one specifically means our protocol
+  /// enum table may be incomplete (or something's off in parsing), which is
+  /// exactly the kind of gap this project's honesty rule says to surface,
+  /// not paper over with a single reassuring-sounding label.
   String get bodyLocationLabel {
     if (device.bodyLocationCheckedAt == null) return 'Not checked';
-    final loc = proto.GarmentDeviceLocation.fromValue(
-      device.bodyLocationRaw ?? -1,
-    );
+    final raw = device.bodyLocationRaw;
+    final loc = raw == null
+        ? null
+        : proto.GarmentDeviceLocation.fromValue(raw);
     switch (loc) {
       case proto.GarmentDeviceLocation.wrist:
         return 'Wrist';
@@ -2040,10 +2069,21 @@ class AppState extends ChangeNotifier {
         return 'Glute';
       case proto.GarmentDeviceLocation.ankle:
         return 'Ankle';
-      default:
-        // unknown / notConclusive / unknownGarment / unmapped raw byte —
-        // the firmware itself couldn't confidently classify it.
+      case proto.GarmentDeviceLocation.notConclusive:
+        // The band itself reports it couldn't confidently classify — a real,
+        // meaningful signal (e.g. too little recent motion data yet).
         return 'Not conclusive';
+      case proto.GarmentDeviceLocation.unknownGarment:
+        // Different from notConclusive: it DID detect a garment, just not one
+        // in the known set.
+        return 'Unrecognized garment';
+      case proto.GarmentDeviceLocation.unknown:
+        return 'Unknown';
+      case null:
+        // Raw byte matched NOTHING in GarmentDeviceLocation — surface the
+        // actual value rather than hiding it, so this can be reported/added
+        // to the enum instead of silently misreported as "not conclusive".
+        return 'Unrecognized (raw: $raw)';
     }
   }
 

--- a/lib/ui/profile/profile_screen.dart
+++ b/lib/ui/profile/profile_screen.dart
@@ -471,9 +471,14 @@ class ProfileScreen extends StatelessWidget {
           : '${d.batteryPct!.round()}%${d.charging == true ? ' ⚡' : ''}',
       wrist: d.wristOn == null ? '—' : (d.wristOn! ? 'On wrist' : 'Off wrist'),
       serial: d.serial ?? app.paired?.serial ?? '—',
+      wearLocation: app.bodyLocationLabel,
       // Manual pull: anything the strap flashed that we don't hold yet, over
       // the CURRENT connection (no reconnect). Only offered while connected.
       onSyncNow: conn == 'connected' ? () => app.forceResync() : null,
+      // On-demand only (GET_BODY_LOCATION_AND_STATUS isn't sent automatically
+      // on connect — see AppState.checkBodyLocation).
+      onCheckWearLocation:
+          conn == 'connected' ? () => app.checkBodyLocation() : null,
       onTap: () => _openDeviceSheet(context, app),
     );
   }
@@ -686,8 +691,10 @@ class DeviceTile extends StatefulWidget {
   final String battery;
   final String wrist;
   final String serial;
+  final String wearLocation;
   final VoidCallback? onTap;
   final Future<void> Function()? onSyncNow;
+  final Future<void> Function()? onCheckWearLocation;
 
   const DeviceTile({
     super.key,
@@ -697,8 +704,10 @@ class DeviceTile extends StatefulWidget {
     required this.battery,
     required this.wrist,
     required this.serial,
+    required this.wearLocation,
     this.onTap,
     this.onSyncNow,
+    this.onCheckWearLocation,
   });
 
   @override
@@ -707,6 +716,7 @@ class DeviceTile extends StatefulWidget {
 
 class _DeviceTileState extends State<DeviceTile> {
   bool _syncing = false;
+  bool _checkingWearLocation = false;
 
   Future<void> _sync() async {
     final run = widget.onSyncNow;
@@ -716,6 +726,17 @@ class _DeviceTileState extends State<DeviceTile> {
       await run();
     } finally {
       if (mounted) setState(() => _syncing = false);
+    }
+  }
+
+  Future<void> _checkWearLocation() async {
+    final run = widget.onCheckWearLocation;
+    if (run == null || _checkingWearLocation) return;
+    setState(() => _checkingWearLocation = true);
+    try {
+      await run();
+    } finally {
+      if (mounted) setState(() => _checkingWearLocation = false);
     }
   }
 
@@ -807,6 +828,54 @@ class _DeviceTileState extends State<DeviceTile> {
                           ],
                           Text(
                             _syncing ? 'Syncing…' : 'Sync now',
+                            style: AppText.caption.copyWith(color: tone.fg),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: Sp.x4),
+            Row(
+              children: [
+                Expanded(
+                  child: _fact(
+                    OsIcon.wear,
+                    'Wear location',
+                    widget.wearLocation,
+                    tone,
+                  ),
+                ),
+                if (widget.onCheckWearLocation != null)
+                  Pressable(
+                    pressedScale: 0.95,
+                    borderRadius: BorderRadius.circular(R.pill),
+                    onTap: _checkingWearLocation ? null : _checkWearLocation,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: Sp.x3 + 2, vertical: 7),
+                      decoration: BoxDecoration(
+                        color: AppColors.nightAlt,
+                        borderRadius: BorderRadius.circular(R.pill),
+                        border: Border.all(color: Colors.white24),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (_checkingWearLocation) ...[
+                            SizedBox(
+                              width: 12,
+                              height: 12,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 1.6,
+                                color: tone.fgMuted,
+                              ),
+                            ),
+                            const SizedBox(width: Sp.x2),
+                          ],
+                          Text(
+                            _checkingWearLocation ? 'Checking…' : 'Check',
                             style: AppText.caption.copyWith(color: tone.fg),
                           ),
                         ],

--- a/test/db_integrity_test.dart
+++ b/test/db_integrity_test.dart
@@ -62,6 +62,46 @@ void main() {
     expect(health['ok'], isTrue, reason: '$health');
   });
 
+  group('body_location_checks (GET_BODY_LOCATION_AND_STATUS raw history)', () {
+    test('persists a check and reads it back verbatim', () async {
+      await LocalDb.insertBodyLocationCheck(
+        ts: 1790000300,
+        revision: 1,
+        locationRaw: 1, // wrist
+        confidence: 200,
+        status: 3,
+      );
+      final rows = await LocalDb.recentBodyLocationChecks(limit: 10);
+      final row = rows.firstWhere((r) => r['ts'] == 1790000300);
+      expect(row['revision'], 1);
+      expect(row['location_raw'], 1);
+      expect(row['confidence'], 200);
+      expect(row['status'], 3);
+    });
+
+    test('keeps a full history, not just the latest', () async {
+      await LocalDb.insertBodyLocationCheck(
+        ts: 1790000400,
+        revision: 1,
+        locationRaw: 128, // notConclusive
+        confidence: 10,
+        status: 0,
+      );
+      await LocalDb.insertBodyLocationCheck(
+        ts: 1790000401,
+        revision: 1,
+        locationRaw: 200, // an unmapped byte — deliberately unrecognized
+        confidence: 5,
+        status: 0,
+      );
+      final rows = await LocalDb.recentBodyLocationChecks(limit: 10);
+      final byTs = {for (final r in rows) r['ts']: r};
+      // Both checks survive independently — never collapsed into "the latest".
+      expect(byTs[1790000400]?['location_raw'], 128);
+      expect(byTs[1790000401]?['location_raw'], 200);
+    });
+  });
+
   test('rec_ts collision leaves no orphaned decoded_rr beats', () async {
     const ts = 1780000000;
     // Pre-reboot record: high counter, THREE beats.

--- a/test/flow_screens_redesign_test.dart
+++ b/test/flow_screens_redesign_test.dart
@@ -214,6 +214,7 @@ void main() {
   for (final (label, palette) in [('light', kLightPalette), ('dark', kDarkPalette)]) {
     testWidgets('device tile renders + sync action runs ($label)', (t) async {
       var synced = 0;
+      var checked = 0;
       await t.pumpWidget(_host(
         DeviceTile(
           name: 'My Strap',
@@ -222,8 +223,10 @@ void main() {
           battery: '82%',
           wrist: 'On wrist',
           serial: '4A0XXXX',
+          wearLocation: 'Not checked',
           onTap: () {},
           onSyncNow: () async => synced++,
+          onCheckWearLocation: () async => checked++,
         ),
         palette: palette,
       ));
@@ -234,6 +237,7 @@ void main() {
       expect(find.text('82%'), findsOneWidget);
       expect(find.text('On wrist'), findsOneWidget);
       expect(find.text('4A0XXXX'), findsOneWidget);
+      expect(find.text('Not checked'), findsOneWidget);
       // No sync-anxiety copy on the tile.
       expect(find.textContaining('stored to'), findsNothing);
       expect(find.textContaining('every ~15'), findsNothing);
@@ -241,10 +245,14 @@ void main() {
       await t.tap(find.text('Sync now'));
       await t.pump(const Duration(milliseconds: 300));
       expect(synced, 1);
+
+      await t.tap(find.text('Check'));
+      await t.pump(const Duration(milliseconds: 300));
+      expect(checked, 1);
     });
   }
 
-  testWidgets('device tile hides sync action when disconnected', (t) async {
+  testWidgets('device tile hides sync + wear-location check actions when disconnected', (t) async {
     await t.pumpWidget(_host(
       const DeviceTile(
         name: 'My Strap',
@@ -253,10 +261,12 @@ void main() {
         battery: '—',
         wrist: '—',
         serial: '4A0XXXX',
+        wearLocation: 'Not checked',
       ),
     ));
     await _pumpTwice(t);
     expect(find.text('Sync now'), findsNothing);
+    expect(find.text('Check'), findsNothing);
     expect(find.text('Disconnected'), findsOneWidget);
   });
 


### PR DESCRIPTION
## Summary
WHOOP garments beyond the wrist strap (bicep band, apparel pocket) mean the band firmware itself classifies which body location it's currently docked in. The protocol layer already had the command builder (`cmdGetBodyLocationAndStatus`, opcode `0x54`, **non-dangerous**) and response parser (`BodyLocationStatusResponse` / `GarmentDeviceLocation` enum) built from APK ground-truth — edge never actually sent the command or surfaced the result anywhere. This wires it end-to-end.

## Changes
- `ble_engine.dart`: `BleEngine.getBodyLocationAndStatus()` sends the command; `_absorbState` handles the `body_location_status` response field into new `DeviceState` fields.
- `models.dart`: `DeviceState.bodyLocationRaw/Confidence/Status/CheckedAt` — raw ints only. `confidence`/`status` are unconfirmed-scale firmware bytes (APK ground-truth only surfaced the command + field layout, not their exact semantics) — never re-interpreted past what's actually confirmed.
- `app_state.dart`: `AppState.checkBodyLocation()` — **user-triggered only**, deliberately NOT sent automatically on connect (keeps the sync-critical handshake path untouched) — plus a `bodyLocationLabel` getter resolving the raw byte into a friendly string, defaulting honestly to "Not checked" / "Not conclusive" rather than assuming "Wrist" just because that's what most users own.
- `profile_screen.dart`: new "Wear location" fact + "Check" action on the strap details tile, right next to the existing Battery/Wrist/Serial facts — mirrors the existing "Sync now" pill button pattern exactly.

## Test plan
- [x] `flutter test --concurrency=1` — 438/445, same 7 pre-existing unrelated failures as clean main
- [x] Updated `DeviceTile` tests: fact renders, "Check" tap wiring, action hidden while disconnected