### PR TITLE
fix: hypnogram/StageBars render regressions (RepaintBoundary + Row overflow)

### DIFF
--- a/lib/ui/design/hypnogram.dart
+++ b/lib/ui/design/hypnogram.dart
@@ -219,32 +219,49 @@ class StageBars extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final entries = <(SleepStage, int)>[
-      if ((awakeMin ?? 0) > 0) (SleepStage.awake, awakeMin!),
-      if ((remMin ?? 0) > 0) (SleepStage.rem, remMin!),
-      if ((lightMin ?? 0) > 0) (SleepStage.light, lightMin!),
-      if ((deepMin ?? 0) > 0) (SleepStage.deep, deepMin!),
-    ];
-    if (entries.isEmpty) return const SizedBox.shrink();
-    final total = entries.fold<int>(0, (a, e) => a + e.$2);
+    // A stage is INCLUDED whenever the caller passed a value at all — even an
+    // explicit 0 — and OMITTED only when the caller never supplied it
+    // (stays null). This matters: a genuinely-absent stage (e.g. no Deep
+    // sleep detected) must render an honest labelled row saying so, never an
+    // invisible gap (see sleep_detail_screen.dart's _stageBreakdown doc
+    // comment) — but a caller that never tracks a given stage at all (e.g.
+    // sleep_periods_screen.dart's per-period breakdown never passes
+    // awakeMin) should still see that stage cleanly omitted, not a spurious
+    // "none detected" row for something it never asked about.
+    final mins = <SleepStage, int?>{
+      SleepStage.awake: awakeMin,
+      SleepStage.rem: remMin,
+      SleepStage.light: lightMin,
+      SleepStage.deep: deepMin,
+    };
+    if (mins.values.every((m) => m == null)) return const SizedBox.shrink();
+    final total = mins.values.fold<int>(0, (a, m) => a + (m ?? 0));
 
     String hm(int m) =>
         m >= 60 ? '${m ~/ 60}h ${(m % 60).toString().padLeft(2, '0')}m' : '${m}m';
 
+    final stages = SleepStage.values;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       mainAxisSize: MainAxisSize.min,
       children: [
-        for (var i = 0; i < entries.length; i++) ...[
-          if (i > 0) const SizedBox(height: Sp.x2),
-          _buildStageBar(entries[i].$1, entries[i].$2, total, hm),
-        ],
+        for (var i = 0; i < stages.length; i++)
+          if (mins[stages[i]] != null) ...[
+            if (i > 0) const SizedBox(height: Sp.x2),
+            _buildStageBar(stages[i], mins[stages[i]]!, total, hm),
+          ],
       ],
     );
   }
 
-  Widget _buildStageBar(SleepStage stage, int mins, int total, String Function(int) hm) {
-    final pct = (mins * 100 / total).round();
+  Widget _buildStageBar(
+    SleepStage stage,
+    int mins,
+    int total,
+    String Function(int) hm,
+  ) {
+    final absent = mins <= 0;
+    final pct = (!absent && total > 0) ? (mins * 100 / total).round() : 0;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       mainAxisSize: MainAxisSize.min,
@@ -256,7 +273,7 @@ class StageBars extends StatelessWidget {
               child: Text(
                 stageName(stage),
                 style: AppText.body.copyWith(
-                  color: stageColor(stage),
+                  color: absent ? AppColors.inkMuted : stageColor(stage),
                   fontWeight: FontWeight.w600,
                 ),
                 maxLines: 1,
@@ -266,7 +283,11 @@ class StageBars extends StatelessWidget {
             const SizedBox(width: Sp.x2),
             Flexible(
               child: Text(
-                '$pct% (${hm(mins)})',
+                absent
+                    ? (stage == SleepStage.deep
+                        ? 'none detected · low-confidence estimate'
+                        : 'none detected')
+                    : '$pct% (${hm(mins)})',
                 style: AppText.captionMuted,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
@@ -279,19 +300,23 @@ class StageBars extends StatelessWidget {
         ClipRRect(
           borderRadius: BorderRadius.circular(R.pill),
           child: SizedBox(
-            height: height, // <-- Used the height parameter here
-            child: Row(
-              children: [
-                Expanded(
-                  flex: pct.clamp(1, 100),
-                  child: Container(color: stageColor(stage)),
-                ),
-                Expanded(
-                  flex: (100 - pct).clamp(0, 100),
-                  child: Container(color: AppColors.divider.withValues(alpha: 0.1)),
-                ),
-              ],
-            ),
+            height: height,
+            child: absent
+                ? Container(color: AppColors.divider.withValues(alpha: 0.1))
+                : Row(
+                    children: [
+                      Expanded(
+                        flex: pct.clamp(1, 100),
+                        child: Container(color: stageColor(stage)),
+                      ),
+                      Expanded(
+                        flex: (100 - pct).clamp(0, 100),
+                        child: Container(
+                          color: AppColors.divider.withValues(alpha: 0.1),
+                        ),
+                      ),
+                    ],
+                  ),
           ),
         ),
       ],

--- a/lib/ui/design/hypnogram.dart
+++ b/lib/ui/design/hypnogram.dart
@@ -144,11 +144,13 @@ class Hypnogram extends StatelessWidget {
   Widget build(BuildContext context) {
     if (segments.isEmpty) return const SizedBox.shrink();
 
-    final plot = SizedBox(
-      height: height,
-      child: CustomPaint(
-        size: Size.infinite,
-        painter: _GanttPainter(segments),
+    final plot = RepaintBoundary(
+      child: SizedBox(
+        height: height,
+        child: CustomPaint(
+          size: Size.infinite,
+          painter: _GanttPainter(segments),
+        ),
       ),
     );
 
@@ -250,16 +252,26 @@ class StageBars extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Text(
-              stageName(stage),
-              style: AppText.body.copyWith(
-                color: stageColor(stage),
-                fontWeight: FontWeight.w600,
+            Flexible(
+              child: Text(
+                stageName(stage),
+                style: AppText.body.copyWith(
+                  color: stageColor(stage),
+                  fontWeight: FontWeight.w600,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
               ),
             ),
-            Text(
-              '$pct% (${hm(mins)})',
-              style: AppText.captionMuted,
+            const SizedBox(width: Sp.x2),
+            Flexible(
+              child: Text(
+                '$pct% (${hm(mins)})',
+                style: AppText.captionMuted,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.right,
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
Fixes ALL 5 real test failures that were showing up in every run regardless of feature branch (unrelated to whatever else was in flight). All trace back to real bugs in `lib/ui/design/hypnogram.dart`, not test-infra issues:

1. **`Hypnogram`'s CustomPaint lost its `RepaintBoundary`** in a refactor (`84e2672`, "replace custom hypnogram with fl_chart") and it was never restored through later rewrites back to a custom Gantt painter. Confirmed via git history — commit `1698705` (the original design) had it. Without it, `workout_sleep_redesign_test.dart`'s pixel-probe helper can never find a `RenderRepaintBoundary`, so it throws a null-check error on every run — this looked like 4 separate failures but is one root cause.
2. **`StageBars._buildStageBar`'s header `Row`** (stage name + "N% (Nh Nm)") had neither `Text` wrapped in `Expanded`/`Flexible`, so it overflows at narrow widths (the design gallery's "every component at phone width" test). Needed both sides flexible + ellipsis — the right-side text alone was still wide enough to overflow on its own after only fixing the label.
3. **`StageBars` silently omitted a genuinely-absent stage entirely** (an "invisible gap") instead of the honest labelled row `sleep_detail_screen.dart`'s own doc comment promises. Fixed by showing a row whenever the caller passes ANY value (including explicit `0`), omitting only when the caller never supplied the stage at all — preserves `sleep_periods_screen.dart`'s intentional omission of `awakeMin` while fixing the real "Deep: none detected" case.

## Test plan
- [x] `flutter test` — 443 total, only 2 pre-existing "failures" remain: untracked debug scratch files (`test/scratch_test.dart`, `test/db2_test.dart`) that don't even compile — not real code, unrelated to this PR
- [x] All 5 real failures this PR set out to fix are now green