### PR TITLE
chore: release v0.9.9+42

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openstrap_edge
 description: "OpenStrap — open-source WHOOP 4.0 companion. BLE drain → raw-first local store → cloud sync."
 publish_to: 'none'
-version: 0.9.8+41
+version: 0.9.9+42
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
## Summary
Release PR for #66 (hypnogram/StageBars render regressions — RepaintBoundary restored, Row overflow fixed, StageBars no longer renders an invisible gap for a genuinely-absent sleep stage).