### PR TITLE
chore: release v0.9.10+43

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openstrap_edge
 description: "OpenStrap — open-source WHOOP 4.0 companion. BLE drain → raw-first local store → cloud sync."
 publish_to: 'none'
-version: 0.9.9+42
+version: 0.9.10+43
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
## Summary
Release PR for #69 (GPS route noise floor + speed clamp, live-map layout harmony + zoom cap, pace sanity ceiling, in-app notifications feed removal).

## Test plan
- [x] flutter test --concurrency=1 — 452/454 (2 pre-existing untracked-scratch-file failures, not real code)