### PR TITLE
fix: Siri query staleness + add StartBreathingIntent action

### DIFF
--- a/ios/OpenStrapIntents.swift
+++ b/ios/OpenStrapIntents.swift
@@ -80,6 +80,29 @@ struct SleepIntent: AppIntent {
   }
 }
 
+// MARK: - Action intents (these actually DO something, not just answer)
+
+/// "Start breathing" — unlike the query intents above, this needs the live
+/// Flutter engine + BLE stack (a guided session reads live RR from the band),
+/// so it must open the app rather than answer standalone. Writes the target
+/// route into the App Group; the Dart side picks it up via
+/// WidgetService.consumePendingRoute() on launch AND on every foreground
+/// resume (see AppState.checkPendingSiriRoute — openAppWhenRun doesn't
+/// guarantee a fresh launch, it may just foreground an already-running
+/// process, so both call sites matter).
+@available(iOS 16.0, *)
+struct StartBreathingIntent: AppIntent {
+  static var title: LocalizedStringResource = "Start Breathing Session"
+  static var description = IntentDescription(
+    "Start a guided resonance-breathing session in OpenStrap.")
+  static var openAppWhenRun = true
+
+  func perform() async throws -> some IntentResult & ProvidesDialog {
+    OpenStrapShared.defaults()?.set("/breathing", forKey: "pending_route")
+    return .result(dialog: "Starting your breathing session.")
+  }
+}
+
 // MARK: - Shortcuts provider (zero-setup Siri phrases)
 
 @available(iOS 16.0, *)
@@ -112,5 +135,16 @@ struct OpenStrapShortcuts: AppShortcutsProvider {
       ],
       shortTitle: "Sleep",
       systemImageName: "moon.zzz")
+
+    AppShortcut(
+      intent: StartBreathingIntent(),
+      phrases: [
+        "Start breathing in \(.applicationName)",
+        "\(.applicationName) breathe",
+        "Start a breathing session in \(.applicationName)",
+        "Breathe with \(.applicationName)",
+      ],
+      shortTitle: "Breathe",
+      systemImageName: "wind")
   }
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
@@ -23,6 +25,7 @@ import 'ui/workouts/workouts_screen.dart';
 import 'ui/activity/live_session_screen.dart';
 import 'ui/ai/ai_breakdown_screen.dart';
 import 'ui/journal/journal_compose_screen.dart';
+import 'ui/stress/calm_breathing_screen.dart';
 
 class OpenStrapApp extends StatefulWidget {
   const OpenStrapApp({super.key});
@@ -66,6 +69,10 @@ class _OpenStrapAppState extends State<OpenStrapApp> with WidgetsBindingObserver
       app.maybeFinishFromLiveActivity();
       app.refreshAppStatus(); // re-check OTA + admin banner on every foreground
       app.runCadenceChecks(); // evening wind-down / weekly recap nudges (best-effort)
+      // A Siri "start breathing" App Intent may have just foregrounded an
+      // already-running process (openAppWhenRun doesn't guarantee a fresh
+      // launch) — the constructor-time check alone would miss that case.
+      unawaited(app.checkPendingSiriRoute());
       if (app.isPaired) app.openSession();
     } else if (state == AppLifecycleState.paused) {
       // Backgrounded: hand the band to the iOS restore path so it can wake-and-drain
@@ -176,6 +183,10 @@ class _ShellState extends State<_Shell> {
       kRouteAiEvening =>
         const AiBreakdownScreen(period: BriefingPeriod.evening),
       kRouteJournalCompose => const JournalComposeScreen(),
+      // Siri/Shortcuts "start breathing" App Intent — see StartBreathingIntent
+      // in OpenStrapIntents.swift, which writes this route into the App Group
+      // for WidgetService.consumePendingRoute() to pick up on launch/resume.
+      kRouteBreathing => const CalmBreathingScreen(autoStart: true),
       _ => null,
     };
     if (screen == null) return;

--- a/lib/notify/tap_router.dart
+++ b/lib/notify/tap_router.dart
@@ -9,6 +9,7 @@
 const String kRouteAiMorning = '/ai/morning';
 const String kRouteAiEvening = '/ai/evening';
 const String kRouteJournalCompose = '/journal/compose';
+const String kRouteBreathing = '/breathing';
 
 class TapTarget {
   /// Shell tab index to land on (always valid; unknown → 0 = Today).
@@ -33,6 +34,7 @@ const Set<String> _screenRoutes = {
   kRouteAiMorning,
   kRouteAiEvening,
   kRouteJournalCompose,
+  kRouteBreathing,
 };
 
 TapTarget resolveTapRoute(String route) {

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -655,6 +655,19 @@ class AppState extends ChangeNotifier {
     // Notification taps → request a tab switch (the shell listens to navRequest).
     _tapSub = NotificationService.instance.taps.listen(_handleTapRoute);
     unawaited(NotificationService.instance.consumeLaunchRoute());
+    unawaited(checkPendingSiriRoute());
+  }
+
+  /// A Siri/Shortcuts App Intent (e.g. "start breathing") may have set a
+  /// pending route in the App Group before launching/foregrounding the app —
+  /// see WidgetService.consumePendingRoute + StartBreathingIntent in
+  /// OpenStrapIntents.swift. Checked on cold launch (constructor, above) AND
+  /// on every foreground resume (app.dart's didChangeAppLifecycleState),
+  /// since `openAppWhenRun = true` may just foreground an already-running
+  /// process rather than trigger a fresh launch.
+  Future<void> checkPendingSiriRoute() async {
+    final route = await WidgetService.consumePendingRoute();
+    if (route != null) _handleTapRoute(route);
   }
 
   @override

--- a/lib/sync/ios_bg_task.dart
+++ b/lib/sync/ios_bg_task.dart
@@ -33,6 +33,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../compute/derivation_engine.dart';
 import '../compute/profile.dart';
 import '../ble/ios_ble_restore.dart';
+import '../data/local_repository_impl.dart';
+import '../models/payloads.dart';
+import '../widget/widget_service.dart';
 import 'background_sync.dart';
 import 'headless_gate.dart';
 
@@ -93,6 +96,7 @@ class IosBgTask {
             // baseline-dependent scalars on recent finalized days if the
             // rolling baseline moved. Cheap no-op when unchanged.
             await engine.rescanRecent(profile);
+            await _refreshWidgetSnapshot(profile);
           } catch (e) {
             debugPrint('[ios-bgtask] heavy derive skipped: $e');
           }
@@ -104,6 +108,7 @@ class IosBgTask {
             final engine = DerivationEngine(
                 log: (l) => debugPrint('[ios-bgrefresh-derive] $l'));
             await engine.run(profile, heavy: false);
+            await _refreshWidgetSnapshot(profile);
           } catch (e) {
             debugPrint('[ios-bgrefresh] light derive skipped: $e');
           }
@@ -129,6 +134,26 @@ class IosBgTask {
       return Profile.fromMap((jsonDecode(raw) as Map).cast<String, dynamic>());
     } catch (_) {
       return const Profile();
+    }
+  }
+
+  /// Push a fresh Today snapshot to the App Group after a headless derive so
+  /// the home/lock-screen widget AND the Siri/Shortcuts query intents
+  /// (RecoveryIntent/StrainIntent/SleepIntent — see OpenStrapIntents.swift,
+  /// which read this same App Group) don't go stale just because the user
+  /// hasn't opened the Today screen. Previously WidgetService.push() was only
+  /// ever called from today_screen.dart's fetch() — a real gap: "ask Siri
+  /// without opening the app" is the whole point of a Siri Shortcut, so any
+  /// answer would silently reflect however-stale the last Today-screen visit
+  /// was (or "I don't have today's numbers yet" if that never happened at
+  /// all). Best-effort — never throws into the caller.
+  static Future<void> _refreshWidgetSnapshot(Profile profile) async {
+    try {
+      final repo = LocalRepositoryImpl(getProfileMap: () => profile.toMap());
+      final today = await repo.getToday();
+      await WidgetService.push(TodayData.fromJson(today));
+    } catch (e) {
+      debugPrint('[ios-bgtask] widget snapshot refresh skipped: $e');
     }
   }
 }

--- a/lib/ui/stress/calm_breathing_screen.dart
+++ b/lib/ui/stress/calm_breathing_screen.dart
@@ -18,11 +18,25 @@ import '../../state/app_state.dart';
 import '../design/design.dart';
 
 class CalmBreathingScreen extends StatelessWidget {
-  const CalmBreathingScreen({super.key});
+  /// Auto-begin the session the moment this screen mounts — used when opened
+  /// via the "start breathing" Siri/Shortcuts App Intent, where the spoken
+  /// command already IS the "start" action. The normal in-app entry point
+  /// (Stress screen's own button) leaves this false and shows the Ready state.
+  final bool autoStart;
+
+  const CalmBreathingScreen({super.key, this.autoStart = false});
 
   @override
   Widget build(BuildContext context) {
     final app = context.watch<AppState>();
+    if (autoStart && !app.breathingActive && app.isConnected) {
+      // Guarded by breathingActive so this only ever fires once per mount —
+      // startBreathingSession() flips breathingActive true and notifies,
+      // which rebuilds this widget and short-circuits the guard.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!app.breathingActive) app.startBreathingSession();
+      });
+    }
     return CalmBreathingView(
       connected: app.isConnected,
       active: app.breathingActive,

--- a/lib/widget/widget_service.dart
+++ b/lib/widget/widget_service.dart
@@ -173,6 +173,27 @@ class WidgetService {
     return false;
   }
 
+  /// Non-null once (and clears) if a Siri/Shortcuts App Intent asked to open a
+  /// specific in-app screen (e.g. StartBreathingIntent sets `pending_route` =
+  /// '/breathing' in the App Group before launching the app). Same
+  /// App-Group-flag pattern as [consumeEndSessionFlag]. Feed the result
+  /// through the normal tap-route pipeline (AppState._handleTapRoute /
+  /// tap_router.dart) — never invent a separate navigation path.
+  static Future<String?> consumePendingRoute() async {
+    try {
+      await init();
+      final v = await HomeWidget.getWidgetData<String>(
+        'pending_route',
+        defaultValue: '',
+      );
+      if (v != null && v.isNotEmpty) {
+        await HomeWidget.saveWidgetData<String>('pending_route', '');
+        return v;
+      }
+    } catch (_) {}
+    return null;
+  }
+
   static String _coachLine(CoachData? c) {
     if (c == null) return '';
     if (c.plan.isNotEmpty) return c.plan.first.title;

--- a/test/tap_router_test.dart
+++ b/test/tap_router_test.dart
@@ -1,0 +1,32 @@
+// tap_router.dart — pure route resolution. Regression coverage for the new
+// kRouteBreathing entry (Siri/Shortcuts "start breathing" App Intent).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/notify/tap_router.dart';
+
+void main() {
+  test('tab routes land on their index with no sub-screen', () {
+    expect(resolveTapRoute('/today').tab, 0);
+    expect(resolveTapRoute('/today').screen, isNull);
+    expect(resolveTapRoute('/sleep').tab, 1);
+    expect(resolveTapRoute('/workouts').tab, 4);
+  });
+
+  test('kRouteBreathing resolves to Today tab + the breathing sub-screen', () {
+    final t = resolveTapRoute(kRouteBreathing);
+    expect(t.tab, 0);
+    expect(t.screen, kRouteBreathing);
+  });
+
+  test('other sub-screen routes still resolve correctly', () {
+    expect(resolveTapRoute(kRouteAiMorning).screen, kRouteAiMorning);
+    expect(resolveTapRoute(kRouteAiEvening).screen, kRouteAiEvening);
+    expect(resolveTapRoute(kRouteJournalCompose).screen, kRouteJournalCompose);
+  });
+
+  test('an unknown/stale route falls back to Today, never crashes', () {
+    final t = resolveTapRoute('/recap');
+    expect(t.tab, 0);
+    expect(t.screen, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
Two things: (1) root-cause fix for "Siri fails a lot in early testing", (2) the first real Siri **action** intent (not just query), tying into the just-shipped cardiac-coherence feature.

## 1. Root cause of Siri staleness/failure
`OpenStrapIntents.swift`'s `RecoveryIntent`/`StrainIntent`/`SleepIntent` read `readiness`/`strain`/`hrv`/`sleep_min`/`rhr` from the App Group. **The only place that ever wrote those keys was `today_screen.dart`'s `fetch()`** — i.e. only when the user had recently opened the Today screen in the foreground app. "Ask Siri instead of opening the app" is the entire point of a Siri Shortcut, so any query made without a recent Today-screen visit answered from stale data (or hit the generic "I don't have today's numbers yet" fallback) — reading exactly like "Siri is broken."

**Fix**: `ios_bg_task.dart` now pushes a fresh Today snapshot after every headless derive pass (both the heavy BGProcessingTask and light BGAppRefreshTask profiles), via a standalone `LocalRepositoryImpl` (no Provider/BuildContext needed, same headless-safe construction this file already uses elsewhere). Best-effort, never throws into the caller.

## 2. New action intent: StartBreathingIntent
Unlike the query intents, starting a breathing session needs the live Flutter engine + BLE stack (real RR from the band), so `openAppWhenRun = true`. It writes a pending route into the App Group (mirrors the existing `end_session` Live-Activity-intent pattern), consumed on the Dart side via a new `WidgetService.consumePendingRoute()`, fed through the **same** tap-route deep-link pipeline notifications already use (`tap_router.dart`'s new `kRouteBreathing` → `CalmBreathingScreen(autoStart: true)`). Checked at cold launch (`AppState`'s constructor) **and** on every foreground resume (`app.dart`), since `openAppWhenRun` may just foreground an already-running process rather than a fresh launch.

New phrases: "Start breathing in OpenStrap", "OpenStrap breathe", "Start a breathing session in OpenStrap", "Breathe with OpenStrap".

## Test plan
- [x] `dart analyze` on all touched files — clean (2 pre-existing unrelated warnings)
- [x] `flutter test --concurrency=1` — 454/456 real passes (450 + 4 new `tap_router_test.dart` cases), same 2 pre-existing scratch-file failures as clean main (not real code)
- [x] `flutter build ios --debug --no-codesign` — succeeds, new Swift intent compiles cleanly
- [ ] **Not verified**: actual on-device Siri recognition latency/reliability for the new phrase — this is real OS-side behavior outside static verification, needs a real-device test