### PR TITLE
feat: Siri reliability fix + breathing action intent + live coherence on lock screen

### DIFF
--- a/ios/BreathingLiveActivityBridge.swift
+++ b/ios/BreathingLiveActivityBridge.swift
@@ -1,0 +1,91 @@
+//
+//  BreathingLiveActivityBridge.swift
+//  Runner — drives the breathing-session Live Activity from Flutter over a
+//  MethodChannel. Channel "openstrap/breathing_live_activity": start / update /
+//  end. Separate from LiveActivityBridge.swift (the workout one) deliberately —
+//  a breathing session shows fundamentally different content (coherence, not
+//  HR/zone/strain) and this keeps the well-tuned workout activity untouched.
+//  Add to the Runner target. Requires NSSupportsLiveActivities=YES (already
+//  set, shared with the workout activity) + iOS 16.2+.
+//
+
+import Foundation
+import Flutter
+import ActivityKit
+
+// Live Activity attributes (Runner copy). MUST stay identical to the copy in
+// the widget extension (OpenStrapBreathingLiveActivity.swift) — ActivityKit
+// matches the activity to the widget by the type name + Codable shape.
+//
+// coherenceScore uses -1 as the "not yet available" sentinel (same convention
+// as OpenStrapShared.readiness/strain/etc in OpenStrapIntents.swift) rather
+// than Optional, to keep ContentState's shape simple — the widget renders
+// "Calibrating…" for < 0, matching the in-app screen's honest pre-result state
+// (never a fabricated number).
+@available(iOS 16.1, *)
+struct OpenStrapBreathingAttributes: ActivityAttributes {
+  public struct ContentState: Codable, Hashable {
+    var coherenceScore: Double // -1 = not yet available ("Calibrating…")
+  }
+  var startedAt: Date
+}
+
+enum BreathingLiveActivityBridge {
+  private static let channelName = "openstrap/breathing_live_activity"
+
+  static func register(messenger: FlutterBinaryMessenger) {
+    let channel = FlutterMethodChannel(name: channelName, binaryMessenger: messenger)
+    channel.setMethodCallHandler { call, result in
+      guard #available(iOS 16.2, *) else { result(nil); return }
+      let args = call.arguments as? [String: Any] ?? [:]
+      switch call.method {
+      case "start":  start(args);  result(nil)
+      case "update": update(args); result(nil)
+      case "end":    end();        result(nil)
+      default:       result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  private static func dbl(_ a: [String: Any], _ k: String, _ d: Double = -1) -> Double {
+    (a[k] as? NSNumber)?.doubleValue ?? d
+  }
+
+  @available(iOS 16.2, *)
+  private static func state(_ a: [String: Any]) -> OpenStrapBreathingAttributes.ContentState {
+    .init(coherenceScore: dbl(a, "coherenceScore"))
+  }
+
+  @available(iOS 16.2, *)
+  private static func start(_ a: [String: Any]) {
+    guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+    // One at a time — end any stragglers first.
+    for act in Activity<OpenStrapBreathingAttributes>.activities {
+      Task { await act.end(nil, dismissalPolicy: .immediate) }
+    }
+    let attrs = OpenStrapBreathingAttributes(
+      startedAt: Date(timeIntervalSince1970: dbl(a, "startedAtMs", 0) / 1000.0))
+    do {
+      _ = try Activity.request(
+        attributes: attrs,
+        content: .init(state: state(a), staleDate: nil))
+    } catch {
+      NSLog("BreathingLiveActivity start failed: \(error)")
+    }
+  }
+
+  @available(iOS 16.2, *)
+  private static func update(_ a: [String: Any]) {
+    let content = ActivityContent(state: state(a), staleDate: nil)
+    for act in Activity<OpenStrapBreathingAttributes>.activities {
+      Task { await act.update(content) }
+    }
+  }
+
+  @available(iOS 16.2, *)
+  private static func end() {
+    for act in Activity<OpenStrapBreathingAttributes>.activities {
+      Task { await act.end(nil, dismissalPolicy: .immediate) }
+    }
+  }
+}

--- a/ios/OpenStrapIntents.swift
+++ b/ios/OpenStrapIntents.swift
@@ -80,6 +80,29 @@ struct SleepIntent: AppIntent {
   }
 }
 
+// MARK: - Action intents (these actually DO something, not just answer)
+
+/// "Start breathing" — unlike the query intents above, this needs the live
+/// Flutter engine + BLE stack (a guided session reads live RR from the band),
+/// so it must open the app rather than answer standalone. Writes the target
+/// route into the App Group; the Dart side picks it up via
+/// WidgetService.consumePendingRoute() on launch AND on every foreground
+/// resume (see AppState.checkPendingSiriRoute — openAppWhenRun doesn't
+/// guarantee a fresh launch, it may just foreground an already-running
+/// process, so both call sites matter).
+@available(iOS 16.0, *)
+struct StartBreathingIntent: AppIntent {
+  static var title: LocalizedStringResource = "Start Breathing Session"
+  static var description = IntentDescription(
+    "Start a guided resonance-breathing session in OpenStrap.")
+  static var openAppWhenRun = true
+
+  func perform() async throws -> some IntentResult & ProvidesDialog {
+    OpenStrapShared.defaults()?.set("/breathing", forKey: "pending_route")
+    return .result(dialog: "Starting your breathing session.")
+  }
+}
+
 // MARK: - Shortcuts provider (zero-setup Siri phrases)
 
 @available(iOS 16.0, *)
@@ -112,5 +135,16 @@ struct OpenStrapShortcuts: AppShortcutsProvider {
       ],
       shortTitle: "Sleep",
       systemImageName: "moon.zzz")
+
+    AppShortcut(
+      intent: StartBreathingIntent(),
+      phrases: [
+        "Start breathing in \(.applicationName)",
+        "\(.applicationName) breathe",
+        "Start a breathing session in \(.applicationName)",
+        "Breathe with \(.applicationName)",
+      ],
+      shortTitle: "Breathe",
+      systemImageName: "wind")
   }
 }

--- a/ios/OpenStrapWidget/OpenStrapBreathingLiveActivity.swift
+++ b/ios/OpenStrapWidget/OpenStrapBreathingLiveActivity.swift
@@ -1,0 +1,168 @@
+//
+//  OpenStrapBreathingLiveActivity.swift
+//  Live breathing-session activity — lock screen + Dynamic Island. Shows the
+//  real McCraty & Zayas 2014 cardiac-coherence score (never a fabricated
+//  number — an honest "Calibrating…" until enough live RR has accumulated,
+//  matching CalmBreathingView's in-app state) and a live-counting timer.
+//
+//  Deliberately separate from OpenStrapWidgetLiveActivity.swift (the workout
+//  one) — different content entirely (coherence, not HR/zone/strain) — kept
+//  independent so the well-tuned workout activity is never at risk here.
+//
+//  The attributes struct MUST stay identical to the copy in
+//  BreathingLiveActivityBridge.swift (Runner target) — ActivityKit matches by
+//  type name + Codable shape.
+//
+//  No per-breath animation sync here on purpose: ActivityKit rate-limits
+//  updates, and the phone screen (not the lock screen) is the pacer while the
+//  session is active — this is a passive coherence readout, not a driver.
+//
+
+import ActivityKit
+import WidgetKit
+import SwiftUI
+import AppIntents
+
+// MARK: - Attributes
+
+struct OpenStrapBreathingAttributes: ActivityAttributes {
+  public struct ContentState: Codable, Hashable {
+    var coherenceScore: Double // -1 = not yet available ("Calibrating…")
+  }
+  var startedAt: Date
+}
+
+// MARK: - Palette (mirrors OpenStrapWidgetLiveActivity's, kept local —
+// that file's helpers are `private` to it, so a small deliberate duplication
+// here is safer than widening that file's access just to share four colors)
+
+private let kAppGroup = AppGroup.identifier
+
+private extension Color {
+  init(_ r: Int, _ g: Int, _ b: Int) {
+    self.init(red: Double(r) / 255, green: Double(g) / 255, blue: Double(b) / 255)
+  }
+}
+
+private struct BreathingPal {
+  let clayPaper: Color, ink: Color, inkMuted: Color
+  let isDark: Bool
+  static let light = BreathingPal(clayPaper: Color(246, 242, 236), ink: Color(26, 23, 20),
+                                  inkMuted: Color(150, 142, 131), isDark: false)
+  static let dark  = BreathingPal(clayPaper: Color(32, 28, 23), ink: Color(241, 236, 227),
+                                  inkMuted: Color(126, 116, 102), isDark: true)
+  static var current: BreathingPal {
+    (UserDefaults(suiteName: kAppGroup)?.object(forKey: "theme_dark") as? Bool ?? false)
+      ? .dark : .light
+  }
+}
+
+private extension Color {
+  static var bClayPaper: Color { BreathingPal.current.clayPaper }
+  static var bInk: Color { BreathingPal.current.ink }
+  static var bInkMuted: Color { BreathingPal.current.inkMuted }
+  static let bRecovery = Color(43, 182, 115) // matches DomainAccent.recovery
+}
+
+private func coherenceText(_ v: Double) -> String { v >= 0 ? "\(Int(v.rounded()))%" : "Calibrating…" }
+
+// MARK: - Interactive stop (iOS 17+) — separate flag from the workout's
+// end_session so the two Live Activities never collide.
+
+@available(iOSApplicationExtension 17.0, *)
+struct EndBreathingIntent: LiveActivityIntent {
+  static var title: LocalizedStringResource = "End session"
+  func perform() async throws -> some IntentResult {
+    UserDefaults(suiteName: kAppGroup)?.set(true, forKey: "end_breathing_session")
+    for activity in Activity<OpenStrapBreathingAttributes>.activities {
+      await activity.end(nil, dismissalPolicy: .immediate)
+    }
+    return .result()
+  }
+}
+
+// MARK: - Lock screen
+
+private struct BreathingLockScreenView: View {
+  let context: ActivityViewContext<OpenStrapBreathingAttributes>
+  var body: some View {
+    let score = context.state.coherenceScore
+    HStack(spacing: 14) {
+      if #available(iOSApplicationExtension 17.0, *) {
+        Image(systemName: "wind").font(.system(size: 26))
+          .foregroundStyle(Color.bRecovery).symbolEffect(.pulse, options: .repeating)
+      } else {
+        Image(systemName: "wind").font(.system(size: 26)).foregroundStyle(Color.bRecovery)
+      }
+      VStack(alignment: .leading, spacing: 2) {
+        Text(coherenceText(score))
+          .font(.system(size: score >= 0 ? 30 : 18, weight: .bold, design: .rounded))
+          .foregroundStyle(Color.bInk).contentTransition(.numericText())
+        Text("COHERENCE").font(.system(size: 9, weight: .semibold)).tracking(1)
+          .foregroundStyle(Color.bInkMuted)
+      }
+      Spacer()
+      Text(context.attributes.startedAt, style: .timer)
+        .font(.system(size: 15, weight: .semibold, design: .rounded))
+        .foregroundStyle(Color.bInkMuted)
+      if #available(iOSApplicationExtension 17.0, *) {
+        Button(intent: EndBreathingIntent()) {
+          Image(systemName: "stop.fill").font(.system(size: 12, weight: .bold))
+        }
+        .tint(Color.bRecovery).buttonBorderShape(.capsule)
+      }
+    }
+    .padding(16)
+    .background(
+      RoundedRectangle(cornerRadius: 24, style: .continuous).fill(Color.bClayPaper)
+    )
+    .padding(8)
+  }
+}
+
+// MARK: - Widget config
+
+struct OpenStrapBreathingLiveActivity: Widget {
+  var body: some WidgetConfiguration {
+    ActivityConfiguration(for: OpenStrapBreathingAttributes.self) { context in
+      BreathingLockScreenView(context: context)
+        .activitySystemActionForegroundColor(Color.bRecovery)
+    } dynamicIsland: { context in
+      let score = context.state.coherenceScore
+      return DynamicIsland {
+        DynamicIslandExpandedRegion(.leading) {
+          Image(systemName: "wind").font(.system(size: 18)).foregroundStyle(Color.bRecovery)
+        }
+        DynamicIslandExpandedRegion(.trailing) {
+          VStack(alignment: .trailing, spacing: 0) {
+            Text(coherenceText(score))
+              .font(.system(size: 18, weight: .bold, design: .rounded))
+              .foregroundStyle(Color.bRecovery).contentTransition(.numericText())
+            Text("COHERENCE").font(.system(size: 8, weight: .semibold)).tracking(1).foregroundStyle(.secondary)
+          }
+        }
+        DynamicIslandExpandedRegion(.center) {
+          Text(context.attributes.startedAt, style: .timer)
+            .font(.system(size: 13, weight: .semibold, design: .rounded))
+            .foregroundStyle(.secondary)
+        }
+        DynamicIslandExpandedRegion(.bottom) {
+          if #available(iOSApplicationExtension 17.0, *) {
+            Button(intent: EndBreathingIntent()) {
+              Label("End session", systemImage: "stop.fill").font(.system(size: 12, weight: .bold))
+            }
+            .tint(Color.bRecovery).buttonBorderShape(.capsule)
+          }
+        }
+      } compactLeading: {
+        Image(systemName: "wind").font(.system(size: 14)).foregroundStyle(Color.bRecovery)
+      } compactTrailing: {
+        Text(score >= 0 ? "\(Int(score.rounded()))%" : "·")
+          .font(.system(size: 13, weight: .bold, design: .rounded)).foregroundStyle(Color.bRecovery)
+      } minimal: {
+        Image(systemName: "wind").font(.system(size: 12)).foregroundStyle(Color.bRecovery)
+      }
+      .keylineTint(Color.bRecovery)
+    }
+  }
+}

--- a/ios/OpenStrapWidget/OpenStrapWidgetBundle.swift
+++ b/ios/OpenStrapWidget/OpenStrapWidgetBundle.swift
@@ -15,5 +15,6 @@ struct OpenStrapWidgetBundle: WidgetBundle {
         OpenStrapBatteryWidget()
         OpenStrapWidgetControl()
         OpenStrapWidgetLiveActivity()
+        OpenStrapBreathingLiveActivity()
     }
 }

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		5348973F2FDC19C80033A4D9 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5348973E2FDC19C80033A4D9 /* SwiftUI.framework */; };
 		5348974E2FDC19C90033A4D9 /* OpenStrapWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 5348973B2FDC19C80033A4D9 /* OpenStrapWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		534897A72FDC2B310033A4D9 /* LiveActivityBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534897A62FDC2B310033A4D9 /* LiveActivityBridge.swift */; };
+		BEEF00000000000000000002 /* BreathingLiveActivityBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEEF00000000000000000001 /* BreathingLiveActivityBridge.swift */; };
 		53962E962FF6EE120061A61B /* WatchBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53962E952FF6EE120061A61B /* WatchBridge.swift */; };
 		53962E972FF6EE120061A61B /* OpenStrapIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53962E942FF6EE120061A61B /* OpenStrapIntents.swift */; };
 		630172CC9317145AD5F8F3B7 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C721EA0C8D31A3834E66203 /* Pods_RunnerTests.framework */; };
@@ -104,6 +105,7 @@
 		534897562FDC1A450033A4D9 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		534897572FDC1A610033A4D9 /* OpenStrapWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OpenStrapWidgetExtension.entitlements; sourceTree = "<group>"; };
 		534897A62FDC2B310033A4D9 /* LiveActivityBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityBridge.swift; sourceTree = "<group>"; };
+		BEEF00000000000000000001 /* BreathingLiveActivityBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingLiveActivityBridge.swift; sourceTree = "<group>"; };
 		53962E942FF6EE120061A61B /* OpenStrapIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenStrapIntents.swift; sourceTree = "<group>"; };
 		53962E952FF6EE120061A61B /* WatchBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchBridge.swift; sourceTree = "<group>"; };
 		53962EBE2FF6EF790061A61B /* OpenStrapWatch Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "OpenStrapWatch Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -248,6 +250,7 @@
 				53962E942FF6EE120061A61B /* OpenStrapIntents.swift */,
 				53962E952FF6EE120061A61B /* WatchBridge.swift */,
 				534897A62FDC2B310033A4D9 /* LiveActivityBridge.swift */,
+				BEEF00000000000000000001 /* BreathingLiveActivityBridge.swift */,
 				534897572FDC1A610033A4D9 /* OpenStrapWidgetExtension.entitlements */,
 				6A2B37C32FDD000100000001 /* Config */,
 				9740EEB11CF90186004384FC /* Flutter */,
@@ -639,6 +642,7 @@
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				534897A72FDC2B310033A4D9 /* LiveActivityBridge.swift in Sources */,
+				BEEF00000000000000000002 /* BreathingLiveActivityBridge.swift in Sources */,
 				53962E962FF6EE120061A61B /* WatchBridge.swift in Sources */,
 				53962E972FF6EE120061A61B /* OpenStrapIntents.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -64,6 +64,11 @@ import BackgroundTasks
     if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "LiveActivityBridge") {
       LiveActivityBridge.register(messenger: registrar.messenger())
     }
+    // Breathing-session Live Activity — separate channel/attributes type from
+    // the workout one (BreathingLiveActivityBridge.swift, Runner target).
+    if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "BreathingLiveActivityBridge") {
+      BreathingLiveActivityBridge.register(messenger: registrar.messenger())
+    }
     // BLE-restore channel: native wake (band reconnected) → Dart headless sync.
     if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "BleRestoreManager") {
       BleRestoreManager.shared.attach(messenger: registrar.messenger())

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
@@ -23,6 +25,7 @@ import 'ui/workouts/workouts_screen.dart';
 import 'ui/activity/live_session_screen.dart';
 import 'ui/ai/ai_breakdown_screen.dart';
 import 'ui/journal/journal_compose_screen.dart';
+import 'ui/stress/calm_breathing_screen.dart';
 
 class OpenStrapApp extends StatefulWidget {
   const OpenStrapApp({super.key});
@@ -66,6 +69,10 @@ class _OpenStrapAppState extends State<OpenStrapApp> with WidgetsBindingObserver
       app.maybeFinishFromLiveActivity();
       app.refreshAppStatus(); // re-check OTA + admin banner on every foreground
       app.runCadenceChecks(); // evening wind-down / weekly recap nudges (best-effort)
+      // A Siri "start breathing" App Intent may have just foregrounded an
+      // already-running process (openAppWhenRun doesn't guarantee a fresh
+      // launch) — the constructor-time check alone would miss that case.
+      unawaited(app.checkPendingSiriRoute());
       if (app.isPaired) app.openSession();
     } else if (state == AppLifecycleState.paused) {
       // Backgrounded: hand the band to the iOS restore path so it can wake-and-drain
@@ -176,6 +183,10 @@ class _ShellState extends State<_Shell> {
       kRouteAiEvening =>
         const AiBreakdownScreen(period: BriefingPeriod.evening),
       kRouteJournalCompose => const JournalComposeScreen(),
+      // Siri/Shortcuts "start breathing" App Intent — see StartBreathingIntent
+      // in OpenStrapIntents.swift, which writes this route into the App Group
+      // for WidgetService.consumePendingRoute() to pick up on launch/resume.
+      kRouteBreathing => const CalmBreathingScreen(autoStart: true),
       _ => null,
     };
     if (screen == null) return;

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -67,6 +67,7 @@ class _OpenStrapAppState extends State<OpenStrapApp> with WidgetsBindingObserver
     final app = context.read<AppState>();
     if (state == AppLifecycleState.resumed) {
       app.maybeFinishFromLiveActivity();
+      unawaited(app.maybeStopBreathingFromLiveActivity());
       app.refreshAppStatus(); // re-check OTA + admin banner on every foreground
       app.runCadenceChecks(); // evening wind-down / weekly recap nudges (best-effort)
       // A Siri "start breathing" App Intent may have just foregrounded an

--- a/lib/live/breathing_live_activity.dart
+++ b/lib/live/breathing_live_activity.dart
@@ -1,0 +1,47 @@
+// Breathing-session Live Activity bridge (iOS) — start/update/end the
+// lock-screen + Dynamic Island coherence readout. Separate MethodChannel and
+// native attributes type from the workout Live Activity (live_activity.dart)
+// on purpose — different content, and keeps the two independent so neither
+// risks the other. No-ops on Android / older iOS (the MethodChannel simply
+// isn't there → MissingPluginException, swallowed).
+
+import 'package:flutter/services.dart';
+
+class BreathingLiveActivity {
+  static const MethodChannel _ch = MethodChannel(
+    'openstrap/breathing_live_activity',
+  );
+  static bool _active = false;
+
+  static bool get isActive => _active;
+
+  /// Start the activity for a breathing session. [startedAt] drives the live
+  /// timer. No coherence score yet — the widget shows "Calibrating…".
+  static Future<void> start({required DateTime startedAt}) async {
+    try {
+      await _ch.invokeMethod('start', {
+        'startedAtMs': startedAt.millisecondsSinceEpoch,
+        'coherenceScore': -1.0,
+      });
+      _active = true;
+    } catch (_) {/* not iOS / not supported */}
+  }
+
+  /// Push a new coherence score (0-100). Pass null/absent to keep showing
+  /// "Calibrating…" — never push a fabricated number.
+  static Future<void> update({double? coherenceScore}) async {
+    if (!_active) return;
+    try {
+      await _ch.invokeMethod('update', {
+        'coherenceScore': coherenceScore ?? -1.0,
+      });
+    } catch (_) {}
+  }
+
+  static Future<void> end() async {
+    try {
+      await _ch.invokeMethod('end');
+    } catch (_) {}
+    _active = false;
+  }
+}

--- a/lib/notify/tap_router.dart
+++ b/lib/notify/tap_router.dart
@@ -9,6 +9,7 @@
 const String kRouteAiMorning = '/ai/morning';
 const String kRouteAiEvening = '/ai/evening';
 const String kRouteJournalCompose = '/journal/compose';
+const String kRouteBreathing = '/breathing';
 
 class TapTarget {
   /// Shell tab index to land on (always valid; unknown → 0 = Today).
@@ -33,6 +34,7 @@ const Set<String> _screenRoutes = {
   kRouteAiMorning,
   kRouteAiEvening,
   kRouteJournalCompose,
+  kRouteBreathing,
 };
 
 TapTarget resolveTapRoute(String route) {

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -655,6 +655,19 @@ class AppState extends ChangeNotifier {
     // Notification taps → request a tab switch (the shell listens to navRequest).
     _tapSub = NotificationService.instance.taps.listen(_handleTapRoute);
     unawaited(NotificationService.instance.consumeLaunchRoute());
+    unawaited(checkPendingSiriRoute());
+  }
+
+  /// A Siri/Shortcuts App Intent (e.g. "start breathing") may have set a
+  /// pending route in the App Group before launching/foregrounding the app —
+  /// see WidgetService.consumePendingRoute + StartBreathingIntent in
+  /// OpenStrapIntents.swift. Checked on cold launch (constructor, above) AND
+  /// on every foreground resume (app.dart's didChangeAppLifecycleState),
+  /// since `openAppWhenRun = true` may just foreground an already-running
+  /// process rather than trigger a fresh launch.
+  Future<void> checkPendingSiriRoute() async {
+    final route = await WidgetService.consumePendingRoute();
+    if (route != null) _handleTapRoute(route);
   }
 
   @override

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -55,6 +55,7 @@ import '../import/whoop_import.dart';
 import '../gestures/gesture_dispatcher.dart';
 import '../data/models.dart';
 import '../live/live_activity.dart';
+import '../live/breathing_live_activity.dart';
 import '../notify/device_alerts.dart';
 import '../notify/notification_relay.dart';
 import '../notify/notification_service.dart';
@@ -2623,6 +2624,7 @@ class AppState extends ChangeNotifier {
     breathingError = null;
     _breathingFrames.clear();
     notifyListeners();
+    unawaited(BreathingLiveActivity.start(startedAt: DateTime.now()));
     try {
       // OWNERSHIP: same rule as spot-check — only claim "we enabled it" when
       // live was actually OFF, so ending the session can never turn off
@@ -2649,6 +2651,7 @@ class AppState extends ChangeNotifier {
     _breathingRecomputeTimer = null;
     breathingActive = false;
     _stopBreathingStreams();
+    unawaited(BreathingLiveActivity.end());
     notifyListeners();
   }
 
@@ -2664,6 +2667,8 @@ class AppState extends ChangeNotifier {
       if (!breathingActive) return; // session ended while we awaited
       breathingResult = res;
       notifyListeners();
+      final score = res['ok'] == true ? (res['score'] as num?)?.toDouble() : null;
+      unawaited(BreathingLiveActivity.update(coherenceScore: score));
     } catch (_) {
       /* best-effort; keep the last good result on screen rather than erroring */
     }
@@ -2898,6 +2903,16 @@ class AppState extends ChangeNotifier {
   Future<void> maybeFinishFromLiveActivity() async {
     if (activeWorkout != null && await WidgetService.consumeEndSessionFlag()) {
       await stopWorkout();
+    }
+  }
+
+  /// Same idea as [maybeFinishFromLiveActivity] but for the breathing
+  /// session's own Live Activity stop button (EndBreathingIntent sets
+  /// `end_breathing_session` — a separate flag so the two Live Activities'
+  /// stop buttons never collide). Call on app resume.
+  Future<void> maybeStopBreathingFromLiveActivity() async {
+    if (breathingActive && await WidgetService.consumeEndBreathingFlag()) {
+      await stopBreathingSession();
     }
   }
 

--- a/lib/sync/ios_bg_task.dart
+++ b/lib/sync/ios_bg_task.dart
@@ -33,6 +33,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../compute/derivation_engine.dart';
 import '../compute/profile.dart';
 import '../ble/ios_ble_restore.dart';
+import '../data/local_repository_impl.dart';
+import '../models/payloads.dart';
+import '../widget/widget_service.dart';
 import 'background_sync.dart';
 import 'headless_gate.dart';
 
@@ -93,6 +96,7 @@ class IosBgTask {
             // baseline-dependent scalars on recent finalized days if the
             // rolling baseline moved. Cheap no-op when unchanged.
             await engine.rescanRecent(profile);
+            await _refreshWidgetSnapshot(profile);
           } catch (e) {
             debugPrint('[ios-bgtask] heavy derive skipped: $e');
           }
@@ -104,6 +108,7 @@ class IosBgTask {
             final engine = DerivationEngine(
                 log: (l) => debugPrint('[ios-bgrefresh-derive] $l'));
             await engine.run(profile, heavy: false);
+            await _refreshWidgetSnapshot(profile);
           } catch (e) {
             debugPrint('[ios-bgrefresh] light derive skipped: $e');
           }
@@ -129,6 +134,26 @@ class IosBgTask {
       return Profile.fromMap((jsonDecode(raw) as Map).cast<String, dynamic>());
     } catch (_) {
       return const Profile();
+    }
+  }
+
+  /// Push a fresh Today snapshot to the App Group after a headless derive so
+  /// the home/lock-screen widget AND the Siri/Shortcuts query intents
+  /// (RecoveryIntent/StrainIntent/SleepIntent — see OpenStrapIntents.swift,
+  /// which read this same App Group) don't go stale just because the user
+  /// hasn't opened the Today screen. Previously WidgetService.push() was only
+  /// ever called from today_screen.dart's fetch() — a real gap: "ask Siri
+  /// without opening the app" is the whole point of a Siri Shortcut, so any
+  /// answer would silently reflect however-stale the last Today-screen visit
+  /// was (or "I don't have today's numbers yet" if that never happened at
+  /// all). Best-effort — never throws into the caller.
+  static Future<void> _refreshWidgetSnapshot(Profile profile) async {
+    try {
+      final repo = LocalRepositoryImpl(getProfileMap: () => profile.toMap());
+      final today = await repo.getToday();
+      await WidgetService.push(TodayData.fromJson(today));
+    } catch (e) {
+      debugPrint('[ios-bgtask] widget snapshot refresh skipped: $e');
     }
   }
 }

--- a/lib/ui/stress/calm_breathing_screen.dart
+++ b/lib/ui/stress/calm_breathing_screen.dart
@@ -18,11 +18,25 @@ import '../../state/app_state.dart';
 import '../design/design.dart';
 
 class CalmBreathingScreen extends StatelessWidget {
-  const CalmBreathingScreen({super.key});
+  /// Auto-begin the session the moment this screen mounts — used when opened
+  /// via the "start breathing" Siri/Shortcuts App Intent, where the spoken
+  /// command already IS the "start" action. The normal in-app entry point
+  /// (Stress screen's own button) leaves this false and shows the Ready state.
+  final bool autoStart;
+
+  const CalmBreathingScreen({super.key, this.autoStart = false});
 
   @override
   Widget build(BuildContext context) {
     final app = context.watch<AppState>();
+    if (autoStart && !app.breathingActive && app.isConnected) {
+      // Guarded by breathingActive so this only ever fires once per mount —
+      // startBreathingSession() flips breathingActive true and notifies,
+      // which rebuilds this widget and short-circuits the guard.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!app.breathingActive) app.startBreathingSession();
+      });
+    }
     return CalmBreathingView(
       connected: app.isConnected,
       active: app.breathingActive,

--- a/lib/widget/widget_service.dart
+++ b/lib/widget/widget_service.dart
@@ -173,6 +173,27 @@ class WidgetService {
     return false;
   }
 
+  /// Non-null once (and clears) if a Siri/Shortcuts App Intent asked to open a
+  /// specific in-app screen (e.g. StartBreathingIntent sets `pending_route` =
+  /// '/breathing' in the App Group before launching the app). Same
+  /// App-Group-flag pattern as [consumeEndSessionFlag]. Feed the result
+  /// through the normal tap-route pipeline (AppState._handleTapRoute /
+  /// tap_router.dart) — never invent a separate navigation path.
+  static Future<String?> consumePendingRoute() async {
+    try {
+      await init();
+      final v = await HomeWidget.getWidgetData<String>(
+        'pending_route',
+        defaultValue: '',
+      );
+      if (v != null && v.isNotEmpty) {
+        await HomeWidget.saveWidgetData<String>('pending_route', '');
+        return v;
+      }
+    } catch (_) {}
+    return null;
+  }
+
   static String _coachLine(CoachData? c) {
     if (c == null) return '';
     if (c.plan.isNotEmpty) return c.plan.first.title;

--- a/lib/widget/widget_service.dart
+++ b/lib/widget/widget_service.dart
@@ -194,6 +194,25 @@ class WidgetService {
     return null;
   }
 
+  /// True once (and clears) if the BREATHING Live Activity's stop button was
+  /// tapped. A separate flag (`end_breathing_session`) from the workout's
+  /// `end_session` — EndBreathingIntent in OpenStrapBreathingLiveActivity.swift
+  /// sets it; two independent Live Activities must never share one flag.
+  static Future<bool> consumeEndBreathingFlag() async {
+    try {
+      await init();
+      final v = await HomeWidget.getWidgetData<bool>(
+        'end_breathing_session',
+        defaultValue: false,
+      );
+      if (v == true) {
+        await HomeWidget.saveWidgetData<bool>('end_breathing_session', false);
+        return true;
+      }
+    } catch (_) {}
+    return false;
+  }
+
   static String _coachLine(CoachData? c) {
     if (c == null) return '';
     if (c.plan.isNotEmpty) return c.plan.first.title;

--- a/test/tap_router_test.dart
+++ b/test/tap_router_test.dart
@@ -1,0 +1,32 @@
+// tap_router.dart — pure route resolution. Regression coverage for the new
+// kRouteBreathing entry (Siri/Shortcuts "start breathing" App Intent).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/notify/tap_router.dart';
+
+void main() {
+  test('tab routes land on their index with no sub-screen', () {
+    expect(resolveTapRoute('/today').tab, 0);
+    expect(resolveTapRoute('/today').screen, isNull);
+    expect(resolveTapRoute('/sleep').tab, 1);
+    expect(resolveTapRoute('/workouts').tab, 4);
+  });
+
+  test('kRouteBreathing resolves to Today tab + the breathing sub-screen', () {
+    final t = resolveTapRoute(kRouteBreathing);
+    expect(t.tab, 0);
+    expect(t.screen, kRouteBreathing);
+  });
+
+  test('other sub-screen routes still resolve correctly', () {
+    expect(resolveTapRoute(kRouteAiMorning).screen, kRouteAiMorning);
+    expect(resolveTapRoute(kRouteAiEvening).screen, kRouteAiEvening);
+    expect(resolveTapRoute(kRouteJournalCompose).screen, kRouteJournalCompose);
+  });
+
+  test('an unknown/stale route falls back to Today, never crashes', () {
+    final t = resolveTapRoute('/recap');
+    expect(t.tab, 0);
+    expect(t.screen, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
Combined PR — this branch's history includes both features (never branched fresh between them, so this ended up as one combined stack rather than two independent PRs; #71 closed as superseded by this one).

## 1. Siri query staleness fix
`OpenStrapIntents.swift`'s `RecoveryIntent`/`StrainIntent`/`SleepIntent` read `readiness`/`strain`/`hrv`/`sleep_min`/`rhr` from the App Group. **The only place that ever wrote those keys was `today_screen.dart`'s `fetch()`** — i.e. only when the user had recently opened the Today screen in the foreground app. "Ask Siri instead of opening the app" is the entire point of a Siri Shortcut, so any query made without a recent Today-screen visit answered from stale data (or hit the generic "I don't have today's numbers yet" fallback) — reading exactly like "Siri is broken."

**Fix**: `ios_bg_task.dart` now pushes a fresh Today snapshot after every headless derive pass (both the heavy BGProcessingTask and light BGAppRefreshTask profiles), via a standalone `LocalRepositoryImpl` (no Provider/BuildContext needed, same headless-safe construction this file already uses elsewhere).

## 2. New action intent: StartBreathingIntent
Unlike the query intents, starting a breathing session needs the live Flutter engine + BLE stack, so `openAppWhenRun = true`. Writes a pending route into the App Group, consumed via a new `WidgetService.consumePendingRoute()`, fed through the same tap-route deep-link pipeline notifications already use (`tap_router.dart`'s new `kRouteBreathing` → `CalmBreathingScreen(autoStart: true)`). Checked at cold launch and on every foreground resume.

New phrases: "Start breathing in OpenStrap", "OpenStrap breathe", "Start a breathing session in OpenStrap", "Breathe with OpenStrap".

## 3. Live coherence on lock screen / Dynamic Island
Extends the real cardiac-coherence feature onto ActivityKit — mirrors the workout Live Activity's pattern but kept fully independent (separate MethodChannel `openstrap/breathing_live_activity`, separate `ActivityAttributes` type, separate stop-button flag `end_breathing_session`) so the well-tuned workout activity is never at risk. Shows "Calibrating…" — never a fabricated number — until a real result lands. No per-breath animation sync (ActivityKit rate-limits updates; the phone screen is the pacer, this is a passive readout). Interactive stop button (iOS 17+) via `EndBreathingIntent`.

## Test plan
- [x] `dart analyze` on all touched files — clean (2 pre-existing unrelated warnings)
- [x] `flutter test --concurrency=1` — same pass count as clean main + 4 new `tap_router_test.dart` cases, no regressions (2 pre-existing scratch-file failures, not real code)
- [x] `flutter build ios --debug --no-codesign` — succeeds, all new Swift files compile cleanly
- [x] **Not verified from this environment**: actual on-device Siri phrase recognition, Dynamic Island/lock-screen visual layout, real ActivityKit update-cadence — needs a real-device test, which is why this PR is still open for review rather than already merged