### PR TITLE
chore: release v0.9.12

### DIFF
--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -180,7 +180,20 @@ import 'substrate.dart';
 // min, against an Apple Watch Ultra ground truth of wake=3 light=330 deep=38
 // rem=162 min for the same night. Bump so this genuinely different (much more
 // accurate) staging recomputes; "Re-analyze data" needed for finalized nights.
-const int kAlgoVersion = 37;
+// v38: audit-fix sweep, two changes actually touch output. (1) analytics'
+// `readinessLnRmssd` was including tonight's own value in its own baseline
+// window (`historyLnRmssd.sublist(start)` ran to the end of the list instead
+// of stopping before it) - pulled the mean/sd toward tonight, understating
+// how far off a genuinely suppressed/elevated night reads, worst exactly
+// when the window is smallest. Now strictly prior nights only, changing
+// `readiness_lnrmssd`'s z/cv/value for every day. (2) day windows here used
+// `_localDayLabelToSec(day) + 86400`, assuming every local day is exactly
+// 24h - wrong on the two DST-transition days a year (23h/25h), which could
+// clip or over-include a day's substrate window right at the boundary. Now
+// `_localNextDayLabelToSec` asks DateTime for the actual start of the next
+// day. Bump so recent days recompute onto the corrected readiness baseline;
+// only matters for history on the rare day that crossed a DST transition.
+const int kAlgoVersion = 38;
 
 /// Raw is kept this many days past derivation, then pruned (derived stays).
 const int rawRetentionDays = 3;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -957,7 +957,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "56acd93a00f56bc6244f396b33bc4c20e98f6cc8"
+      resolved-ref: "068d4e71020d4bcac946b6159eaae31cb4fc5159"
       url: "https://github.com/OpenStrap/analytics.git"
     source: git
     version: "1.0.0"
@@ -975,7 +975,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "5f53be5ebae2e53d9d9bd54a1111ef36a1d224ce"
+      resolved-ref: "3892cd53defdcaaa48b2a66e2df233bc71d1c106"
       url: "https://github.com/OpenStrap/protocol.git"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openstrap_edge
 description: "OpenStrap — open-source WHOOP 4.0 companion. BLE drain → raw-first local store → cloud sync."
 publish_to: 'none'
-version: 0.9.11+44
+version: 0.9.12+45
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
version bump for release: 0.9.11+44 -> 0.9.12+45.

picks up today's merged protocol #12 and analytics #23 fix/bugs PRs
(lockfile was still pinned to the pre-merge commits). also bumps
kAlgoVersion 37->38 since two of the merged changes actually touch
computed output:

- analytics' readinessLnRmssd was including tonight's own value in its
  own baseline window (off-by-one on the sublist start), pulling mean/sd
  toward tonight and understating how far off a suppressed/elevated night
  reads - now strictly prior nights only.
- this repo's own audit-fix pass replaced `_localDayLabelToSec(day) + 86400`
  (assumes every day is exactly 24h) with DST-aware next-day boundaries,
  which can shift a day's substrate window on the two DST-transition
  days a year.

steps bout-gate fix and the Calories usedDefault* flags were already
covered / not consumed by edge respectively - see derivation_engine.dart
comment for the full v38 rationale.

flutter test --concurrency=1: 457 passed.
flutter analyze: 5 info/warning issues, no errors (pre-existing
glassBoxReadiness deprecation + 3 underscore-name infos + 1 unused-param
warning from the audit-fix sweep).