### PR TITLE
Fix/workmanager scope and lifecycle

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -311,8 +311,14 @@ class _LiveBanner extends StatefulWidget {
 }
 
 class _LiveBannerState extends State<_LiveBanner> with SingleTickerProviderStateMixin {
-  late final AnimationController _pulse =
-      AnimationController(vsync: this, duration: const Duration(milliseconds: 900))..repeat(reverse: true);
+  late final AnimationController _pulse;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulse = AnimationController(vsync: this, duration: const Duration(milliseconds: 900))..repeat(reverse: true);
+  }
+
   @override
   void dispose() { _pulse.dispose(); super.dispose(); }
 

--- a/lib/compute/background_derivation.dart
+++ b/lib/compute/background_derivation.dart
@@ -37,8 +37,13 @@ import 'derivation_engine.dart';
 import 'profile.dart';
 import '../sync/background_sync.dart';
 
-const String _kHeavyTask = 'openstrap.derive.heavy';
-const String _kSyncTask = 'openstrap.sync';
+// Public (not `_`-prefixed): main.dart needs these unique names to scope its
+// startup cancelByUniqueName() cleanup to exactly these two tasks, without
+// touching unrelated WorkManager jobs (e.g. the native KeepAliveWorker
+// watchdog, which shares the same OS-level WorkManager instance and would
+// otherwise get wiped by an unscoped cancelAll()).
+const String kHeavyDeriveTaskName = 'openstrap.derive.heavy';
+const String kSyncTaskName = 'openstrap.sync';
 const String _kProfileKey = 'local_profile_json'; // mirrors AppState._kProfile
 
 /// The WorkManager entry point. MUST be a top-level / static fn with the
@@ -54,11 +59,11 @@ void derivationDispatcher() {
     } catch (_) {}
     
     try {
-      if (task == _kSyncTask) {
+      if (task == kSyncTaskName) {
         debugPrint('[bg-sync] triggered by WorkManager');
         await runHeadlessSync();
         return true;
-      } else if (task == _kHeavyTask) {
+      } else if (task == kHeavyDeriveTaskName) {
         debugPrint('[bg-derive] triggered by WorkManager');
         final profile = await _loadProfile();
         final engine = DerivationEngine(log: (m) => debugPrint('[bg-derive] $m'));
@@ -102,8 +107,8 @@ class BackgroundDerivation {
       
       // Schedule Sync Task (every 10 min - note Android clamps to 15 min minimum)
       await Workmanager().registerPeriodicTask(
-        _kSyncTask,
-        _kSyncTask,
+        kSyncTaskName,
+        kSyncTaskName,
         frequency: const Duration(minutes: 10),
         constraints: Constraints(
           networkType: NetworkType.notRequired,
@@ -115,8 +120,8 @@ class BackgroundDerivation {
 
       // Schedule Analyze/Derivation Task (every 10 min - note Android clamps to 15 min minimum)
       await Workmanager().registerPeriodicTask(
-        _kHeavyTask,
-        _kHeavyTask,
+        kHeavyDeriveTaskName,
+        kHeavyDeriveTaskName,
         frequency: const Duration(minutes: 10),
         constraints: Constraints(
           networkType: NetworkType.notRequired,

--- a/lib/health/health_export.dart
+++ b/lib/health/health_export.dart
@@ -59,6 +59,7 @@ class HealthExporter {
         HealthDataType.RESTING_HEART_RATE,
         _hrvType,
         HealthDataType.RESPIRATORY_RATE,
+        HealthDataType.HEART_RATE,
         HealthDataType.ACTIVE_ENERGY_BURNED,
         HealthDataType.BASAL_ENERGY_BURNED,
         HealthDataType.STEPS,
@@ -266,34 +267,86 @@ class HealthExporter {
     await writeAt(HealthDataType.RESPIRATORY_RATE, sc('resp_rate'),
         HealthDataUnit.RESPIRATIONS_PER_MINUTE, mid);
 
-    // Active energy over the whole day.
-    final cal = sc('calories');
-    if (cal != null && cal > 0) {
+    // Active energy: chunked into hourly buckets over the day.
+    // We subtract workout calories to prevent double-counting, because workouts
+    // are exported separately.
+    var cal = sc('calories')?.toDouble() ?? 0.0;
+    try {
+      final rows = await LocalDb.sessionsInRange(
+          dayStart.millisecondsSinceEpoch ~/ 1000,
+          dayEnd.millisecondsSinceEpoch ~/ 1000);
+      var workoutCal = 0.0;
+      for (final r in rows) {
+        if ((r['status']?.toString() ?? '') == 'live') continue;
+        workoutCal += (r['calories'] as num?)?.toDouble() ?? 0.0;
+      }
+      cal = (cal > workoutCal) ? cal - workoutCal : 0.0;
+    } catch (_) {}
+
+    if (cal > 0) {
       try {
-        await _health.writeHealthData(
-            value: cal.toDouble(),
-            type: HealthDataType.ACTIVE_ENERGY_BURNED,
-            startTime: dayStart,
-            endTime: dayEnd,
-            unit: HealthDataUnit.KILOCALORIE);
+        final calPerHour = cal / 24;
+        for (int i = 0; i < 24; i++) {
+          await _health.writeHealthData(
+              value: calPerHour,
+              type: HealthDataType.ACTIVE_ENERGY_BURNED,
+              startTime: dayStart.add(Duration(hours: i)),
+              endTime: dayStart.add(Duration(hours: i + 1)),
+              unit: HealthDataUnit.KILOCALORIE);
+        }
       } catch (e) {
         debugPrint('[health] write energy: $e');
       }
     }
 
-    // Basal energy = total daily energy (TDEE) − active, over the whole day.
+    // Basal energy = total daily energy (TDEE) − active, chunked hourly.
     final calTotal = sc('calories_total');
-    if (calTotal != null && cal != null && calTotal > cal) {
+    final rawCal = sc('calories');
+    if (calTotal != null && rawCal != null && calTotal > rawCal) {
       try {
-        await _health.writeHealthData(
-            value: (calTotal - cal).toDouble(),
-            type: HealthDataType.BASAL_ENERGY_BURNED,
-            startTime: dayStart,
-            endTime: dayEnd,
-            unit: HealthDataUnit.KILOCALORIE);
+        final basal = (calTotal - rawCal).toDouble();
+        final basalPerHour = basal / 24;
+        for (int i = 0; i < 24; i++) {
+          await _health.writeHealthData(
+              value: basalPerHour,
+              type: HealthDataType.BASAL_ENERGY_BURNED,
+              startTime: dayStart.add(Duration(hours: i)),
+              endTime: dayStart.add(Duration(hours: i + 1)),
+              unit: HealthDataUnit.KILOCALORIE);
+        }
       } catch (e) {
         debugPrint('[health] write basal energy: $e');
       }
+    }
+
+    // Continuous Heart Rate (minute-by-minute average).
+    try {
+      final db = await LocalDb.instance;
+      final startTs = dayStart.millisecondsSinceEpoch ~/ 1000;
+      final endTs = dayEnd.millisecondsSinceEpoch ~/ 1000;
+      // Group by minute to downsample
+      final hrRows = await db.rawQuery(
+          'SELECT (rec_ts / 60) * 60 AS minute_ts, AVG(hr) as avg_hr '
+          'FROM decoded_onehz '
+          'WHERE rec_ts >= ? AND rec_ts < ? AND hr > 0 '
+          'GROUP BY minute_ts',
+          [startTs, endTs]);
+      
+      for (final r in hrRows) {
+        final minuteTs = (r['minute_ts'] as num).toInt();
+        final avgHr = (r['avg_hr'] as num).toDouble();
+        if (avgHr > 0) {
+          final t = DateTime.fromMillisecondsSinceEpoch(minuteTs * 1000);
+          await _health.writeHealthData(
+              value: avgHr,
+              type: HealthDataType.HEART_RATE,
+              startTime: t,
+              endTime: t.add(const Duration(minutes: 1)),
+              unit: HealthDataUnit.BEATS_PER_MINUTE);
+        }
+      }
+    } catch (e) {
+      debugPrint('[health] write continuous hr: $e');
     }
 
     // Steps (24/7 estimate) over the whole day.

--- a/lib/health/health_export.dart
+++ b/lib/health/health_export.dart
@@ -200,8 +200,10 @@ class HealthExporter {
     Duration(hours: 6),
     Duration(hours: 24),
   ];
+  // Entries start at attempts==1 (recorded right after the first failure), so
+  // index by attempts-1: the first failure gets the first (shortest) tier.
   Duration _backoffFor(int attempts) =>
-      _kRetryBackoff[attempts.clamp(0, _kRetryBackoff.length - 1)];
+      _kRetryBackoff[(attempts - 1).clamp(0, _kRetryBackoff.length - 1)];
 
   Future<Map<String, dynamic>> _loadRetryState() async {
     final raw = await LocalDb.getCursor(_kRetryCursor);
@@ -243,8 +245,19 @@ class HealthExporter {
         }
 
         final entry = (retryState[date] as Map?)?.cast<String, dynamic>();
-        final attempts = (entry?['attempts'] as num?)?.toInt() ?? 0;
-        final lastAttemptMs = (entry?['last_ms'] as num?)?.toInt();
+        var attempts = (entry?['attempts'] as num?)?.toInt() ?? 0;
+        var lastAttemptMs = (entry?['last_ms'] as num?)?.toInt();
+        final wasFinalized = entry?['finalized'] as bool? ?? false;
+        if (finalized && !wasFinalized && attempts > 0) {
+          // The day just transitioned non-finalized -> finalized: a
+          // materially different (complete, now-immutable) payload than
+          // whatever was still re-deriving during the "recent tail" attempts
+          // that accrued this cap/backoff. Give it a clean attempt budget so
+          // a newly-finalized day is never skipped because of a cap earned
+          // against the old mutable version.
+          attempts = 0;
+          lastAttemptMs = null;
+        }
         final nowMs = DateTime.now().millisecondsSinceEpoch;
 
         var ok = false;
@@ -264,7 +277,11 @@ class HealthExporter {
             }
           } else {
             final nextAttempts = attempts + 1;
-            retryState[date] = {'attempts': nextAttempts, 'last_ms': nowMs};
+            retryState[date] = {
+              'attempts': nextAttempts,
+              'last_ms': nowMs,
+              'finalized': finalized,
+            };
             retryStateDirty = true;
             debugPrint(
                 '[health] day $date export incomplete (attempt $nextAttempts/$_kMaxExportAttempts)');
@@ -367,12 +384,17 @@ class HealthExporter {
         HealthDataUnit.RESPIRATIONS_PER_MINUTE, mid);
 
     // Hourly buckets spanning [dayStart, dayEnd), shared by the active/basal
-    // energy writers below. Built from the real dayEnd boundary (not fixed
-    // 1-hour Durations from dayStart) so every bucket — including the last —
-    // stays inside the correct calendar day on DST-transition days.
-    final bucketSpan = dayEnd.difference(dayStart) ~/ 24;
-    final bucketBounds = List<DateTime>.generate(
-        25, (i) => i == 24 ? dayEnd : dayStart.add(bucketSpan * i));
+    // energy writers below. Each bucket is a real elapsed clock-hour (not
+    // 1/24th of the day's span — that would give 57.5min/62.5min "hours" on
+    // DST-transition days); the day's actual length (23/24/25 real hours)
+    // instead changes bucketCount, with the final bucket clipped to dayEnd so
+    // it never spills into the next calendar day.
+    final bucketBounds = <DateTime>[dayStart];
+    while (bucketBounds.last.isBefore(dayEnd)) {
+      final next = bucketBounds.last.add(const Duration(hours: 1));
+      bucketBounds.add(next.isAfter(dayEnd) ? dayEnd : next);
+    }
+    final bucketCount = bucketBounds.length - 1;
 
     // Active energy: chunked into hourly buckets over the day.
     // We subtract workout calories to prevent double-counting, because workouts
@@ -400,8 +422,8 @@ class HealthExporter {
     }
 
     if (cal > 0) {
-      final calPerHour = cal / 24;
-      for (int i = 0; i < 24; i++) {
+      final calPerHour = cal / bucketCount;
+      for (int i = 0; i < bucketCount; i++) {
         try {
           await _health.writeHealthData(
               value: calPerHour,
@@ -421,8 +443,8 @@ class HealthExporter {
     final rawCal = sc('calories');
     if (calTotal != null && rawCal != null && calTotal > rawCal) {
       final basal = (calTotal - rawCal).toDouble();
-      final basalPerHour = basal / 24;
-      for (int i = 0; i < 24; i++) {
+      final basalPerHour = basal / bucketCount;
+      for (int i = 0; i < bucketCount; i++) {
         try {
           await _health.writeHealthData(
               value: basalPerHour,

--- a/lib/health/health_export.dart
+++ b/lib/health/health_export.dart
@@ -170,12 +170,60 @@ class HealthExporter {
   /// over the contiguous finalized-and-exported prefix; the recent tail is
   /// re-written on each call. [reset] re-exports the whole retained window.
   /// Returns the number of days written. Never throws.
+  // Per-day export retry state, keyed by date, persisted as JSON in the same
+  // sync_cursor key-value table exportAll() already uses for its cursor (no
+  // schema migration needed): {date: {attempts, last_ms}}.
+  //
+  // Design rationale (why bounded retry-with-backoff, not indefinite block):
+  // exportAll() runs on EVERY drain/derive pass (light + heavy — see
+  // AppState), so a naive "retry every call until it succeeds" would hammer
+  // HealthKit/Health Connect many times an hour. And blocking the cursor
+  // indefinitely on one bad day would freeze every later day's export too,
+  // forever, over one persistently-failing write. This codebase already has
+  // precedent against indefinite blocking for exactly this class of problem:
+  // derivation_engine.dart marks a pathological day with a skip marker
+  // "so it isn't retried forever" and caps per-day compute so "the sweep
+  // always makes progress"; the BLE layer's BondRefusalGiveUp does the same
+  // (give up after N refusals rather than retry forever). We follow that
+  // convention: back off with growing spacing, and after _kMaxExportAttempts
+  // give up on that specific day (log it, let the cursor advance past it)
+  // rather than wedge the pipeline. Note this only matters for genuine
+  // thrown errors — an ungranted health permission doesn't throw (writes
+  // silently no-op, see the comment above _ensureConfigured), so it never
+  // enters this retry path or gets "given up on" by it.
+  static const _kRetryCursor = 'health_export_retry_state';
+  static const _kMaxExportAttempts = 6;
+  static const _kRetryBackoff = [
+    Duration(minutes: 5),
+    Duration(minutes: 30),
+    Duration(hours: 2),
+    Duration(hours: 6),
+    Duration(hours: 24),
+  ];
+  Duration _backoffFor(int attempts) =>
+      _kRetryBackoff[attempts.clamp(0, _kRetryBackoff.length - 1)];
+
+  Future<Map<String, dynamic>> _loadRetryState() async {
+    final raw = await LocalDb.getCursor(_kRetryCursor);
+    if (raw == null || raw.isEmpty) return {};
+    try {
+      return (jsonDecode(raw) as Map).cast<String, dynamic>();
+    } catch (_) {
+      return {};
+    }
+  }
+
   Future<int> exportAll({bool reset = false, void Function(int days)? onProgress}) async {
     await _ensureConfigured();
     if (await _androidUnavailable() != null) return 0; // HC missing/outdated
     try {
-      if (reset) await LocalDb.setCursor('health_export_through', '');
+      if (reset) {
+        await LocalDb.setCursor('health_export_through', '');
+        await LocalDb.setCursor(_kRetryCursor, '');
+      }
       final cursor = await LocalDb.getCursor('health_export_through') ?? '';
+      final retryState = await _loadRetryState();
+      var retryStateDirty = false;
       final rows = await LocalDb.recentDayResults(400); // newest-first
       final ascending = rows.reversed.toList();
       var done = 0;
@@ -193,14 +241,50 @@ class HealthExporter {
           if (!finalized) prefixContiguous = false;
           continue;
         }
-        final ok = await _exportDay(date, bundle); // delete-then-write (idempotent)
+
+        final entry = (retryState[date] as Map?)?.cast<String, dynamic>();
+        final attempts = (entry?['attempts'] as num?)?.toInt() ?? 0;
+        final lastAttemptMs = (entry?['last_ms'] as num?)?.toInt();
+        final nowMs = DateTime.now().millisecondsSinceEpoch;
+
+        var ok = false;
+        var giveUp = false;
+        if (attempts >= _kMaxExportAttempts) {
+          giveUp = true;
+        } else if (lastAttemptMs != null &&
+            nowMs - lastAttemptMs < _backoffFor(attempts).inMilliseconds) {
+          // Not due for retry yet — don't hammer the health store on every
+          // drain/derive pass; counts as "not done" for the cursor below.
+        } else {
+          ok = await _exportDay(date, bundle); // delete-then-write (idempotent)
+          if (ok) {
+            if (entry != null) {
+              retryState.remove(date);
+              retryStateDirty = true;
+            }
+          } else {
+            final nextAttempts = attempts + 1;
+            retryState[date] = {'attempts': nextAttempts, 'last_ms': nowMs};
+            retryStateDirty = true;
+            debugPrint(
+                '[health] day $date export incomplete (attempt $nextAttempts/$_kMaxExportAttempts)');
+            if (nextAttempts >= _kMaxExportAttempts) {
+              debugPrint(
+                  '[health] day $date exceeded $_kMaxExportAttempts export attempts — giving up, will stop blocking newer days');
+            }
+          }
+        }
+
         if (ok) {
           done++;
           onProgress?.call(done);
         }
-        // Advance the cursor only while the finalized prefix stays unbroken; the
-        // first non-finalized day stops it (that day re-exports next pass).
-        if (prefixContiguous && finalized) {
+        // Advance the cursor only while the finalized prefix stays unbroken —
+        // a non-finalized day, a still-backing-off retry, or a day still
+        // under the attempt cap all stop it (re-checked next pass); a
+        // given-up day counts alongside a genuine success so it can't wedge
+        // every later day's cursor forever.
+        if (prefixContiguous && finalized && (ok || giveUp)) {
           newCursor = date;
         } else {
           prefixContiguous = false;
@@ -208,6 +292,9 @@ class HealthExporter {
       }
       if (newCursor != cursor) {
         await LocalDb.setCursor('health_export_through', newCursor);
+      }
+      if (retryStateDirty) {
+        await LocalDb.setCursor(_kRetryCursor, jsonEncode(retryState));
       }
       debugPrint('[health] exported $done day(s); finalized-cursor=$newCursor');
       return done;
@@ -222,7 +309,17 @@ class HealthExporter {
   Future<bool> _exportDay(String date, Map<String, dynamic> b) async {
     final dayStart = _localMidnight(date);
     if (dayStart == null) return false;
-    final dayEnd = dayStart.add(const Duration(days: 1));
+    // DST-safe next local midnight (calendar-field construction, NOT +24h of
+    // absolute Duration — the latter overshoots/undershoots by an hour on the
+    // two DST-transition days/year, spilling hourly buckets into the wrong day).
+    final dayEnd = DateTime(dayStart.year, dayStart.month, dayStart.day + 1);
+
+    // Aggregate success across every write below: a day is only "exported" if
+    // everything we attempted actually landed. Any per-write/per-query failure
+    // flips this to false so exportAll()'s cursor won't mark the day done —
+    // see the retry/backoff logic there. We still attempt every remaining
+    // write on failure (best-effort, idempotent re-export corrects it later).
+    var success = true;
 
     // Idempotency: remove OUR previously-written samples for this day (HealthKit /
     // Health Connect only let an app delete its own data), then re-write fresh.
@@ -231,6 +328,7 @@ class HealthExporter {
         await _health.delete(type: t, startTime: dayStart, endTime: dayEnd);
       } catch (e) {
         debugPrint('[health] delete ${t.name}: $e');
+        success = false;
       }
     }
 
@@ -247,7 +345,7 @@ class HealthExporter {
 
     Future<void> writeAt(HealthDataType type, num? v, HealthDataUnit unit,
         DateTime t) async {
-      if (v == null || v <= 0) return;
+      if (v == null || v <= 0) return; // absent input, not a failure
       try {
         await _health.writeHealthData(
             value: v.toDouble(),
@@ -257,6 +355,7 @@ class HealthExporter {
             unit: unit);
       } catch (e) {
         debugPrint('[health] write ${type.name}: $e');
+        success = false;
       }
     }
 
@@ -267,35 +366,53 @@ class HealthExporter {
     await writeAt(HealthDataType.RESPIRATORY_RATE, sc('resp_rate'),
         HealthDataUnit.RESPIRATIONS_PER_MINUTE, mid);
 
+    // Hourly buckets spanning [dayStart, dayEnd), shared by the active/basal
+    // energy writers below. Built from the real dayEnd boundary (not fixed
+    // 1-hour Durations from dayStart) so every bucket — including the last —
+    // stays inside the correct calendar day on DST-transition days.
+    final bucketSpan = dayEnd.difference(dayStart) ~/ 24;
+    final bucketBounds = List<DateTime>.generate(
+        25, (i) => i == 24 ? dayEnd : dayStart.add(bucketSpan * i));
+
     // Active energy: chunked into hourly buckets over the day.
     // We subtract workout calories to prevent double-counting, because workouts
-    // are exported separately.
+    // are exported separately (their totalEnergyBurned already covers it).
+    // Upper bound is exclusive (dayEnd - 1s): sessionsInRange is inclusive on
+    // both ends, so a workout starting exactly at midnight would otherwise be
+    // double-subtracted from both this day and the next.
     var cal = sc('calories')?.toDouble() ?? 0.0;
     try {
       final rows = await LocalDb.sessionsInRange(
           dayStart.millisecondsSinceEpoch ~/ 1000,
-          dayEnd.millisecondsSinceEpoch ~/ 1000);
+          (dayEnd.millisecondsSinceEpoch ~/ 1000) - 1);
       var workoutCal = 0.0;
       for (final r in rows) {
         if ((r['status']?.toString() ?? '') == 'live') continue;
         workoutCal += (r['calories'] as num?)?.toDouble() ?? 0.0;
       }
       cal = (cal > workoutCal) ? cal - workoutCal : 0.0;
-    } catch (_) {}
+    } catch (e) {
+      // Unknown whether cal is workout-adjusted — still write our best guess
+      // below (idempotent re-export corrects it once this query succeeds),
+      // but flag the day so it isn't marked done on this pass.
+      debugPrint('[health] workout-calorie query: $e');
+      success = false;
+    }
 
     if (cal > 0) {
-      try {
-        final calPerHour = cal / 24;
-        for (int i = 0; i < 24; i++) {
+      final calPerHour = cal / 24;
+      for (int i = 0; i < 24; i++) {
+        try {
           await _health.writeHealthData(
               value: calPerHour,
               type: HealthDataType.ACTIVE_ENERGY_BURNED,
-              startTime: dayStart.add(Duration(hours: i)),
-              endTime: dayStart.add(Duration(hours: i + 1)),
+              startTime: bucketBounds[i],
+              endTime: bucketBounds[i + 1],
               unit: HealthDataUnit.KILOCALORIE);
+        } catch (e) {
+          debugPrint('[health] write energy bucket $i: $e');
+          success = false;
         }
-      } catch (e) {
-        debugPrint('[health] write energy: $e');
       }
     }
 
@@ -303,50 +420,59 @@ class HealthExporter {
     final calTotal = sc('calories_total');
     final rawCal = sc('calories');
     if (calTotal != null && rawCal != null && calTotal > rawCal) {
-      try {
-        final basal = (calTotal - rawCal).toDouble();
-        final basalPerHour = basal / 24;
-        for (int i = 0; i < 24; i++) {
+      final basal = (calTotal - rawCal).toDouble();
+      final basalPerHour = basal / 24;
+      for (int i = 0; i < 24; i++) {
+        try {
           await _health.writeHealthData(
               value: basalPerHour,
               type: HealthDataType.BASAL_ENERGY_BURNED,
-              startTime: dayStart.add(Duration(hours: i)),
-              endTime: dayStart.add(Duration(hours: i + 1)),
+              startTime: bucketBounds[i],
+              endTime: bucketBounds[i + 1],
               unit: HealthDataUnit.KILOCALORIE);
+        } catch (e) {
+          debugPrint('[health] write basal energy bucket $i: $e');
+          success = false;
         }
-      } catch (e) {
-        debugPrint('[health] write basal energy: $e');
       }
     }
 
     // Continuous Heart Rate (minute-by-minute average).
+    List<Map<String, Object?>>? hrRows;
     try {
       final db = await LocalDb.instance;
       final startTs = dayStart.millisecondsSinceEpoch ~/ 1000;
       final endTs = dayEnd.millisecondsSinceEpoch ~/ 1000;
       // Group by minute to downsample
-      final hrRows = await db.rawQuery(
+      hrRows = await db.rawQuery(
           'SELECT (rec_ts / 60) * 60 AS minute_ts, AVG(hr) as avg_hr '
           'FROM decoded_onehz '
           'WHERE rec_ts >= ? AND rec_ts < ? AND hr > 0 '
           'GROUP BY minute_ts',
           [startTs, endTs]);
-      
+    } catch (e) {
+      debugPrint('[health] query continuous hr: $e');
+      success = false;
+    }
+    if (hrRows != null) {
       for (final r in hrRows) {
         final minuteTs = (r['minute_ts'] as num).toInt();
         final avgHr = (r['avg_hr'] as num).toDouble();
         if (avgHr > 0) {
           final t = DateTime.fromMillisecondsSinceEpoch(minuteTs * 1000);
-          await _health.writeHealthData(
-              value: avgHr,
-              type: HealthDataType.HEART_RATE,
-              startTime: t,
-              endTime: t.add(const Duration(minutes: 1)),
-              unit: HealthDataUnit.BEATS_PER_MINUTE);
+          try {
+            await _health.writeHealthData(
+                value: avgHr,
+                type: HealthDataType.HEART_RATE,
+                startTime: t,
+                endTime: t.add(const Duration(minutes: 1)),
+                unit: HealthDataUnit.BEATS_PER_MINUTE);
+          } catch (e) {
+            debugPrint('[health] write continuous hr @$minuteTs: $e');
+            success = false;
+          }
         }
       }
-    } catch (e) {
-      debugPrint('[health] write continuous hr: $e');
     }
 
     // Steps (24/7 estimate) over the whole day.
@@ -361,6 +487,7 @@ class HealthExporter {
             unit: HealthDataUnit.COUNT);
       } catch (e) {
         debugPrint('[health] write steps: $e');
+        success = false;
       }
     }
 
@@ -382,32 +509,45 @@ class HealthExporter {
             endTime: DateTime.fromMillisecondsSinceEpoch(en * 1000));
       } catch (e) {
         debugPrint('[health] write sleep ${type.name}: $e');
+        success = false;
       }
     }
 
-    // Workouts (manual/live/detected) finalized in this calendar day.
+    // Workouts (manual/live/detected) finalized in this calendar day. Upper
+    // bound is exclusive (dayEnd - 1s) for the same midnight-boundary reason
+    // as the active-energy query above — otherwise a workout starting exactly
+    // at midnight gets written into both this day and the next.
     {
+      List<Map<String, Object?>>? rows;
       try {
-        final rows = await LocalDb.sessionsInRange(
+        rows = await LocalDb.sessionsInRange(
             dayStart.millisecondsSinceEpoch ~/ 1000,
-            dayEnd.millisecondsSinceEpoch ~/ 1000);
+            (dayEnd.millisecondsSinceEpoch ~/ 1000) - 1);
+      } catch (e) {
+        debugPrint('[health] query workouts: $e');
+        success = false;
+      }
+      if (rows != null) {
         for (final r in rows) {
           if ((r['status']?.toString() ?? '') == 'live') continue;
           final st = (r['start_ts'] as num?)?.toInt();
           final en = (r['end_ts'] as num?)?.toInt();
           if (st == null || en == null || en <= st) continue;
-          await _health.writeWorkoutData(
-            activityType: _activity(r['type']?.toString()),
-            start: DateTime.fromMillisecondsSinceEpoch(st * 1000),
-            end: DateTime.fromMillisecondsSinceEpoch(en * 1000),
-            totalEnergyBurned: (r['calories'] as num?)?.round(),
-          );
+          try {
+            await _health.writeWorkoutData(
+              activityType: _activity(r['type']?.toString()),
+              start: DateTime.fromMillisecondsSinceEpoch(st * 1000),
+              end: DateTime.fromMillisecondsSinceEpoch(en * 1000),
+              totalEnergyBurned: (r['calories'] as num?)?.round(),
+            );
+          } catch (e) {
+            debugPrint('[health] write workout @$st: $e');
+            success = false;
+          }
         }
-      } catch (e) {
-        debugPrint('[health] write workouts: $e');
       }
     }
-    return true;
+    return success;
   }
 
   HealthDataType? _sleepType(String stage) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,10 @@ import 'theme/theme_controller.dart';
 import 'widget/widget_service.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
+import 'package:workmanager/workmanager.dart';
+import 'dart:io';
+import 'compute/background_derivation.dart' show kHeavyDeriveTaskName, kSyncTaskName;
+
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   
@@ -34,6 +38,28 @@ Future<void> main() async {
   // catch framework + uncaught async errors on their own, and a custom root zone
   // is a known source of release-startup fragility.
   TelemetryService.instance.installErrorHandlers();
+
+  // Android: Cancel the two legacy WorkManager tasks by unique name. A previous
+  // version scheduled heavy derivation passes in the background, but they were
+  // pulled due to isolate collisions/deadlocks with the main UI's database access.
+  // We must explicitly cancel them here otherwise they survive app updates and
+  // cause the app to hang on the loading screen (buffering circle) when they fire
+  // concurrently with AppState._init().
+  //
+  // IMPORTANT: this MUST be scoped by unique name, never Workmanager().cancelAll().
+  // AndroidX WorkManager is a single OS-wide instance shared by every caller —
+  // the Dart workmanager plugin's cancelAll() maps straight to the native
+  // WorkManager.cancelAllWork(), which is NOT scoped to jobs the plugin itself
+  // registered. EdgeApplication.onCreate() (native Kotlin) schedules the
+  // KeepAliveWorker FGS-restart watchdog via that same WorkManager instance
+  // BEFORE this Dart main() runs — an unscoped cancelAll() here wipes that
+  // watchdog out on every single cold start, silently disabling it.
+  if (Platform.isAndroid) {
+    try {
+      await Workmanager().cancelByUniqueName(kHeavyDeriveTaskName);
+      await Workmanager().cancelByUniqueName(kSyncTaskName);
+    } catch (_) {}
+  }
 
   // iOS CoreBluetooth State Preservation & Restoration: opt the flutter_blue_plus
   // central (the one that actually subscribes to the band's HR/event characteristics)

--- a/lib/ui/design/pressable.dart
+++ b/lib/ui/design/pressable.dart
@@ -76,9 +76,9 @@ class _PressableState extends State<Pressable> {
     }
 
     return Listener(
-      onPointerDown: (_) => setState(() => _down = true),
-      onPointerUp: (_) => setState(() => _down = false),
-      onPointerCancel: (_) => setState(() => _down = false),
+      onPointerDown: (_) { if (mounted) setState(() => _down = true); },
+      onPointerUp: (_) { if (mounted) setState(() => _down = false); },
+      onPointerCancel: (_) { if (mounted) setState(() => _down = false); },
       child: AnimatedScale(
         scale: _down ? widget.pressedScale : 1.0,
         duration: Motion.fast,

--- a/lib/ui/today/step_calibration_screen.dart
+++ b/lib/ui/today/step_calibration_screen.dart
@@ -28,9 +28,12 @@ class _StepCalibrationScreenState extends State<StepCalibrationScreen> {
   double? _learnedCadence;
   String? _error;
 
+  late final AppState _appState;
+
   @override
   void initState() {
     super.initState();
+    _appState = context.read<AppState>();
     WidgetsBinding.instance.addPostFrameCallback((_) => _start());
   }
 
@@ -70,7 +73,7 @@ class _StepCalibrationScreenState extends State<StepCalibrationScreen> {
   void dispose() {
     // If we leave without saving, stop the stream + drop the partial walk.
     if (_learnedCadence == null) {
-      context.read<AppState>().cancelStepCalibration();
+      _appState.cancelStepCalibration();
     }
     super.dispose();
   }


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on background task management, health data export accuracy, and UI robustness. The most significant changes include safer and more precise handling of background tasks to avoid interfering with unrelated system jobs, enhancements to health data export granularity, and minor UI code safety improvements.

**Background Task Management:**
* Refactored background derivation task names to use public, uniquely-scoped constants (`kHeavyDeriveTaskName`, `kSyncTaskName`) to ensure that only the intended WorkManager jobs are cancelled during app startup, preventing accidental cancellation of unrelated jobs like native watchdogs. (`lib/compute/background_derivation.dart`, `lib/main.dart`) [[1]](diffhunk://#diff-6481db284babd77b9ea0a6c6a788a2c48efc5dcd8af8abb2f7a1878e2d8c8113L40-R46) [[2]](diffhunk://#diff-6481db284babd77b9ea0a6c6a788a2c48efc5dcd8af8abb2f7a1878e2d8c8113L57-R66) [[3]](diffhunk://#diff-6481db284babd77b9ea0a6c6a788a2c48efc5dcd8af8abb2f7a1878e2d8c8113L105-R111) [[4]](diffhunk://#diff-6481db284babd77b9ea0a6c6a788a2c48efc5dcd8af8abb2f7a1878e2d8c8113L118-R124) [[5]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R19-R22) [[6]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R42-R63)

**Health Data Export Improvements:**
* Export of active and basal energy is now chunked into hourly buckets instead of a single daily value, and active energy subtracts workout calories to prevent double-counting. (`lib/health/health_export.dart`)
* Added export of continuous heart rate data as minute-by-minute averages. (`lib/health/health_export.dart`)
* Included `HealthDataType.HEART_RATE` in the list of exported health data types. (`lib/health/health_export.dart`)

**UI and Code Safety:**
* Improved the `Pressable` widget to check if the widget is still mounted before calling `setState`, preventing possible errors. (`lib/ui/design/pressable.dart`)
* In `StepCalibrationScreen`, cached the `AppState` instance in `initState` to avoid repeated context lookups and ensure proper cleanup. (`lib/ui/today/step_calibration_screen.dart`) [[1]](diffhunk://#diff-57e791d6c57f9eb98c157a30211c8fbe5f06145840ad63bad75edd212e34e09dR31-R36) [[2]](diffhunk://#diff-57e791d6c57f9eb98c157a30211c8fbe5f06145840ad63bad75edd212e34e09dL73-R76)

**Other:**
* Refactored initialization of the `_pulse` animation controller in `_LiveBannerState` to occur in `initState`, aligning with best practices for resource management. (`lib/app.dart`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health data exports now include continuous heart-rate samples.
  * Active and basal energy are exported as hourly samples for improved detail.
* **Bug Fixes**
  * Prevented updates to UI state after pressable widgets are disposed.
  * Improved step-calibration cleanup when leaving the screen.
  * Improved reliability of health export retries and background derivation/sync scheduling.
* **Chores**
  * Refined background job identifiers and added platform-conditional startup cleanup.
  * Improved animation controller initialization for the live banner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->