### PR TITLE
Fix first-run blockers for external contributors on current Flutter and iOS

### DIFF
--- a/ios/OpenStrapWatch Watch App/OpenStrapWatch Watch App.entitlements
+++ b/ios/OpenStrapWatch Watch App/OpenStrapWatch Watch App.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.wtf.openstrap</string>
+		<string>$(APP_GROUP_IDENTIFIER)</string>
 	</array>
 </dict>
 </plist>

--- a/ios/OpenStrapWidget/OpenStrapBatteryWidget.swift
+++ b/ios/OpenStrapWidget/OpenStrapBatteryWidget.swift
@@ -17,7 +17,7 @@
 import WidgetKit
 import SwiftUI
 
-private let kAppGroup = "group.wtf.openstrap"
+private let kAppGroup = AppGroup.identifier
 
 // MARK: - Theme (mirrors OpenStrapWidget's Ember-on-Paper / Char)
 

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -50,7 +50,9 @@ class DefaultFirebaseOptions {
   }
 
   static const FirebaseOptions android = FirebaseOptions(
-    apiKey: 'dummy_api_key_for_android',
+    // Dummy value in the format FirebaseInstallations validates natively
+    // (39 chars, 'A' prefix) — a malformed key is an uncatchable NSException.
+    apiKey: 'AIzaSyDummyDummyDummyDummyDummyDummyDum',
     appId: '1:000000000000:android:0000000000000000000000',
     messagingSenderId: '000000000000',
     projectId: 'dummy-project',
@@ -58,7 +60,8 @@ class DefaultFirebaseOptions {
   );
 
   static const FirebaseOptions ios = FirebaseOptions(
-    apiKey: 'dummy_api_key_for_ios',
+    // See android note: format-valid dummy, never a real key.
+    apiKey: 'AIzaSyDummyDummyDummyDummyDummyDummyDum',
     appId: '1:000000000000:ios:0000000000000000000000',
     messagingSenderId: '000000000000',
     projectId: 'dummy-project',

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2505,7 +2505,15 @@ class AppState extends ChangeNotifier {
 
   Future<bool> bluetoothReady() async {
     if (!await FlutterBluePlus.isSupported) return false;
-    final state = await FlutterBluePlus.adapterState.first;
+    // CoreBluetooth boots in `unknown` before settling — `.first` loses that
+    // race and misreads a powered-on adapter as off. Wait for a determinate
+    // state (bounded, in case it never settles).
+    final state = await FlutterBluePlus.adapterState
+        .firstWhere((s) => s != BluetoothAdapterState.unknown)
+        .timeout(
+          const Duration(seconds: 3),
+          onTimeout: () => BluetoothAdapterState.unknown,
+        );
     return state == BluetoothAdapterState.on;
   }
 

--- a/lib/theme/theme.dart
+++ b/lib/theme/theme.dart
@@ -14,6 +14,7 @@
 // [Palette] (not the live getters) so the light + dark ThemeData objects are
 // each internally consistent regardless of which mode is currently active.
 
+import 'package:flutter/cupertino.dart' show CupertinoPageTransitionsBuilder;
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'page_transitions.dart';

--- a/lib/ui/pairing_screen.dart
+++ b/lib/ui/pairing_screen.dart
@@ -211,19 +211,22 @@ class _ScanStepState extends State<_ScanStep> {
     // On Android / iOS < 18 we use the service-filtered scan flow.
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
+      // ASK first: the picker needs no CoreBluetooth authorization, and before
+      // any accessory is provisioned iOS reports the adapter as unauthorized —
+      // gating on bluetoothReady() here would deadlock the pairing flow.
+      final ask = await context.read<AppState>().accessorySetupSupported();
+      if (!mounted) return;
+      if (ask) {
+        setState(() => _phase = PairPhase.askReady);
+        return;
+      }
       if (!await context.read<AppState>().bluetoothReady()) {
         if (!mounted) return;
         setState(() => _phase = PairPhase.bluetoothOff);
         return;
       }
       if (!mounted) return;
-      final ask = await context.read<AppState>().accessorySetupSupported();
-      if (!mounted) return;
-      if (ask) {
-        setState(() => _phase = PairPhase.askReady);
-      } else {
-        _scan();
-      }
+      _scan();
     });
   }
 


### PR DESCRIPTION
- theme.dart: import CupertinoPageTransitionsBuilder from cupertino (no longer re-exported by material on Flutter 3.44+)
- firebase_options.dart: use a format-valid dummy API key; FirebaseInstallations validates the key format natively and the resulting NSException cannot be caught from Dart, crashing the app at launch on device
- Watch app entitlements: use $(APP_GROUP_IDENTIFIER) instead of the hardcoded group.wtf.openstrap, which breaks signing for any external team
- OpenStrapBatteryWidget: read the app group from AppGroup.identifier instead of a hardcoded constant
- pairing_screen: offer the AccessorySetupKit picker before checking bluetoothReady(); before any ASK-provisioned accessory exists, iOS reports the adapter as unauthorized, so the old order deadlocked pairing behind a false 'Bluetooth is off' screen
- app_state: bluetoothReady() now waits for a determinate adapter state instead of grabbing the initial 'unknown'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth readiness detection during device pairing.
  * Pairing now correctly prioritizes supported iOS 18 accessory selection flows.
  * Prevented pairing from being blocked by Bluetooth’s initial startup state.
  * Improved reliability of shared data between the app and watch/widget.
  * Updated Firebase configuration handling to avoid startup issues with platform validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->