### PR TITLE
Add Tasker action to buzz the whoop, and ability to subscribe to double-tap from Tasker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.fvm
+.fvmrc
 # Miscellaneous
 *.class
 *.log

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -145,7 +145,12 @@
         </receiver>
 
         <!-- Tasker integration: receive Broadcast intents from Tasker (or any app)
-             to buzz the WHOOP strap. Optional int extra "pattern" (default 2). -->
+             to buzz the WHOOP strap. Exported with no manifest permission (a
+             signature permission would block Tasker itself) — TaskerReceiver
+             instead requires a String extra "token" matching the per-install
+             secret shown in Settings -> Automation, plus a short rate limit;
+             anything else is silently dropped. Optional int extra "pattern"
+             (default 2). -->
         <receiver
             android:name=".TaskerReceiver"
             android:exported="true"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -144,6 +144,17 @@
             </intent-filter>
         </receiver>
 
+        <!-- Tasker integration: receive Broadcast intents from Tasker (or any app)
+             to buzz the WHOOP strap. Optional int extra "pattern" (default 2). -->
+        <receiver
+            android:name=".TaskerReceiver"
+            android:exported="true"
+            android:enabled="true">
+            <intent-filter>
+                <action android:name="wtf.openstrap.openstrap_edge.BUZZ_STRAP" />
+            </intent-filter>
+        </receiver>
+
         <!-- Notification relay (notification_listener_service plugin). The system binds
              this to deliver posted notifications; gated behind the user granting
              "Notification access" in system settings. Class lives in the plugin. -->

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/NativeChannels.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/NativeChannels.kt
@@ -29,7 +29,9 @@ object NativeChannels {
     private const val EDGE_TRACKING_CHANNEL = "openstrap/edge_tracking"
     private const val DEVICE_ACTIONS_CHANNEL = "openstrap/device_actions"
     private const val ANDROID_BG_CHANNEL = "openstrap/android_background"
+    const val TASKER_CHANNEL = "openstrap/tasker"
     const val ACTION_DOUBLE_TAP = "wtf.openstrap.openstrap_edge.DOUBLE_TAP"
+    private const val TASKER_TOKEN_KEY = "tasker_auth_token"
 
     private var torchOn = false
 
@@ -116,6 +118,60 @@ object NativeChannels {
                     else -> result.notImplemented()
                 }
             }
+
+        // Tasker integration support. TaskerReceiver (a BroadcastReceiver, not a
+        // Flutter plugin) writes directly to the native "openstrap_runtime"
+        // SharedPreferences file — NOT through the shared_preferences PLUGIN,
+        // which owns a separate, plugin-managed store (its own file, with
+        // flutter.-prefixed keys) that can never see what a native-only
+        // BroadcastReceiver wrote. Dart must go through this channel instead
+        // of SharedPreferences.getInstance() to see/clear the pending buzz, or
+        // to read the per-install auth token TaskerReceiver requires.
+        MethodChannel(engine.dartExecutor.binaryMessenger, TASKER_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                val prefs = app.getSharedPreferences("openstrap_runtime", Context.MODE_PRIVATE)
+                when (call.method) {
+                    "peek_pending_buzz" -> {
+                        val pending = prefs.getBoolean(TaskerReceiver.PENDING_BUZZ_KEY, false)
+                        result.success(
+                            if (pending) {
+                                prefs.getInt(TaskerReceiver.PENDING_PATTERN_KEY, TaskerReceiver.DEFAULT_PATTERN)
+                            } else {
+                                null
+                            }
+                        )
+                    }
+                    "clear_pending_buzz" -> {
+                        prefs.edit()
+                            .remove(TaskerReceiver.PENDING_BUZZ_KEY)
+                            .remove(TaskerReceiver.PENDING_PATTERN_KEY)
+                            .apply()
+                        result.success(null)
+                    }
+                    "get_auth_token" -> result.success(getOrCreateTaskerToken(app))
+                    else -> result.notImplemented()
+                }
+            }
+    }
+
+    /**
+     * Per-install shared secret Tasker (or any automation app) must echo back
+     * as the `token` string extra on a BUZZ_STRAP broadcast (see
+     * TaskerReceiver.onReceive). Generated once and persisted in the native
+     * "openstrap_runtime" prefs; surfaced to Dart (Settings → Automation,
+     * copy-to-clipboard) via [TASKER_CHANNEL]. Without this, the exported,
+     * permission-less receiver would let ANY installed app trigger strap
+     * haptics on demand — including the alarm-mode pattern, which buzzes
+     * until acknowledged. A manifest `android:permission` isn't viable here:
+     * Tasker can't declare a permission for our arbitrary custom string ahead
+     * of time, so it would just block the legitimate use case too.
+     */
+    internal fun getOrCreateTaskerToken(ctx: Context): String {
+        val prefs = ctx.getSharedPreferences("openstrap_runtime", Context.MODE_PRIVATE)
+        prefs.getString(TASKER_TOKEN_KEY, null)?.let { return it }
+        val token = java.util.UUID.randomUUID().toString().replace("-", "")
+        prefs.edit().putString(TASKER_TOKEN_KEY, token).apply()
+        return token
     }
 
     private fun perform(ctx: Context, action: String): Boolean {

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/NativeChannels.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/NativeChannels.kt
@@ -29,6 +29,7 @@ object NativeChannels {
     private const val EDGE_TRACKING_CHANNEL = "openstrap/edge_tracking"
     private const val DEVICE_ACTIONS_CHANNEL = "openstrap/device_actions"
     private const val ANDROID_BG_CHANNEL = "openstrap/android_background"
+    const val ACTION_DOUBLE_TAP = "wtf.openstrap.openstrap_edge.DOUBLE_TAP"
 
     private var torchOn = false
 
@@ -107,7 +108,8 @@ object NativeChannels {
                     "capabilities" -> result.success(
                         listOf(
                             "media_play_pause", "media_next", "media_prev",
-                            "volume_up", "volume_down", "ring_phone", "torch"
+                            "volume_up", "volume_down", "ring_phone", "torch",
+                            "broadcast_to_tasker"
                         )
                     )
                     "perform" -> result.success(perform(app, call.argument<String>("action") ?: ""))
@@ -126,6 +128,7 @@ object NativeChannels {
                 "volume_down" -> adjustVolume(ctx, AudioManager.ADJUST_LOWER)
                 "ring_phone" -> ringPhone(ctx)
                 "torch" -> toggleTorch(ctx)
+                "broadcast_to_tasker" -> sendTaskerBroadcast(ctx)
                 else -> return false
             }
             true
@@ -321,4 +324,17 @@ object NativeChannels {
             vibrator.vibrate(500)
         }
     }
+
+    /** Send a broadcast intent so Tasker (or any automation app) can subscribe
+     * to band double-taps. The intent action is
+     * `wtf.openstrap.openstrap_edge.DOUBLE_TAP`; Tasker listens via
+     * Event → Intent Received.
+     */
+    private fun sendTaskerBroadcast(ctx: Context) {
+        val intent = Intent(ACTION_DOUBLE_TAP).apply {
+            addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
+        }
+        ctx.sendBroadcast(intent)
+    }
+
 }

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/TaskerReceiver.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/TaskerReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.os.SystemClock
 import android.util.Log
 import io.flutter.embedding.engine.FlutterEngineCache
 import io.flutter.plugin.common.MethodChannel
@@ -13,6 +14,26 @@ class TaskerReceiver : BroadcastReceiver() {
         val action = intent.action
         Log.i(TAG, "onReceive: action=$action")
         if (action != ACTION_BUZZ_STRAP) return
+
+        // This receiver is exported with no manifest permission (a signature
+        // permission would block Tasker itself, since it isn't signed by us) —
+        // so anyone who can send an explicit broadcast can reach it. Require a
+        // per-install shared secret the user copies from Settings → Automation
+        // into their Tasker action, plus a short rate limit as defense in
+        // depth. See NativeChannels.getOrCreateTaskerToken.
+        val expected = NativeChannels.getOrCreateTaskerToken(context)
+        val provided = intent.getStringExtra(EXTRA_TOKEN)
+        if (provided == null || provided != expected) {
+            Log.w(TAG, "rejected: missing/incorrect token")
+            return
+        }
+
+        val nowElapsed = SystemClock.elapsedRealtime()
+        if (nowElapsed - lastAcceptedElapsedMs < MIN_INTERVAL_MS) {
+            Log.w(TAG, "rejected: rate-limited (< ${MIN_INTERVAL_MS}ms since last accepted broadcast)")
+            return
+        }
+        lastAcceptedElapsedMs = nowElapsed
 
         val pattern = intent.getIntExtra(EXTRA_PATTERN, DEFAULT_PATTERN)
         Log.i(TAG, "pattern=$pattern")
@@ -26,7 +47,7 @@ class TaskerReceiver : BroadcastReceiver() {
             args["pattern"] = pattern
             MethodChannel(
                 engine.dartExecutor.binaryMessenger,
-                CHANNEL
+                NativeChannels.TASKER_CHANNEL
             ).invokeMethod("buzz_strap", args)
             return
         }
@@ -54,9 +75,16 @@ class TaskerReceiver : BroadcastReceiver() {
         const val ACTION_BUZZ_STRAP =
             "wtf.openstrap.openstrap_edge.BUZZ_STRAP"
         const val EXTRA_PATTERN = "pattern"
+        const val EXTRA_TOKEN = "token"
         const val PENDING_BUZZ_KEY = "pending_tasker_buzz"
         const val PENDING_PATTERN_KEY = "pending_tasker_buzz_pattern"
         const val DEFAULT_PATTERN = 2
-        private const val CHANNEL = "openstrap/tasker"
+        private const val MIN_INTERVAL_MS = 1500L
+
+        // Process-lifetime, not persisted — a fresh process restarting the
+        // rate-limit window on cold start is fine; the goal is only to blunt a
+        // tight resend loop within one running process.
+        @Volatile
+        private var lastAcceptedElapsedMs = 0L
     }
 }

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/TaskerReceiver.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/TaskerReceiver.kt
@@ -4,21 +4,26 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.util.Log
 import io.flutter.embedding.engine.FlutterEngineCache
 import io.flutter.plugin.common.MethodChannel
 
 class TaskerReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val action = intent.action
+        Log.i(TAG, "onReceive: action=$action")
         if (action != ACTION_BUZZ_STRAP) return
 
         val pattern = intent.getIntExtra(EXTRA_PATTERN, DEFAULT_PATTERN)
+        Log.i(TAG, "pattern=$pattern")
 
         val engine = FlutterEngineCache.getInstance()
             .get(EdgeApplication.ENGINE_ID)
 
         if (engine != null) {
-            val args = mapOf("pattern" to pattern)
+            Log.i(TAG, "engine alive, invoking method channel")
+            val args = java.util.HashMap<String, Any>()
+            args["pattern"] = pattern
             MethodChannel(
                 engine.dartExecutor.binaryMessenger,
                 CHANNEL
@@ -26,6 +31,7 @@ class TaskerReceiver : BroadcastReceiver() {
             return
         }
 
+        Log.i(TAG, "engine dead, persisting pending flag")
         val prefs = context.getSharedPreferences(
             "openstrap_runtime",
             Context.MODE_PRIVATE
@@ -44,6 +50,7 @@ class TaskerReceiver : BroadcastReceiver() {
     }
 
     companion object {
+        const val TAG = "TaskerReceiver"
         const val ACTION_BUZZ_STRAP =
             "wtf.openstrap.openstrap_edge.BUZZ_STRAP"
         const val EXTRA_PATTERN = "pattern"

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/TaskerReceiver.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/TaskerReceiver.kt
@@ -15,12 +15,28 @@ class TaskerReceiver : BroadcastReceiver() {
         Log.i(TAG, "onReceive: action=$action")
         if (action != ACTION_BUZZ_STRAP) return
 
+        // The token rides as a plain intent extra. If Tasker (or anything
+        // else) sends this as an IMPLICIT broadcast (no setPackage/
+        // setComponent), Android delivers it to every app on the device with
+        // a matching action intent-filter — including a hostile one that
+        // declares the same action just to eavesdrop on the extras. That app
+        // could then replay the captured token straight at us later. Require
+        // the delivered intent to have been explicitly targeted at this app
+        // (our Settings → Automation copy already instructs "set Package to
+        // wtf.openstrap.openstrap_edge") BEFORE even looking at the token.
+        if (intent.`package` != context.packageName &&
+            intent.component?.packageName != context.packageName
+        ) {
+            Log.w(TAG, "rejected: not explicitly targeted at this app")
+            return
+        }
+
         // This receiver is exported with no manifest permission (a signature
         // permission would block Tasker itself, since it isn't signed by us) —
-        // so anyone who can send an explicit broadcast can reach it. Require a
-        // per-install shared secret the user copies from Settings → Automation
-        // into their Tasker action, plus a short rate limit as defense in
-        // depth. See NativeChannels.getOrCreateTaskerToken.
+        // so anyone who can send an explicitly-targeted broadcast can still
+        // reach it. Require a per-install shared secret the user copies from
+        // Settings → Automation into their Tasker action, plus a short rate
+        // limit as defense in depth. See NativeChannels.getOrCreateTaskerToken.
         val expected = NativeChannels.getOrCreateTaskerToken(context)
         val provided = intent.getStringExtra(EXTRA_TOKEN)
         if (provided == null || provided != expected) {

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/TaskerReceiver.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/TaskerReceiver.kt
@@ -1,0 +1,55 @@
+package wtf.openstrap.openstrap_edge
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import io.flutter.embedding.engine.FlutterEngineCache
+import io.flutter.plugin.common.MethodChannel
+
+class TaskerReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.action
+        if (action != ACTION_BUZZ_STRAP) return
+
+        val pattern = intent.getIntExtra(EXTRA_PATTERN, DEFAULT_PATTERN)
+
+        val engine = FlutterEngineCache.getInstance()
+            .get(EdgeApplication.ENGINE_ID)
+
+        if (engine != null) {
+            val args = mapOf("pattern" to pattern)
+            MethodChannel(
+                engine.dartExecutor.binaryMessenger,
+                CHANNEL
+            ).invokeMethod("buzz_strap", args)
+            return
+        }
+
+        val prefs = context.getSharedPreferences(
+            "openstrap_runtime",
+            Context.MODE_PRIVATE
+        )
+        prefs.edit()
+            .putBoolean(PENDING_BUZZ_KEY, true)
+            .putInt(PENDING_PATTERN_KEY, pattern)
+            .apply()
+
+        val svcIntent = Intent(context, EdgeTrackingService::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(svcIntent)
+        } else {
+            context.startService(svcIntent)
+        }
+    }
+
+    companion object {
+        const val ACTION_BUZZ_STRAP =
+            "wtf.openstrap.openstrap_edge.BUZZ_STRAP"
+        const val EXTRA_PATTERN = "pattern"
+        const val PENDING_BUZZ_KEY = "pending_tasker_buzz"
+        const val PENDING_PATTERN_KEY = "pending_tasker_buzz_pattern"
+        const val DEFAULT_PATTERN = 2
+        private const val CHANNEL = "openstrap/tasker"
+    }
+}

--- a/guides/BUZZ_MEANINGS.md
+++ b/guides/BUZZ_MEANINGS.md
@@ -1,0 +1,8 @@
+* `0`: A quick buzz of the device
+* `1`: An alarm, buzzes until acked by tapping the device
+* `2`: A quick double buzz
+* `3`: Nothing
+* `4`: Nothing
+* `5`: Nothing
+* `6`: Nothing
+* `7`: Nothing

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -2508,8 +2508,10 @@ class BleEngine {
 
   Future<void> getBattery() => _send(Cmd.getBatteryLevel, const []);
   Future<void> getHello() => _send(Cmd.getHelloHarvard, const [0x00]);
-  Future<void> buzz() =>
-      _send(Cmd.runHapticsPattern, const [hapticShortPulse, 0, 0, 0, 0]);
+  Future<void> buzz() => buzzPattern(hapticShortPulse);
+
+  Future<void> buzzPattern(int pattern) =>
+      _send(Cmd.runHapticsPattern, [pattern, 0, 0, 0, 0]);
 
   /// Enable live foreground streams (makes the band emit live R10/R11 + optical).
   /// Optical stays WRIST-GATED (0x6B only). This sends the toggle commands but

--- a/lib/gestures/device_action.dart
+++ b/lib/gestures/device_action.dart
@@ -24,6 +24,9 @@ enum DeviceAction {
   // (iOS can't reach other apps, but it can always do these).
   markMoment,
   workoutToggle,
+  // Native broadcast — sends an Android broadcast intent for Tasker to subscribe
+  // to (see NativeChannels.kt). Only offered on Android.
+  broadcastToTasker,
 }
 
 extension DeviceActionX on DeviceAction {
@@ -51,6 +54,8 @@ extension DeviceActionX on DeviceAction {
         return 'mark_moment';
       case DeviceAction.workoutToggle:
         return 'workout_toggle';
+      case DeviceAction.broadcastToTasker:
+        return 'broadcast_to_tasker';
     }
   }
 
@@ -77,6 +82,8 @@ extension DeviceActionX on DeviceAction {
         return 'Mark a moment';
       case DeviceAction.workoutToggle:
         return 'Start / stop workout';
+      case DeviceAction.broadcastToTasker:
+        return 'Broadcast to Tasker';
     }
   }
 
@@ -103,6 +110,8 @@ extension DeviceActionX on DeviceAction {
         return 'Tag the current moment in your journal.';
       case DeviceAction.workoutToggle:
         return 'Begin or end a workout from your wrist.';
+      case DeviceAction.broadcastToTasker:
+        return 'Fire a broadcast intent so Tasker can trigger any automation.';
     }
   }
 

--- a/lib/platform/tasker_bridge.dart
+++ b/lib/platform/tasker_bridge.dart
@@ -1,11 +1,8 @@
 import 'package:flutter/foundation.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/services.dart';
 
 class TaskerBridge {
   static const _ch = MethodChannel('openstrap/tasker');
-  static const _pendingKey = 'pending_tasker_buzz';
-  static const _pendingPatternKey = 'pending_tasker_buzz_pattern';
 
   final Future<void> Function(int pattern) buzzPattern;
 
@@ -28,13 +25,43 @@ class TaskerBridge {
     }
   }
 
-  static Future<int?> consumePendingBuzz() async {
-    final prefs = await SharedPreferences.getInstance();
-    final pending = prefs.getBool(_pendingKey) ?? false;
-    if (!pending) return null;
-    final pattern = prefs.getInt(_pendingPatternKey) ?? 2;
-    await prefs.remove(_pendingKey);
-    await prefs.remove(_pendingPatternKey);
-    return pattern;
+  /// Read (without clearing) a buzz Tasker requested while the app was fully
+  /// dead — see TaskerReceiver.kt's "engine dead" fallback. This goes through
+  /// a native method-channel call reading the SAME native SharedPreferences
+  /// file ("openstrap_runtime") TaskerReceiver writes to directly. The
+  /// `shared_preferences` PLUGIN reads/writes a DIFFERENT, plugin-managed
+  /// store (its own file, `flutter.`-prefixed keys) — it can never see what
+  /// TaskerReceiver persisted, so do not "simplify" this back to
+  /// `SharedPreferences.getInstance()`.
+  static Future<int?> peekPendingBuzz() async {
+    try {
+      return await _ch.invokeMethod<int>('peek_pending_buzz');
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Clear the pending flag. Call ONLY after the buzz was actually delivered
+  /// (see AppState._checkPendingTaskerBuzz) — never as part of the read —
+  /// so a request that couldn't be sent yet (no BLE connection) survives to
+  /// the next attempt instead of being silently dropped.
+  static Future<void> clearPendingBuzz() async {
+    try {
+      await _ch.invokeMethod('clear_pending_buzz');
+    } catch (_) {}
+  }
+
+  /// The per-install secret Tasker (or any automation app) must echo back as
+  /// the `token` string extra on its BUZZ_STRAP broadcast — generated once
+  /// and persisted natively on first request. Surfaced in Settings →
+  /// Automation for the user to copy into their Tasker action; without it,
+  /// the exported, permission-less receiver would let any installed app
+  /// trigger strap haptics. Returns null only on a channel/platform failure.
+  static Future<String?> authToken() async {
+    try {
+      return await _ch.invokeMethod<String>('get_auth_token');
+    } catch (_) {
+      return null;
+    }
   }
 }

--- a/lib/platform/tasker_bridge.dart
+++ b/lib/platform/tasker_bridge.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/services.dart';
 
@@ -14,8 +15,16 @@ class TaskerBridge {
 
   Future<void> _onMethodCall(MethodCall call) async {
     if (call.method == 'buzz_strap') {
-      final pattern = (call.arguments as Map?)?['pattern'] as int? ?? 2;
-      await buzzPattern(pattern);
+      try {
+        final args = call.arguments;
+        debugPrint('[tasker] _onMethodCall args=$args (${args.runtimeType})');
+        final map = args is Map ? args : <dynamic, dynamic>{};
+        final pattern = (map['pattern'] as int?) ?? 2;
+        debugPrint('[tasker] buzz pattern=$pattern');
+        await buzzPattern(pattern);
+      } catch (e, st) {
+        debugPrint('[tasker] buzz failed: $e\n$st');
+      }
     }
   }
 

--- a/lib/platform/tasker_bridge.dart
+++ b/lib/platform/tasker_bridge.dart
@@ -1,0 +1,31 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/services.dart';
+
+class TaskerBridge {
+  static const _ch = MethodChannel('openstrap/tasker');
+  static const _pendingKey = 'pending_tasker_buzz';
+  static const _pendingPatternKey = 'pending_tasker_buzz_pattern';
+
+  final Future<void> Function(int pattern) buzzPattern;
+
+  TaskerBridge({required this.buzzPattern}) {
+    _ch.setMethodCallHandler(_onMethodCall);
+  }
+
+  Future<void> _onMethodCall(MethodCall call) async {
+    if (call.method == 'buzz_strap') {
+      final pattern = (call.arguments as Map?)?['pattern'] as int? ?? 2;
+      await buzzPattern(pattern);
+    }
+  }
+
+  static Future<int?> consumePendingBuzz() async {
+    final prefs = await SharedPreferences.getInstance();
+    final pending = prefs.getBool(_pendingKey) ?? false;
+    if (!pending) return null;
+    final pattern = prefs.getInt(_pendingPatternKey) ?? 2;
+    await prefs.remove(_pendingKey);
+    await prefs.remove(_pendingPatternKey);
+    return pattern;
+  }
+}

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1285,10 +1285,40 @@ class AppState extends ChangeNotifier {
 
   Future<void> _checkPendingTaskerBuzz() async {
     if (!Platform.isAndroid) return;
-    final pattern = await TaskerBridge.consumePendingBuzz();
+    final pattern = await TaskerBridge.peekPendingBuzz();
     if (pattern == null) return;
+    // A Tasker BUZZ_STRAP can arrive while the app is fully dead; the
+    // reconnect this _init() already kicked off may not have landed by the
+    // time we get here. Wait (bounded) for a live link rather than firing
+    // into a not-yet-connected engine and silently losing the request — and
+    // only clear the persisted flag once we actually attempt delivery on a
+    // live connection, so a request that times out here survives for the
+    // next app-open / service-start to retry instead of vanishing.
+    final connected = await _waitUntil(
+      () => engine.isConnected,
+      const Duration(seconds: 20),
+    );
+    if (!connected) {
+      _log('[tasker] pending buzz (pattern=$pattern) still queued — '
+          'no connection within 20s, leaving it for the next attempt');
+      return;
+    }
     _log('[tasker] consuming pending buzz (pattern=$pattern) from headless intent');
     await engine.buzzPattern(pattern);
+    await TaskerBridge.clearPendingBuzz();
+  }
+
+  /// Poll [check] every 500ms until it's true or [timeout] elapses. Small and
+  /// generic on purpose — currently only used for the Tasker pending-buzz
+  /// handoff, which needs to wait for a real BLE connection rather than a
+  /// fixed delay.
+  Future<bool> _waitUntil(bool Function() check, Duration timeout) async {
+    final deadline = DateTime.now().add(timeout);
+    while (!check()) {
+      if (DateTime.now().isAfter(deadline)) return check();
+      await Future.delayed(const Duration(milliseconds: 500));
+    }
+    return true;
   }
 
   /// (Re)register standing scheduled reminders per the user's prefs. Idempotent;

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -657,6 +657,7 @@ class AppState extends ChangeNotifier {
     // skip the headless BLE path (it would fight FBP for the peripheral) — route
     // them to a catch-up pull over the existing live connection instead.
     IosBgTask.foregroundPull = foregroundCatchUp;
+    taskerBridge; // force init: register the method channel handler
     _init();
     // Notification taps → request a tab switch (the shell listens to navRequest).
     _tapSub = NotificationService.instance.taps.listen(_handleTapRoute);

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -51,6 +51,7 @@ import '../health/health_export.dart';
 import '../import/noop_import.dart';
 import '../import/whoop_import.dart';
 import '../gestures/gesture_dispatcher.dart';
+import '../platform/tasker_bridge.dart';
 import '../data/models.dart';
 import '../live/live_activity.dart';
 import '../live/breathing_live_activity.dart';
@@ -124,6 +125,12 @@ class AppState extends ChangeNotifier {
   late final WaterBuzzer _waterBuzzer = WaterBuzzer(
     buzz: () => engine.buzz(),
     isConnected: () => engine.isConnected,
+  );
+
+  /// Tasker integration bridge — listens for Android broadcast intents from
+  /// Tasker and buzzes the strap. Wired in the constructor.
+  late final TaskerBridge taskerBridge = TaskerBridge(
+    buzzPattern: (p) => engine.buzzPattern(p),
   );
   Sample? lastSynced;
   // REAL device time (epoch SECONDS) of the newest record we hold — the band's
@@ -1272,6 +1279,15 @@ class AppState extends ChangeNotifier {
         openSession();
       }
     }
+    unawaited(_checkPendingTaskerBuzz());
+  }
+
+  Future<void> _checkPendingTaskerBuzz() async {
+    if (!Platform.isAndroid) return;
+    final pattern = await TaskerBridge.consumePendingBuzz();
+    if (pattern == null) return;
+    _log('[tasker] consuming pending buzz (pattern=$pattern) from headless intent');
+    await engine.buzzPattern(pattern);
   }
 
   /// (Re)register standing scheduled reminders per the user's prefs. Idempotent;
@@ -2020,6 +2036,11 @@ class AppState extends ChangeNotifier {
   Future<void> testAlarmBuzz() async {
     if (!isConnected) throw Exception('Connect to your strap first');
     await engine.runAlarm();
+  }
+
+  Future<void> testBuzzPattern(int pattern) async {
+    if (!isConnected) throw Exception('Connect to your strap first');
+    await engine.buzzPattern(pattern);
   }
 
   Future<void> disableAlarm() async {

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1283,29 +1283,45 @@ class AppState extends ChangeNotifier {
     unawaited(_checkPendingTaskerBuzz());
   }
 
+  // Single-flight guard for _checkPendingTaskerBuzz — it's now invoked both
+  // from _init() and from every "became connected" transition
+  // (_onEngineState), so an overlapping call (e.g. a connect landing while
+  // the _init()-triggered call is still in its bounded wait) must no-op
+  // rather than race a second concurrent buzz/clear.
+  bool _taskerBuzzCheckInFlight = false;
+
   Future<void> _checkPendingTaskerBuzz() async {
     if (!Platform.isAndroid) return;
-    final pattern = await TaskerBridge.peekPendingBuzz();
-    if (pattern == null) return;
-    // A Tasker BUZZ_STRAP can arrive while the app is fully dead; the
-    // reconnect this _init() already kicked off may not have landed by the
-    // time we get here. Wait (bounded) for a live link rather than firing
-    // into a not-yet-connected engine and silently losing the request — and
-    // only clear the persisted flag once we actually attempt delivery on a
-    // live connection, so a request that times out here survives for the
-    // next app-open / service-start to retry instead of vanishing.
-    final connected = await _waitUntil(
-      () => engine.isConnected,
-      const Duration(seconds: 20),
-    );
-    if (!connected) {
-      _log('[tasker] pending buzz (pattern=$pattern) still queued — '
-          'no connection within 20s, leaving it for the next attempt');
-      return;
+    if (_taskerBuzzCheckInFlight) return;
+    _taskerBuzzCheckInFlight = true;
+    try {
+      final pattern = await TaskerBridge.peekPendingBuzz();
+      if (pattern == null) return;
+      // A Tasker BUZZ_STRAP can arrive while the app is fully dead; the
+      // reconnect this _init() already kicked off may not have landed by the
+      // time we get here. Wait (bounded) for a live link rather than firing
+      // into a not-yet-connected engine and silently losing the request —
+      // and only clear the persisted flag once we actually attempt delivery
+      // on a live connection. If this 20s wait still times out, the request
+      // is NOT lost: _onEngineState calls back in here on every subsequent
+      // "became connected" transition for the rest of this process's life,
+      // so a slower reconnect still eventually delivers it instead of
+      // requiring a full app restart.
+      final connected = await _waitUntil(
+        () => engine.isConnected,
+        const Duration(seconds: 20),
+      );
+      if (!connected) {
+        _log('[tasker] pending buzz (pattern=$pattern) still queued — '
+            'no connection within 20s, will retry on the next reconnect');
+        return;
+      }
+      _log('[tasker] consuming pending buzz (pattern=$pattern) from headless intent');
+      await engine.buzzPattern(pattern);
+      await TaskerBridge.clearPendingBuzz();
+    } finally {
+      _taskerBuzzCheckInFlight = false;
     }
-    _log('[tasker] consuming pending buzz (pattern=$pattern) from headless intent');
-    await engine.buzzPattern(pattern);
-    await TaskerBridge.clearPendingBuzz();
   }
 
   /// Poll [check] every 500ms until it's true or [timeout] elapses. Small and
@@ -1762,6 +1778,16 @@ class AppState extends ChangeNotifier {
       } else {
         _releaseForegroundLease();
       }
+    }
+    if (_prevConn != 'connected' && s.connection == 'connected') {
+      // A Tasker BUZZ_STRAP that arrived while disconnected/dead only gets a
+      // bounded wait inside _checkPendingTaskerBuzz (called from _init()) —
+      // if that timed out before this connection landed, nothing else was
+      // going to retry it before a full process restart (see PR #89 review).
+      // Re-check on every fresh "became connected" transition instead; the
+      // method no-ops instantly if nothing's pending, and is single-flight
+      // guarded against overlapping with its own in-progress wait.
+      unawaited(_checkPendingTaskerBuzz());
     }
     _prevConn = s.connection;
     notifyListeners();

--- a/lib/ui/profile/gesture_section.dart
+++ b/lib/ui/profile/gesture_section.dart
@@ -59,25 +59,34 @@ class GestureSettingsCard extends StatelessWidget {
                 Text('What happens when you double-tap the band.',
                     style: AppText.captionMuted),
                 const SizedBox(height: Sp.x4),
-                ...options.map((a) {
-                  final selected = a == settings.doubleTap;
-                  return ListRow(
-                    title: a.label,
-                    subtitle: a.blurb,
-                    trailing: selected
-                        ? AppIcon(OsIcon.check, size: 20, color: AppColors.positive)
-                        : const SizedBox(width: 20),
-                    onTap: () {
-                      settings.setDoubleTap(a);
-                      Navigator.of(sheetCtx).pop();
-                    },
-                  );
-                }),
-                if (options.length <= 1) ...[
-                  const SizedBox(height: Sp.x3),
-                  Text('No band actions are available on this device yet.',
-                      style: AppText.caption),
-                ],
+                Flexible(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        ...options.map((a) {
+                          final selected = a == settings.doubleTap;
+                          return ListRow(
+                            title: a.label,
+                            subtitle: a.blurb,
+                            trailing: selected
+                                ? AppIcon(OsIcon.check, size: 20, color: AppColors.positive)
+                                : const SizedBox(width: 20),
+                            onTap: () {
+                              settings.setDoubleTap(a);
+                              Navigator.of(sheetCtx).pop();
+                            },
+                          );
+                        }),
+                        if (options.length <= 1) ...[
+                          const SizedBox(height: Sp.x3),
+                          Text('No band actions are available on this device yet.',
+                              style: AppText.caption),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
               ],
             ),
           ),

--- a/lib/ui/profile/profile_screen.dart
+++ b/lib/ui/profile/profile_screen.dart
@@ -17,6 +17,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../../data/db.dart';
 import '../../health/health_export.dart';
+import '../../platform/tasker_bridge.dart';
 import '../../state/app_state.dart';
 import '../../state/units_controller.dart';
 import '../../debug/debug_mode.dart';
@@ -351,50 +352,62 @@ class ProfileScreen extends StatelessWidget {
           const SizedBox(height: Sp.x6),
 
           // ── Automation (Tasker) ──────────────────────────────────────
-          const SectionHeader('Automation'),
-          _SettingsCard(rows: [
-            GestureDetector(
-              onLongPress: () {
-                Clipboard.setData(
-                  const ClipboardData(text: 'wtf.openstrap.openstrap_edge.BUZZ_STRAP'),
-                );
-                _snack(context, 'Copied BUZZ_STRAP action.');
-              },
-              child: ListRow(
-                icon: OsIcon.activity,
-                title: 'Tasker buzz strap',
-                subtitle: 'wtf.openstrap.openstrap_edge.BUZZ_STRAP',
-                onTap: null,
+          // Android-only: TaskerReceiver + the broadcast_to_tasker capability
+          // have no iOS counterpart (same convention as _KeepAliveRow above).
+          if (Platform.isAndroid) ...[
+            const SectionHeader('Automation'),
+            _SettingsCard(rows: [
+              GestureDetector(
+                onLongPress: () async {
+                  await Clipboard.setData(
+                    const ClipboardData(text: 'wtf.openstrap.openstrap_edge.BUZZ_STRAP'),
+                  );
+                  if (context.mounted) {
+                    _snack(context, 'Copied BUZZ_STRAP action.');
+                  }
+                },
+                child: ListRow(
+                  icon: OsIcon.activity,
+                  title: 'Tasker buzz strap',
+                  subtitle: 'wtf.openstrap.openstrap_edge.BUZZ_STRAP',
+                  divider: true,
+                  onTap: null,
+                ),
               ),
+              const _TaskerTokenRow(),
+            ]),
+            const _CardNote(
+              'Send a Broadcast intent from Tasker or any automation app to '
+              'vibrate your WHOOP strap. On Android 12+, set Package to '
+              'wtf.openstrap.openstrap_edge. Requires a String extra "token" '
+              'matching the automation token below (long-press to copy) — '
+              'without it, the strap won\'t buzz. Optional int extra '
+              '"pattern" (default 2).',
             ),
-          ]),
-          const _CardNote(
-            'Send a Broadcast intent from Tasker or any automation app to '
-            'vibrate your WHOOP strap. On Android 12+, set Package to '
-            'wtf.openstrap.openstrap_edge. Optional int extra "pattern" (default 2).',
-          ),
-          const SizedBox(height: Sp.x3),
-          _SettingsCard(rows: [
-            GestureDetector(
-              onLongPress: () {
-                Clipboard.setData(
-                  const ClipboardData(text: 'wtf.openstrap.openstrap_edge.DOUBLE_TAP'),
-                );
-                _snack(context, 'Copied DOUBLE_TAP action.');
-              },
-              child: ListRow(
-                icon: OsIcon.activity,
-                title: 'Double-tap broadcast',
-                subtitle: 'wtf.openstrap.openstrap_edge.DOUBLE_TAP',
-                onTap: null,
+            const SizedBox(height: Sp.x3),
+            _SettingsCard(rows: [
+              GestureDetector(
+                onLongPress: () async {
+                  await Clipboard.setData(
+                    const ClipboardData(text: 'wtf.openstrap.openstrap_edge.DOUBLE_TAP'),
+                  );
+                  if (context.mounted) {
+                    _snack(context, 'Copied DOUBLE_TAP action.');
+                  }
+                },
+                child: ListRow(
+                  icon: OsIcon.activity,
+                  title: 'Double-tap broadcast',
+                  subtitle: 'wtf.openstrap.openstrap_edge.DOUBLE_TAP',
+                  onTap: null,
+                ),
               ),
+            ]),
+            const _CardNote(
+              'Set double-tap gesture to "Broadcast to Tasker", then create '
+              'a Tasker profile: Event → Intent Received → action above.',
             ),
-          ]),
-          const _CardNote(
-            'Set double-tap gesture to "Broadcast to Tasker", then create '
-            'a Tasker profile: Event → Intent Received → action above.',
-          ),
-
+          ],
           const SizedBox(height: Sp.x6),
 
           // ── Notifications ────────────────────────────────────────────
@@ -678,6 +691,48 @@ class _CardNote extends StatelessWidget {
         padding: const EdgeInsets.only(top: Sp.x2, left: Sp.x2),
         child: Text(text, style: AppText.captionMuted),
       );
+}
+
+/// The per-install secret TaskerReceiver requires as the `token` extra on a
+/// BUZZ_STRAP broadcast (see TaskerBridge.authToken / TaskerReceiver.kt).
+/// Fetched once natively (a StatefulWidget so it survives ProfileScreen's
+/// frequent context.watch() rebuilds rather than re-fetching every time).
+class _TaskerTokenRow extends StatefulWidget {
+  const _TaskerTokenRow();
+  @override
+  State<_TaskerTokenRow> createState() => _TaskerTokenRowState();
+}
+
+class _TaskerTokenRowState extends State<_TaskerTokenRow> {
+  String? _token;
+
+  @override
+  void initState() {
+    super.initState();
+    TaskerBridge.authToken().then((t) {
+      if (mounted) setState(() => _token = t);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final token = _token;
+    return GestureDetector(
+      onLongPress: token == null
+          ? null
+          : () async {
+              await Clipboard.setData(ClipboardData(text: token));
+              if (context.mounted) {
+                _snack(context, 'Copied automation token.');
+              }
+            },
+      child: ListRow(
+        icon: OsIcon.activity,
+        title: 'Automation token',
+        subtitle: token ?? 'Loading…',
+      ),
+    );
+  }
 }
 
 /// A titled toggle card (icon tile + title + one-liner + Switch).

--- a/lib/ui/profile/profile_screen.dart
+++ b/lib/ui/profile/profile_screen.dart
@@ -361,7 +361,8 @@ class ProfileScreen extends StatelessWidget {
           ]),
           const _CardNote(
             'Send a Broadcast intent from Tasker or any automation app to '
-            'vibrate your WHOOP strap. Optional int extra "pattern" (default 2).',
+            'vibrate your WHOOP strap. On Android 12+, set Package to '
+            'wtf.openstrap.openstrap_edge. Optional int extra "pattern" (default 2).',
           ),
 
           const SizedBox(height: Sp.x6),

--- a/lib/ui/profile/profile_screen.dart
+++ b/lib/ui/profile/profile_screen.dart
@@ -349,6 +349,23 @@ class ProfileScreen extends StatelessWidget {
 
           const SizedBox(height: Sp.x6),
 
+          // ── Automation (Tasker) ──────────────────────────────────────
+          const SectionHeader('Automation'),
+          _SettingsCard(rows: [
+            ListRow(
+              icon: OsIcon.activity,
+              title: 'Tasker buzz strap',
+              subtitle: 'wtf.openstrap.openstrap_edge.BUZZ_STRAP',
+              onTap: null,
+            ),
+          ]),
+          const _CardNote(
+            'Send a Broadcast intent from Tasker or any automation app to '
+            'vibrate your WHOOP strap. Optional int extra "pattern" (default 2).',
+          ),
+
+          const SizedBox(height: Sp.x6),
+
           // ── Notifications ────────────────────────────────────────────
           const SectionHeader('Notifications'),
           _SettingsCard(rows: [
@@ -1267,6 +1284,40 @@ class _DeviceSheet extends StatelessWidget {
               ),
             ]),
           ),
+        if (connected) ...[
+          const SizedBox(height: Sp.x2),
+          Text('Buzz patterns', style: AppText.captionMuted),
+          const SizedBox(height: Sp.x2),
+          Wrap(
+            spacing: Sp.x2,
+            runSpacing: Sp.x2,
+            children: [
+              for (final p in [0, 1, 2, 3, 4, 5, 6, 7])
+                SizedBox(
+                  width: 48,
+                  height: 48,
+                  child: OutlinedButton(
+                    onPressed: () async {
+                      try {
+                        await live.testBuzzPattern(p);
+                        if (context.mounted) {
+                          _snack(context, 'Pattern $p sent.');
+                        }
+                      } catch (e) {
+                        if (context.mounted) {
+                          _snack(context, 'Pattern $p failed: $e');
+                        }
+                      }
+                    },
+                    style: OutlinedButton.styleFrom(
+                      padding: EdgeInsets.zero,
+                    ),
+                    child: Text('$p', style: AppText.body),
+                  ),
+                ),
+            ],
+          ),
+        ],
         Divider(height: Sp.x4, thickness: 1, color: AppColors.divider),
         ListRow(
           icon: OsIcon.info,

--- a/lib/ui/profile/profile_screen.dart
+++ b/lib/ui/profile/profile_screen.dart
@@ -10,6 +10,7 @@
 import 'dart:io' show Platform;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -352,17 +353,46 @@ class ProfileScreen extends StatelessWidget {
           // ── Automation (Tasker) ──────────────────────────────────────
           const SectionHeader('Automation'),
           _SettingsCard(rows: [
-            ListRow(
-              icon: OsIcon.activity,
-              title: 'Tasker buzz strap',
-              subtitle: 'wtf.openstrap.openstrap_edge.BUZZ_STRAP',
-              onTap: null,
+            GestureDetector(
+              onLongPress: () {
+                Clipboard.setData(
+                  const ClipboardData(text: 'wtf.openstrap.openstrap_edge.BUZZ_STRAP'),
+                );
+                _snack(context, 'Copied BUZZ_STRAP action.');
+              },
+              child: ListRow(
+                icon: OsIcon.activity,
+                title: 'Tasker buzz strap',
+                subtitle: 'wtf.openstrap.openstrap_edge.BUZZ_STRAP',
+                onTap: null,
+              ),
             ),
           ]),
           const _CardNote(
             'Send a Broadcast intent from Tasker or any automation app to '
             'vibrate your WHOOP strap. On Android 12+, set Package to '
             'wtf.openstrap.openstrap_edge. Optional int extra "pattern" (default 2).',
+          ),
+          const SizedBox(height: Sp.x3),
+          _SettingsCard(rows: [
+            GestureDetector(
+              onLongPress: () {
+                Clipboard.setData(
+                  const ClipboardData(text: 'wtf.openstrap.openstrap_edge.DOUBLE_TAP'),
+                );
+                _snack(context, 'Copied DOUBLE_TAP action.');
+              },
+              child: ListRow(
+                icon: OsIcon.activity,
+                title: 'Double-tap broadcast',
+                subtitle: 'wtf.openstrap.openstrap_edge.DOUBLE_TAP',
+                onTap: null,
+              ),
+            ),
+          ]),
+          const _CardNote(
+            'Set double-tap gesture to "Broadcast to Tasker", then create '
+            'a Tasker profile: Event → Intent Received → action above.',
           ),
 
           const SizedBox(height: Sp.x6),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -884,10 +884,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1396,26 +1396,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   timezone:
     dependency: "direct main"
     description:


### PR DESCRIPTION
NOTE: I have zero experience with Android development so this is heavily vibe-coded. Happy to do any testing or UI changes you see fit! Just wanted to put something up while the fire is hot.

So far, I've tested that the Tasker actions work in both directions. A double-tap can trigger profiles, and with Send Intent you can vibrate the whoop from any Tasker task.

Long-press on the action names in the menu to copy to clipboard.

As a bonus, this fixes scrolling on the double-tap menu, which previously ran off the bottom of the screen and couldn't be scrolled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Tasker automation support to trigger strap buzzes and respond to double-tap gestures.
  * Introduced a “Broadcast to Tasker” device action with configurable buzz patterns (0–7), plus clipboard copy for Tasker intent actions and an automation token helper.
  * Added in-app buzz pattern testing for connected devices.
* **Bug Fixes**
  * Improved the double-tap band action picker layout so options remain usable via scrolling on smaller screens.
* **Documentation**
  * Updated buzz pattern meanings for codes 0–7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->