### PR TITLE
feat(notify): buzz the strap for incoming phone calls

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,9 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- Band-gesture "ring my phone" haptic. Normal permission, no runtime prompt. -->
     <uses-permission android:name="android.permission.VIBRATE" />
+    <!-- Incoming-call strap buzz: observe the RINGING/OFFHOOK/IDLE call state only.
+         Runtime permission; numbers are never read (no READ_CALL_LOG). -->
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <!-- Reboot survival: restart EdgeTrackingService + headless auto-connect after device reboot. -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <!-- CompanionDeviceManager: association makes us a "companion app" (exempt from the

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/CallStateBridge.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/CallStateBridge.kt
@@ -1,0 +1,162 @@
+package wtf.openstrap.openstrap_edge
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.telephony.PhoneStateListener
+import android.telephony.TelephonyCallback
+import android.telephony.TelephonyManager
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Telephony bridge for the incoming-call strap buzz (see lib/notify/call_buzzer.dart).
+ *
+ * Ringing is NOT observable through the notification relay: dialers post the
+ * incoming-call notification as ONGOING (which the relay rightly skips as
+ * "not a ping"), and the dialer itself is a system app the picker hides. So the
+ * Dart side gets a dedicated call-state stream instead: "ringing" | "offhook" |
+ * "idle", straight from TelephonyManager.
+ *
+ * Registered on the long-lived engine (see EdgeApplication) with the application
+ * Context, so the stream keeps flowing while the app is backgrounded. Only the
+ * call STATE is read — never numbers: READ_PHONE_STATE without READ_CALL_LOG
+ * doesn't expose them (and we don't ask).
+ */
+object CallStateBridge {
+    private const val METHOD_CHANNEL = "openstrap/call_state"
+    private const val EVENT_CHANNEL = "openstrap/call_state_events"
+
+    /** Unique within the app; MainActivity routes matching results back here. */
+    private const val PERMISSION_REQUEST_CODE = 4207
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var pendingPermissionResult: MethodChannel.Result? = null
+
+    private var telephony: TelephonyManager? = null
+    private var sink: EventChannel.EventSink? = null
+    // Exactly one of these is registered, by API level. Kept to unregister on cancel.
+    private var modernCallback: TelephonyCallback? = null
+    private var legacyListener: PhoneStateListener? = null
+
+    fun register(engine: FlutterEngine, context: Context) {
+        val app = context.applicationContext
+        MethodChannel(engine.dartExecutor.binaryMessenger, METHOD_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "isPermissionGranted" -> result.success(hasPermission(app))
+                    "requestPermission" -> requestPermission(result)
+                    else -> result.notImplemented()
+                }
+            }
+        EventChannel(engine.dartExecutor.binaryMessenger, EVENT_CHANNEL)
+            .setStreamHandler(object : EventChannel.StreamHandler {
+                override fun onListen(args: Any?, events: EventChannel.EventSink) {
+                    sink = events
+                    startListening(app)
+                }
+
+                override fun onCancel(args: Any?) {
+                    stopListening()
+                    sink = null
+                }
+            })
+    }
+
+    private fun hasPermission(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE) ==
+            PackageManager.PERMISSION_GRANTED
+
+    private fun requestPermission(result: MethodChannel.Result) {
+        // Needs a foreground Activity for the system dialog — borrow the one
+        // CompanionBridge already tracks. Absent (headless) → report ungranted;
+        // the Dart side re-reads the real grant afterwards anyway.
+        val activity = CompanionBridge.currentActivity
+        if (activity == null) {
+            result.success(false)
+            return
+        }
+        if (hasPermission(activity)) {
+            result.success(true)
+            return
+        }
+        pendingPermissionResult?.success(false) // supersede a stale in-flight request
+        pendingPermissionResult = result
+        ActivityCompat.requestPermissions(
+            activity,
+            arrayOf(Manifest.permission.READ_PHONE_STATE),
+            PERMISSION_REQUEST_CODE,
+        )
+    }
+
+    /** MainActivity forwards permission results here. Returns true when consumed. */
+    fun handlePermissionResult(requestCode: Int, grantResults: IntArray): Boolean {
+        if (requestCode != PERMISSION_REQUEST_CODE) return false
+        val granted = grantResults.isNotEmpty() &&
+            grantResults[0] == PackageManager.PERMISSION_GRANTED
+        pendingPermissionResult?.success(granted)
+        pendingPermissionResult = null
+        return true
+    }
+
+    private fun stateName(state: Int): String = when (state) {
+        TelephonyManager.CALL_STATE_RINGING -> "ringing"
+        TelephonyManager.CALL_STATE_OFFHOOK -> "offhook"
+        else -> "idle"
+    }
+
+    // EventSink must be driven from the main thread; telephony callbacks may not be.
+    private fun emit(state: String) {
+        mainHandler.post { sink?.success(state) }
+    }
+
+    private fun startListening(context: Context) {
+        stopListening()
+        // Without the grant, registering throws — stay silent; the Dart side only
+        // subscribes when granted, and re-subscribes after a fresh grant.
+        if (!hasPermission(context)) return
+        val tm = context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
+            ?: return
+        telephony = tm
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                val cb = object : TelephonyCallback(), TelephonyCallback.CallStateListener {
+                    override fun onCallStateChanged(state: Int) = emit(stateName(state))
+                }
+                modernCallback = cb
+                tm.registerTelephonyCallback(ContextCompat.getMainExecutor(context), cb)
+            } else {
+                @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+                val listener = object : PhoneStateListener() {
+                    override fun onCallStateChanged(state: Int, phoneNumber: String?) =
+                        emit(stateName(state))
+                }
+                legacyListener = listener
+                @Suppress("DEPRECATION")
+                tm.listen(listener, PhoneStateListener.LISTEN_CALL_STATE)
+            }
+        } catch (_: SecurityException) {
+            // Grant revoked between the check and the register — stay inert.
+        }
+    }
+
+    private fun stopListening() {
+        val tm = telephony
+        if (tm != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                modernCallback?.let { tm.unregisterTelephonyCallback(it) }
+            }
+            @Suppress("DEPRECATION")
+            legacyListener?.let { tm.listen(it, PhoneStateListener.LISTEN_NONE) }
+        }
+        modernCallback = null
+        legacyListener = null
+        telephony = null
+    }
+}

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/EdgeApplication.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/EdgeApplication.kt
@@ -34,6 +34,7 @@ class EdgeApplication : Application() {
         // Register platform channels on the engine BEFORE Dart starts, so they exist even
         // when no Activity is attached (headless calls like EdgeTracking.start must work).
         NativeChannels.register(engine, applicationContext)
+        CallStateBridge.register(engine, applicationContext)
         engine.dartExecutor.executeDartEntrypoint(
             DartExecutor.DartEntrypoint.createDefault()
         )

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/MainActivity.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/MainActivity.kt
@@ -59,6 +59,18 @@ class MainActivity : FlutterFragmentActivity() {
         super.onDestroy()
     }
 
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        // READ_PHONE_STATE dialog result → CallStateBridge (consumed there).
+        if (CallStateBridge.handlePermissionResult(requestCode, grantResults)) {
+            return
+        }
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+    }
+
     @Deprecated("Deprecated in AndroidX; Flutter still routes plugin results through it")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         // CDM association dialog result → CompanionBridge (consumed there).

--- a/lib/notify/call_buzzer.dart
+++ b/lib/notify/call_buzzer.dart
@@ -58,6 +58,7 @@ class CallBuzzer extends ChangeNotifier with WidgetsBindingObserver {
 
   StreamSubscription<dynamic>? _sub;
   Timer? _ringTimer;
+  bool _ringing = false; // true from first 'ringing' until idle/offhook
   int _buzzCount = 0;
 
   /// Load saved state, refresh permission, and start listening if active. Call
@@ -158,12 +159,17 @@ class CallBuzzer extends ChangeNotifier with WidgetsBindingObserver {
   }
 
   void _startRinging() {
-    if (_ringTimer != null) return; // already mid-cadence — don't restart it
+    if (_ringing) return; // already this ring — don't restart the cadence
+    _ringing = true;
     _buzzCount = 0;
     _fireBuzz();
     _ringTimer = Timer.periodic(repeatEvery, (_) {
       if (_buzzCount >= maxBuzzes) {
-        _stopRinging(); // stuck RINGING — stop after ~one full ring
+        // Stuck RINGING — stop buzzing after ~one full ring, but stay marked
+        // as ringing so a duplicate 'ringing' event for the SAME call can't
+        // start a fresh cadence. Only a terminal state (idle/offhook) clears it.
+        _ringTimer?.cancel();
+        _ringTimer = null;
         return;
       }
       _fireBuzz();
@@ -173,6 +179,7 @@ class CallBuzzer extends ChangeNotifier with WidgetsBindingObserver {
   void _stopRinging() {
     _ringTimer?.cancel();
     _ringTimer = null;
+    _ringing = false;
     _buzzCount = 0;
   }
 

--- a/lib/notify/call_buzzer.dart
+++ b/lib/notify/call_buzzer.dart
@@ -1,0 +1,193 @@
+// call_buzzer.dart — buzz the strap while the phone is RINGING. ANDROID ONLY: it
+// rides a tiny native telephony bridge (CallStateBridge.kt), because ringing is
+// not observable through the notification relay — dialers post the incoming-call
+// notification as ONGOING (which the relay rightly skips as "not a ping"), and
+// the dialer is a system app the app picker hides. iOS has no API to observe the
+// native ringer at all, so on iOS this whole feature is inert and never shown.
+//
+// Flow: user flips the toggle → we ask for READ_PHONE_STATE (call STATE only —
+// numbers are never read) → subscribe to the native ringing/offhook/idle stream
+// → while ringing, buzz the band on a fixed cadence so the ring is hard to miss,
+// and stop the instant the call is answered, declined, or rings out. Same
+// persisted ChangeNotifier idiom as NotificationRelay so the settings UI is live.
+
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/services.dart' show EventChannel, MethodChannel;
+import 'package:flutter/widgets.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class CallBuzzer extends ChangeNotifier with WidgetsBindingObserver {
+  CallBuzzer({required this.buzz, required this.isConnected});
+
+  // Native telephony bridge (CallStateBridge.kt), registered on the long-lived
+  // engine so the stream keeps flowing while the app is backgrounded.
+  static const MethodChannel _channel = MethodChannel('openstrap/call_state');
+  static const EventChannel _events =
+      EventChannel('openstrap/call_state_events');
+
+  /// Fire the strap haptic. Wired by AppState to `engine.buzz()`. Best-effort.
+  final Future<void> Function() buzz;
+
+  /// Whether the band is currently connected (no point buzzing nothing).
+  final bool Function() isConnected;
+
+  static const _kEnabled = 'call_buzz_enabled';
+
+  /// Ring cadence: one buzz the moment ringing starts, then one every
+  /// [repeatEvery] while it keeps ringing — a single pulse is easy to miss on
+  /// the wrist, a steady cadence reads unmistakably as "your phone". [maxBuzzes]
+  /// caps a stuck RINGING state (some OEMs never emit IDLE after a missed call)
+  /// at roughly one standard ~30 s ring.
+  static const Duration repeatEvery = Duration(seconds: 4);
+  static const int maxBuzzes = 8;
+
+  /// Only Android exposes call state. Everything below is a no-op when this is
+  /// false, and the UI hides the feature entirely.
+  bool get supported => Platform.isAndroid;
+
+  bool _enabled = false;
+  bool get enabled => _enabled;
+
+  bool _granted = false;
+  bool get permissionGranted => _granted;
+
+  /// True only when everything needed to actually buzz is in place.
+  bool get active => supported && _enabled && _granted;
+
+  StreamSubscription<dynamic>? _sub;
+  Timer? _ringTimer;
+  int _buzzCount = 0;
+
+  /// Load saved state, refresh permission, and start listening if active. Call
+  /// once at startup. No-op on iOS.
+  Future<void> bootstrap() async {
+    if (!supported) return;
+    final prefs = await SharedPreferences.getInstance();
+    _enabled = prefs.getBool(_kEnabled) ?? false;
+    WidgetsBinding.instance.addObserver(this);
+    await refreshPermission();
+    _resync();
+    notifyListeners();
+  }
+
+  // The grant can change while we're backgrounded (user revokes it in Settings).
+  // On every foreground return, re-check it and re-arm/tear down the stream.
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed && supported) {
+      refreshPermission().then((_) => _resync());
+    }
+  }
+
+  /// Re-query the READ_PHONE_STATE grant. Returns the current value.
+  Future<bool> refreshPermission() async {
+    if (!supported) return false;
+    try {
+      _granted =
+          await _channel.invokeMethod<bool>('isPermissionGranted') ?? false;
+    } catch (_) {
+      _granted = false;
+    }
+    notifyListeners();
+    return _granted;
+  }
+
+  /// Show the system permission dialog and return once it's answered. We re-read
+  /// the real grant rather than trusting the dialog's return value.
+  Future<bool> requestPermission() async {
+    if (!supported) return false;
+    try {
+      await _channel.invokeMethod<bool>('requestPermission');
+    } catch (_) {/* user may just back out */}
+    final ok = await refreshPermission();
+    _resync();
+    return ok;
+  }
+
+  Future<void> setEnabled(bool on) async {
+    if (!supported || on == _enabled) return;
+    _enabled = on;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_kEnabled, on);
+    _resync();
+    notifyListeners();
+  }
+
+  // Subscribe only when the feature can actually do something; otherwise tear
+  // the stream down so the native side isn't holding a telephony listener for
+  // nothing (onCancel unregisters it).
+  void _resync() {
+    final shouldListen = supported && _enabled && _granted;
+    if (shouldListen) {
+      _startListening();
+    } else {
+      _sub?.cancel();
+      _sub = null;
+      _stopRinging();
+    }
+  }
+
+  void _startListening() {
+    if (_sub != null) return;
+    try {
+      _sub = _events.receiveBroadcastStream().listen(
+        (e) => handleStateEvent(e.toString()),
+        // If the stream errors, drop it and let the next _resync re-arm — a
+        // dead subscription must never silently stay dead.
+        onError: (_) {
+          _sub?.cancel();
+          _sub = null;
+        },
+        cancelOnError: true,
+      );
+    } catch (_) {/* stream unavailable — stay inert */}
+  }
+
+  /// One native call-state transition: "ringing" | "offhook" | "idle".
+  /// Exposed so the ring cadence is testable without a platform channel.
+  @visibleForTesting
+  void handleStateEvent(String state) {
+    if (state == 'ringing') {
+      _startRinging();
+    } else {
+      // offhook (answered / outgoing call) or idle (missed / declined / ended).
+      _stopRinging();
+    }
+  }
+
+  void _startRinging() {
+    if (_ringTimer != null) return; // already mid-cadence — don't restart it
+    _buzzCount = 0;
+    _fireBuzz();
+    _ringTimer = Timer.periodic(repeatEvery, (_) {
+      if (_buzzCount >= maxBuzzes) {
+        _stopRinging(); // stuck RINGING — stop after ~one full ring
+        return;
+      }
+      _fireBuzz();
+    });
+  }
+
+  void _stopRinging() {
+    _ringTimer?.cancel();
+    _ringTimer = null;
+    _buzzCount = 0;
+  }
+
+  void _fireBuzz() {
+    _buzzCount++; // count the tick even unconnected, so the cap stays temporal
+    if (!isConnected()) return;
+    // Fire-and-forget; never let a BLE hiccup throw into the stream handler.
+    unawaited(buzz().catchError((_) {}));
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _sub?.cancel();
+    _stopRinging();
+    super.dispose();
+  }
+}

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -685,6 +685,7 @@ class AppState extends ChangeNotifier {
     BandOwnership.markForegroundIntent(false);
     _releaseForegroundLease();
     _deriveScheduler.dispose();
+    callBuzzer.dispose();
     _waterBuzzer.dispose();
     insightsRevision.dispose();
     super.dispose();

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -55,6 +55,7 @@ import '../data/models.dart';
 import '../live/live_activity.dart';
 import '../live/breathing_live_activity.dart';
 import '../notify/device_alerts.dart';
+import '../notify/call_buzzer.dart';
 import '../notify/notification_relay.dart';
 import '../notify/notification_service.dart';
 import '../notify/tap_router.dart';
@@ -115,6 +116,13 @@ class AppState extends ChangeNotifier {
   /// Relay selected phone-app notifications to the strap as a buzz (Android only).
   /// Exposed for the settings UI; buzzes via the live BLE engine when connected.
   late final NotificationRelay notificationRelay = NotificationRelay(
+    buzz: () => engine.buzz(),
+    isConnected: () => engine.isConnected,
+  );
+
+  /// Repeat a strap buzz while the phone is ringing (Android only). Exposed for
+  /// the settings UI; buzzes via the live BLE engine when connected.
+  late final CallBuzzer callBuzzer = CallBuzzer(
     buzz: () => engine.buzz(),
     isConnected: () => engine.isConnected,
   );
@@ -1222,6 +1230,8 @@ class AppState extends ChangeNotifier {
     unawaited(gestureSettings.bootstrap());
     // Notification relay (Android only; inert + invisible elsewhere). Best-effort.
     unawaited(notificationRelay.bootstrap());
+    // Incoming-call buzz (Android only; inert + invisible elsewhere). Best-effort.
+    unawaited(callBuzzer.bootstrap());
     // DB integrity check — see _checkSchemaHealth doc. Best-effort, non-blocking.
     unawaited(_checkSchemaHealth());
     initialized = true;

--- a/lib/ui/profile/notification_relay_section.dart
+++ b/lib/ui/profile/notification_relay_section.dart
@@ -10,6 +10,7 @@ import 'package:installed_apps/app_info.dart';
 import 'package:installed_apps/installed_apps.dart';
 import 'package:provider/provider.dart';
 
+import '../../notify/call_buzzer.dart';
 import '../../notify/notification_relay.dart';
 import '../../state/app_state.dart';
 import '../../theme/theme_switcher.dart';
@@ -22,18 +23,26 @@ class NotificationRelaySection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final relay = context.read<AppState>().notificationRelay;
+    final app = context.read<AppState>();
+    final relay = app.notificationRelay;
+    final calls = app.callBuzzer;
     if (!relay.supported) return const SizedBox.shrink();
     return AnimatedBuilder(
-      animation: relay,
+      animation: Listenable.merge([relay, calls]),
       builder: (context, _) {
-        final subtitle = !relay.enabled
-            ? 'Off'
-            : !relay.permissionGranted
-                ? 'Needs notification access'
-                : relay.appCount == 0
-                    ? 'On · no apps selected'
-                    : 'On · ${relay.appCount} app${relay.appCount == 1 ? '' : 's'}';
+        final String subtitle;
+        if (!relay.enabled && !calls.active) {
+          subtitle = 'Off';
+        } else if (relay.enabled && !relay.permissionGranted) {
+          subtitle = 'Needs notification access';
+        } else if (!relay.enabled) {
+          subtitle = 'On · calls only';
+        } else {
+          final apps = relay.appCount == 0
+              ? 'no apps selected'
+              : '${relay.appCount} app${relay.appCount == 1 ? '' : 's'}';
+          subtitle = 'On · $apps${calls.active ? ' · calls' : ''}';
+        }
         return SurfaceCard(
           padding:
               const EdgeInsets.symmetric(horizontal: Sp.x4, vertical: Sp.x2),
@@ -85,17 +94,19 @@ class _NotificationRelayScreenState extends State<NotificationRelayScreen>
     // Coming back from the system Settings page → re-check the grant.
     if (state == AppLifecycleState.resumed && mounted) {
       context.read<AppState>().notificationRelay.refreshPermission();
+      context.read<AppState>().callBuzzer.refreshPermission();
     }
   }
 
   @override
   Widget build(BuildContext context) {
     final relay = context.read<AppState>().notificationRelay;
+    final calls = context.read<AppState>().callBuzzer;
     return AppScaffold(
       title: 'Band notifications',
       subtitle: 'Buzz the strap when an app notifies',
       body: AnimatedBuilder(
-        animation: relay,
+        animation: Listenable.merge([relay, calls]),
         builder: (context, _) {
           final showApps = relay.enabled && relay.permissionGranted;
           return Column(
@@ -112,6 +123,8 @@ class _NotificationRelayScreenState extends State<NotificationRelayScreen>
                       const SizedBox(height: Sp.x3),
                       _GrantCard(relay: relay),
                     ],
+                    const SizedBox(height: Sp.x3),
+                    _CallBuzzCard(calls: calls),
                     if (showApps) ...[
                       const SizedBox(height: Sp.x5),
                       Text('APPS',
@@ -198,6 +211,74 @@ class _GrantCard extends StatelessWidget {
               child: const Text('Grant access'),
             ),
           ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Incoming-call buzz — independent of the app relay above: ringing is not an
+/// observable notification (dialers post it ONGOING, which the relay skips, and
+/// the dialer is a hidden system app), so it rides READ_PHONE_STATE + a native
+/// telephony bridge instead and works even with "Relay notifications" off.
+class _CallBuzzCard extends StatelessWidget {
+  final CallBuzzer calls;
+  const _CallBuzzCard({required this.calls});
+  @override
+  Widget build(BuildContext context) {
+    return SurfaceCard(
+      padding: const EdgeInsets.symmetric(horizontal: Sp.x4, vertical: Sp.x2),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(2),
+                decoration: BoxDecoration(
+                  color: AppColors.accentSoft,
+                  borderRadius: BorderRadius.circular(R.chip),
+                ),
+                child: const OsAppIcon(OsIcon.notifications, size: 30),
+              ),
+              const SizedBox(width: Sp.x3),
+              Expanded(
+                  child: Text('Buzz on incoming calls', style: AppText.title)),
+              Switch.adaptive(
+                value: calls.enabled,
+                activeTrackColor: AppColors.accent,
+                onChanged: (v) async {
+                  await calls.setEnabled(v);
+                  // Ask for the (state-only) phone permission the moment the
+                  // feature is switched on, not at some later surprise point.
+                  if (v && !calls.permissionGranted) {
+                    await calls.requestPermission();
+                  }
+                },
+              ),
+            ],
+          ),
+          if (calls.enabled && !calls.permissionGranted) ...[
+            const SizedBox(height: Sp.x2),
+            Text(
+              'Android needs the phone permission to know when the phone is '
+              'ringing. Only the ringing state is read — never numbers or calls.',
+              style: AppText.captionMuted,
+            ),
+            const SizedBox(height: Sp.x3),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: FilledButton(
+                onPressed: () => calls.requestPermission(),
+                style: FilledButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                  minimumSize: const Size(0, 44),
+                ),
+                child: const Text('Grant permission'),
+              ),
+            ),
+            const SizedBox(height: Sp.x2),
+          ],
         ],
       ),
     );

--- a/lib/ui/profile/notification_relay_section.dart
+++ b/lib/ui/profile/notification_relay_section.dart
@@ -31,12 +31,14 @@ class NotificationRelaySection extends StatelessWidget {
       animation: Listenable.merge([relay, calls]),
       builder: (context, _) {
         final String subtitle;
-        if (!relay.enabled && !calls.active) {
-          subtitle = 'Off';
-        } else if (relay.enabled && !relay.permissionGranted) {
+        if (relay.enabled && !relay.permissionGranted) {
           subtitle = 'Needs notification access';
+        } else if (calls.enabled && !calls.permissionGranted) {
+          // Calls are switched on but can't work yet — surface the actionable
+          // state instead of reporting 'Off' / silently omitting calls.
+          subtitle = 'Needs phone permission';
         } else if (!relay.enabled) {
-          subtitle = 'On · calls only';
+          subtitle = calls.active ? 'On · calls only' : 'Off';
         } else {
           final apps = relay.appCount == 0
               ? 'no apps selected'

--- a/test/call_buzzer_test.dart
+++ b/test/call_buzzer_test.dart
@@ -1,0 +1,90 @@
+// call_buzzer_test.dart — the incoming-call ring cadence (see CallBuzzer).
+// Drives handleStateEvent directly so no platform channel is involved; timers
+// run under fakeAsync so the cadence is asserted deterministically.
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/notify/call_buzzer.dart';
+
+void main() {
+  CallBuzzer make(void Function() onBuzz, {bool connected = true}) =>
+      CallBuzzer(
+        buzz: () async => onBuzz(),
+        isConnected: () => connected,
+      );
+
+  test('ringing buzzes immediately, then on the cadence until idle', () {
+    fakeAsync((async) {
+      var buzzes = 0;
+      final cb = make(() => buzzes++);
+      cb.handleStateEvent('ringing');
+      expect(buzzes, 1, reason: 'first buzz fires the moment ringing starts');
+      async.elapse(CallBuzzer.repeatEvery * 2 + const Duration(seconds: 1));
+      expect(buzzes, 3, reason: 'one more buzz per elapsed cadence interval');
+      cb.handleStateEvent('idle'); // rang out / declined
+      async.elapse(const Duration(minutes: 1));
+      expect(buzzes, 3, reason: 'idle stops the cadence dead');
+    });
+  });
+
+  test('answering (offhook) stops the cadence', () {
+    fakeAsync((async) {
+      var buzzes = 0;
+      final cb = make(() => buzzes++);
+      cb.handleStateEvent('ringing');
+      async.elapse(CallBuzzer.repeatEvery + const Duration(seconds: 1));
+      expect(buzzes, 2);
+      cb.handleStateEvent('offhook');
+      async.elapse(const Duration(minutes: 5)); // long call — no buzzing through it
+      expect(buzzes, 2);
+    });
+  });
+
+  test('a stuck RINGING state is capped at maxBuzzes', () {
+    fakeAsync((async) {
+      var buzzes = 0;
+      final cb = make(() => buzzes++);
+      cb.handleStateEvent('ringing'); // no idle/offhook ever arrives
+      async.elapse(const Duration(minutes: 10));
+      expect(buzzes, CallBuzzer.maxBuzzes);
+    });
+  });
+
+  test('duplicate ringing events do not restart the cadence', () {
+    fakeAsync((async) {
+      var buzzes = 0;
+      final cb = make(() => buzzes++);
+      cb.handleStateEvent('ringing');
+      async.elapse(const Duration(seconds: 1));
+      cb.handleStateEvent('ringing'); // repeated native event mid-ring
+      expect(buzzes, 1, reason: 'no double-buzz from a repeated event');
+      async.elapse(const Duration(minutes: 1));
+      expect(buzzes, CallBuzzer.maxBuzzes,
+          reason: 'cap unchanged — cadence was not restarted');
+    });
+  });
+
+  test('band disconnected: ticks count toward the cap but nothing buzzes', () {
+    fakeAsync((async) {
+      var buzzes = 0;
+      final cb = make(() => buzzes++, connected: false);
+      cb.handleStateEvent('ringing');
+      async.elapse(const Duration(minutes: 1));
+      expect(buzzes, 0, reason: 'no link — no writes');
+    });
+  });
+
+  test('a new ring after idle starts a fresh cadence', () {
+    fakeAsync((async) {
+      var buzzes = 0;
+      final cb = make(() => buzzes++);
+      cb.handleStateEvent('ringing');
+      async.elapse(const Duration(minutes: 1)); // rings out to the cap
+      expect(buzzes, CallBuzzer.maxBuzzes);
+      cb.handleStateEvent('idle');
+      cb.handleStateEvent('ringing'); // caller tries again
+      expect(buzzes, CallBuzzer.maxBuzzes + 1,
+          reason: 'fresh ring buzzes immediately again');
+    });
+  });
+}

--- a/test/call_buzzer_test.dart
+++ b/test/call_buzzer_test.dart
@@ -74,6 +74,22 @@ void main() {
     });
   });
 
+  test('duplicate ringing after the cap does not restart the cadence', () {
+    fakeAsync((async) {
+      var buzzes = 0;
+      final cb = make(() => buzzes++);
+      cb.handleStateEvent('ringing');
+      async.elapse(const Duration(minutes: 2)); // well past the cap
+      expect(buzzes, CallBuzzer.maxBuzzes);
+      // Some OEMs re-emit RINGING for the same call with no terminal state in
+      // between — that must NOT buzz another full cadence.
+      cb.handleStateEvent('ringing');
+      async.elapse(const Duration(minutes: 2));
+      expect(buzzes, CallBuzzer.maxBuzzes,
+          reason: 'same call — no fresh cadence without idle/offhook between');
+    });
+  });
+
   test('a new ring after idle starts a fresh cadence', () {
     fakeAsync((async) {
       var buzzes = 0;


### PR DESCRIPTION
Closes #92.

## Why the relay can't do this

Two separate blockers mean incoming calls can never ride the existing notification relay:

1. The app picker uses `InstalledApps.getInstalledApps(excludeSystemApps: true)`, and the dialer (Google Phone, Samsung Phone, AOSP Dialer) is a system app on essentially every device — so there's no 'Phone' entry to select (exactly what #92 reports).
2. Even if it were listed, `NotificationRelay._onNotification` skips ongoing notifications (`if (e.hasRemoved || e.onGoing) return;`) — correctly, to avoid media players and foreground services — and Android posts incoming-call notifications as *ongoing* full-screen-intent notifications, so ringing is precisely the kind of notification that filter swallows.

## What this does instead

Calls get their own telephony-based path:

- **`CallStateBridge.kt`** — a small native bridge streaming `ringing` / `offhook` / `idle` from `TelephonyManager` over an EventChannel (`TelephonyCallback` on API 31+, `PhoneStateListener` below). Registered on the long-lived engine alongside `NativeChannels`, so it keeps working while backgrounded/headless. Permission request borrows the Activity `CompanionBridge` already tracks; the result is forwarded from `MainActivity.onRequestPermissionsResult`.
- **`CallBuzzer`** (Dart) — same persisted-ChangeNotifier idiom as `NotificationRelay`. While RINGING it buzzes the band immediately and then every 4 s — a cadence on the wrist reads unmistakably as 'your phone', where a single pulse is easy to miss — and stops the instant the call is answered, declined, or rings out. A cap of 8 buzzes (~one standard 30 s ring) guards against OEMs that never emit IDLE after a missed call.
- **UI** — a 'Buzz on incoming calls' card on the Band-notifications screen, independent of the app-relay master toggle (it doesn't need notification access), with inline permission grant and a truthful profile-card subtitle ('On · calls only', '… · calls').

## Permissions

Adds `READ_PHONE_STATE` (runtime, requested only when the toggle is switched on). Only the call *state* is read — numbers never are (no `READ_CALL_LOG`), and the manifest comment says so. iOS is untouched: no ringer-observation API exists there, so the feature is inert and hidden, matching the relay's pattern.

## Testing

- `flutter analyze` clean for the touched files; `flutter test` — the new `call_buzzer_test.dart` covers the cadence (immediate buzz, repeat interval, stop on offhook/idle, stuck-RINGING cap, duplicate-event and re-ring behaviour) under `fakeAsync`. The two pre-existing `derivation_pipeline_test.dart` failures on main are unrelated (git-dep drift) and unaffected.
- Not yet verified on a physical device — happy to iterate if anything misbehaves on OEM dialers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Android-only incoming-call buzz alert that taps the strap when calls are ringing.
  * Introduced runtime phone-permission handling to enable call buzzing and prompt for access when needed.
  * Added a call-buzz settings card and updated the notification relay section to reflect combined relay/call states.
  * Implemented native call-state monitoring and automatic start/stop of buzzing based on call transitions.
* **Tests**
  * Added automated tests covering ringing cadence, stopping on answered calls, repeat caps, and connection-aware behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->