### PR TITLE
feat(widget): Android home-screen widgets (metrics + band battery)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -178,6 +178,31 @@
             </intent-filter>
         </receiver>
 
+        <!-- Home-screen widgets (Android siblings of ios/OpenStrapWidget). The app
+             pushes snapshots via home_widget (WidgetService); these just render. -->
+        <receiver
+            android:name=".OpenStrapWidgetProvider"
+            android:exported="true"
+            android:label="@string/widget_openstrap_label">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_openstrap_info" />
+        </receiver>
+        <receiver
+            android:name=".OpenStrapBatteryWidgetProvider"
+            android:exported="true"
+            android:label="@string/widget_battery_label">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_band_battery_info" />
+        </receiver>
+
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/OpenStrapBatteryWidgetProvider.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/OpenStrapBatteryWidgetProvider.kt
@@ -1,0 +1,72 @@
+package wtf.openstrap.openstrap_edge
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.SharedPreferences
+import android.widget.RemoteViews
+import es.antonborri.home_widget.HomeWidgetProvider
+
+/**
+ * Band-battery widget — the Android sibling of OpenStrapBatteryWidget.swift.
+ *
+ * Battery is a live BLE value only the app knows (not part of /today), so this
+ * never refreshes over the network: it renders the snapshot the app last wrote
+ * (WidgetService.pushBattery → batt_pct / batt_charging / batt_name / batt_at)
+ * while the band was connected. "—" until we've ever seen the band, and the
+ * reading is muted once it's > 24 h old — we genuinely don't know the current
+ * level if we haven't talked to the band. updatePeriodMillis re-renders every
+ * ~30 min so the staleness flip happens without the app's help.
+ */
+class OpenStrapBatteryWidgetProvider : HomeWidgetProvider() {
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+        widgetData: SharedPreferences,
+    ) {
+        for (id in appWidgetIds) render(context, appWidgetManager, id, widgetData)
+    }
+
+    private fun render(
+        context: Context,
+        manager: AppWidgetManager,
+        id: Int,
+        prefs: SharedPreferences,
+    ) {
+        val w = StrapWidgets
+        val pal = w.pal(prefs)
+
+        val pct = w.readInt(prefs, "batt_pct", -1)
+        val charging = prefs.getBoolean("batt_charging", false)
+        val at = w.readInt(prefs, "batt_at", 0)
+        val rawName = (prefs.getString("batt_name", "") ?: "").trim()
+        val name = rawName.ifEmpty { "Strap" }
+        val stale = at > 0 && (System.currentTimeMillis() / 1000 - at) > 86_400
+
+        // Colour rules mirror BatteryEntry.color: blue while charging, coral when
+        // low, deep-coral when critical, green otherwise — muted with no/old data.
+        val color = when {
+            pct < 0 || stale -> pal.inkMuted
+            charging -> w.SLEEP_BLUE
+            pct <= 10 -> w.CORAL_DEEP
+            pct <= 25 -> w.CORAL
+            else -> w.GOOD
+        }
+        val t = if (pct >= 0) (pct / 100.0).coerceIn(0.0, 1.0) else 0.0
+        val valueText = if (pct >= 0) "$pct%" else "—"
+
+        val views = RemoteViews(context.packageName, R.layout.widget_band_battery)
+        views.setInt(R.id.widget_root, "setBackgroundResource", pal.bgRes)
+        views.setOnClickPendingIntent(R.id.widget_root, w.openAppIntent(context))
+        views.setImageViewBitmap(
+            R.id.ring_batt,
+            w.ringBitmap(context, 64, 8f, pal.track, color, t),
+        )
+        views.setTextViewText(R.id.val_batt, valueText)
+        views.setTextColor(R.id.val_batt, if (stale) pal.inkMuted else pal.ink)
+        views.setTextViewText(R.id.name_batt, if (charging) "⚡ $name" else name)
+        views.setTextColor(R.id.name_batt, pal.inkMuted)
+        manager.updateAppWidget(id, views)
+    }
+}

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/OpenStrapWidgetProvider.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/OpenStrapWidgetProvider.kt
@@ -1,0 +1,143 @@
+package wtf.openstrap.openstrap_edge
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Build
+import android.os.Bundle
+import android.util.SizeF
+import android.widget.RemoteViews
+import es.antonborri.home_widget.HomeWidgetPlugin
+import es.antonborri.home_widget.HomeWidgetProvider
+
+/**
+ * Home-screen metrics widget — the Android sibling of OpenStrapWidget.swift
+ * (Readiness headline + the Strain · Sleep · HRV rings, Ember on Paper).
+ *
+ * Renders the snapshot WidgetService.push() writes through home_widget; the app
+ * broadcasts an update after every sync (this provider name is already wired in
+ * widget_service.dart). Unlike iOS there is no self-refresh fetch of /today —
+ * updatePeriodMillis just re-renders the cached snapshot so the theme/staleness
+ * stay honest when the app hasn't run for a while.
+ *
+ * Two layouts, like the iOS families: a 2×2 ring grid (small) and a readiness
+ * row over the triple rings (medium). On Android 12+ the launcher picks by live
+ * size (RemoteViews size map); below that we choose from the widget's min width.
+ */
+class OpenStrapWidgetProvider : HomeWidgetProvider() {
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+        widgetData: SharedPreferences,
+    ) {
+        for (id in appWidgetIds) render(context, appWidgetManager, id, widgetData)
+    }
+
+    override fun onAppWidgetOptionsChanged(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+        newOptions: Bundle,
+    ) {
+        render(context, appWidgetManager, appWidgetId, HomeWidgetPlugin.getData(context))
+    }
+
+    private fun render(
+        context: Context,
+        manager: AppWidgetManager,
+        id: Int,
+        prefs: SharedPreferences,
+    ) {
+        val views: RemoteViews = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            RemoteViews(
+                mapOf(
+                    SizeF(110f, 110f) to build(context, prefs, small = true),
+                    SizeF(250f, 110f) to build(context, prefs, small = false),
+                ),
+            )
+        } else {
+            val minW = manager.getAppWidgetOptions(id)
+                .getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH)
+            build(context, prefs, small = minW in 1..249)
+        }
+        manager.updateAppWidget(id, views)
+    }
+
+    private fun build(context: Context, prefs: SharedPreferences, small: Boolean): RemoteViews {
+        val w = StrapWidgets
+        val pal = w.pal(prefs)
+
+        // Snapshot (sentinels: -1 = no data — mirrors OpenStrapEntry).
+        val readiness = w.readInt(prefs, "readiness", -1)
+        val strain = w.readDouble(prefs, "strain", -1.0)
+        val sleepMin = w.readInt(prefs, "sleep_min", -1)
+        val needMin = w.readInt(prefs, "sleep_need_min", 480)
+        val hrv = w.readInt(prefs, "hrv", -1)
+        val hrvBaseline = w.readInt(prefs, "hrv_baseline", -1)
+
+        // Ring fractions + colours — same rules as OpenStrapEntry in Swift.
+        val readinessT = if (readiness >= 0) readiness / 100.0 else 0.0
+        val readinessColor = when {
+            readiness < 0 -> pal.inkMuted
+            readiness >= 66 -> w.GOOD
+            readiness >= 40 -> w.CORAL
+            else -> w.CORAL_DEEP
+        }
+        val strainT = if (strain >= 0) (strain / 21.0).coerceAtMost(1.0) else 0.0
+        val sleepT = if (sleepMin >= 0 && needMin > 0) {
+            (sleepMin.toDouble() / needMin).coerceAtMost(1.0)
+        } else {
+            0.0
+        }
+        val hrvT = when {
+            hrv < 0 -> 0.0
+            hrvBaseline > 0 -> (hrv / (1.5 * hrvBaseline)).coerceAtMost(1.0)
+            else -> (hrv / 100.0).coerceAtMost(1.0)
+        }
+        // HRV reads green at/above your baseline, warmer as it drops below it.
+        val hrvColor = when {
+            hrv < 0 || hrvBaseline <= 0 -> w.GOOD
+            hrv >= hrvBaseline -> w.GOOD
+            hrv >= (0.8 * hrvBaseline).toInt() -> w.CORAL
+            else -> w.CORAL_DEEP
+        }
+
+        val strainText = if (strain >= 0) String.format("%.1f", strain) else "—"
+        val readinessText = if (readiness >= 0) "$readiness" else "—"
+        val hrvText = if (hrv >= 0) "$hrv" else "—"
+
+        val layout = if (small) R.layout.widget_openstrap_small else R.layout.widget_openstrap
+        val ringDp = if (small) 40 else 56
+        val strokeDp = if (small) 5f else 7f
+
+        val views = RemoteViews(context.packageName, layout)
+        views.setInt(R.id.widget_root, "setBackgroundResource", pal.bgRes)
+        views.setOnClickPendingIntent(R.id.widget_root, w.openAppIntent(context))
+
+        // Readiness leads the row; its VALUE carries the readiness colour (the
+        // iOS headline treatment, compressed into a cell).
+        views.setImageViewBitmap(
+            R.id.ring_readiness,
+            w.ringBitmap(context, ringDp, strokeDp, pal.track, readinessColor, readinessT),
+        )
+        views.setTextViewText(R.id.val_readiness, readinessText)
+        views.setTextColor(R.id.val_readiness, readinessColor)
+        views.setTextColor(R.id.cap_readiness, pal.inkMuted)
+
+        fun metric(ring: Int, value: Int, cap: Int, bmpColor: Int, t: Double, text: String) {
+            views.setImageViewBitmap(
+                ring,
+                w.ringBitmap(context, ringDp, strokeDp, pal.track, bmpColor, t),
+            )
+            views.setTextViewText(value, text)
+            views.setTextColor(value, pal.ink)
+            views.setTextColor(cap, pal.inkMuted)
+        }
+        metric(R.id.ring_strain, R.id.val_strain, R.id.cap_strain, w.CORAL, strainT, strainText)
+        metric(R.id.ring_sleep, R.id.val_sleep, R.id.cap_sleep, w.SLEEP_BLUE, sleepT, w.hm(sleepMin))
+        metric(R.id.ring_hrv, R.id.val_hrv, R.id.cap_hrv, hrvColor, hrvT, hrvText)
+        return views
+    }
+}

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/StrapWidgets.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/StrapWidgets.kt
@@ -1,0 +1,117 @@
+package wtf.openstrap.openstrap_edge
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+
+/**
+ * Shared bits for the home-screen widgets (see OpenStrapWidgetProvider /
+ * OpenStrapBatteryWidgetProvider) — the Ember-on-Paper palette, readers for the
+ * home_widget snapshot, and the arc-ring renderer.
+ *
+ * The palette and all value/colour rules mirror the Swift widgets under
+ * ios/OpenStrapWidget exactly, so the two platforms read as the same product. Rings are
+ * pre-rendered as bitmaps because RemoteViews can't draw arcs.
+ */
+internal object StrapWidgets {
+
+    // ── Ember on Paper / Char (mirrors Pal in OpenStrapWidget.swift) ─────────
+    class Pal(val bgRes: Int, val ink: Int, val inkMuted: Int, val track: Int)
+
+    private val LIGHT = Pal(
+        R.drawable.widget_bg_paper, 0xFF1A1714.toInt(),
+        0xFFA59C90.toInt(), 0xFFECE7DF.toInt(),
+    )
+    private val DARK = Pal(
+        R.drawable.widget_bg_char, 0xFFF1ECE3.toInt(),
+        0xFF7E7466.toInt(), 0xFF2A251F.toInt(),
+    )
+
+    const val CORAL = 0xFFFF5A36.toInt()
+    const val CORAL_DEEP = 0xFFE8431F.toInt()
+    const val GOOD = 0xFF2BB673.toInt()
+    const val SLEEP_BLUE = 0xFF7CA8F0.toInt()
+
+    /// The app mirrors its in-app appearance into `theme_dark` (see
+    /// WidgetService.setThemeDark) — same source of truth as the iOS widgets.
+    fun pal(prefs: SharedPreferences): Pal =
+        if (prefs.getBoolean("theme_dark", false)) DARK else LIGHT
+
+    // ── home_widget snapshot readers ─────────────────────────────────────────
+    // home_widget's Android store isn't type-stable across Dart types: Dart ints
+    // arrive as Int, but Dart doubles are stored as RAW LONG BITS
+    // (putLong(doubleToRawLongBits)) — see HomeWidgetPlugin.saveWidgetData. Read
+    // through `all[key]` and coerce, so a type drift never crashes a widget.
+
+    fun readInt(prefs: SharedPreferences, key: String, def: Int): Int =
+        when (val v = prefs.all[key]) {
+            is Int -> v
+            is Long -> v.toInt()
+            is Float -> v.toInt()
+            else -> def
+        }
+
+    fun readDouble(prefs: SharedPreferences, key: String, def: Double): Double =
+        when (val v = prefs.all[key]) {
+            is Long -> Double.fromBits(v) // Dart double → raw bits (see above)
+            is Float -> v.toDouble()
+            is Int -> v.toDouble()
+            else -> def
+        }
+
+    // ── formatting (mirrors hm() in OpenStrapWidget.swift) ───────────────────
+    fun hm(min: Int): String {
+        if (min < 0) return "—"
+        val h = min / 60
+        val m = min % 60
+        if (h == 0) return "${m}m"
+        if (m == 0) return "${h}h"
+        return "${h}h ${m}m"
+    }
+
+    // ── ring renderer ────────────────────────────────────────────────────────
+    /** Track circle + progress arc from 12 o'clock, round caps — the iOS Ring. */
+    fun ringBitmap(
+        context: Context,
+        sizeDp: Int,
+        strokeDp: Float,
+        trackColor: Int,
+        color: Int,
+        t: Double,
+    ): Bitmap {
+        val density = context.resources.displayMetrics.density
+        val px = (sizeDp * density).toInt().coerceAtLeast(1)
+        val stroke = strokeDp * density
+        val bmp = Bitmap.createBitmap(px, px, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bmp)
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.STROKE
+            strokeWidth = stroke
+            strokeCap = Paint.Cap.ROUND
+        }
+        val inset = stroke / 2f
+        val rect = RectF(inset, inset, px - inset, px - inset)
+        paint.color = trackColor
+        canvas.drawArc(rect, 0f, 360f, false, paint)
+        val frac = t.coerceIn(0.0, 1.0)
+        if (frac > 0) {
+            paint.color = color
+            canvas.drawArc(rect, -90f, (360.0 * frac).toFloat(), false, paint)
+        }
+        return bmp
+    }
+
+    /** Tap anywhere on a widget → open the app. */
+    fun openAppIntent(context: Context): PendingIntent =
+        PendingIntent.getActivity(
+            context,
+            0,
+            Intent(context, MainActivity::class.java),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+}

--- a/android/app/src/main/res/drawable/widget_bg_char.xml
+++ b/android/app/src/main/res/drawable/widget_bg_char.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Char widget surface (dark). -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#1E1A15" />
+    <corners android:radius="24dp" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_bg_paper.xml
+++ b/android/app/src/main/res/drawable/widget_bg_paper.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Ember on Paper widget surface (light). -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#F4F1EC" />
+    <corners android:radius="24dp" />
+</shape>

--- a/android/app/src/main/res/layout/widget_band_battery.xml
+++ b/android/app/src/main/res/layout/widget_band_battery.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Band-battery widget: battery ring with the percentage inside, strap name
+  below — mirrors OpenStrapBatteryWidget.swift's home-screen family. Colours
+  and background are set at render time (OpenStrapBatteryWidgetProvider).
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="12dp">
+
+    <FrameLayout
+        android:layout_width="64dp"
+        android:layout_height="64dp">
+
+        <ImageView
+            android:id="@+id/ring_batt"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:importantForAccessibility="no" />
+
+        <TextView
+            android:id="@+id/val_batt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:textSize="15sp"
+            android:textStyle="bold"
+            android:maxLines="1" />
+    </FrameLayout>
+
+    <TextView
+        android:id="@+id/name_batt"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:textSize="10sp"
+        android:textStyle="bold"
+        android:letterSpacing="0.05"
+        android:maxLines="1"
+        android:ellipsize="end" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/widget_openstrap.xml
+++ b/android/app/src/main/res/layout/widget_openstrap.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Wide metrics widget: Ready · Strain · Sleep · HRV rings in one row. The iOS
+  medium stacks a readiness headline over the rings, but an Android 4x2 widget
+  only gets ~110dp of height (vs systemMedium's 155pt), so the four rings share
+  a single row instead. Colours/backgrounds set at render time.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="12dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
+
+            <FrameLayout
+                android:layout_width="56dp"
+                android:layout_height="56dp">
+
+                <ImageView
+                    android:id="@+id/ring_readiness"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:importantForAccessibility="no" />
+
+                <TextView
+                    android:id="@+id/val_readiness"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:textSize="15sp"
+                    android:textStyle="bold"
+                    android:maxLines="1" />
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/cap_readiness"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="5dp"
+                android:text="READY"
+                android:textSize="9sp"
+                android:textStyle="bold"
+                android:letterSpacing="0.09"
+                android:maxLines="1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
+
+            <FrameLayout
+                android:layout_width="56dp"
+                android:layout_height="56dp">
+
+                <ImageView
+                    android:id="@+id/ring_strain"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:importantForAccessibility="no" />
+
+                <TextView
+                    android:id="@+id/val_strain"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:textSize="15sp"
+                    android:textStyle="bold"
+                    android:maxLines="1" />
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/cap_strain"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="5dp"
+                android:text="STRAIN"
+                android:textSize="9sp"
+                android:textStyle="bold"
+                android:letterSpacing="0.09"
+                android:maxLines="1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
+
+            <FrameLayout
+                android:layout_width="56dp"
+                android:layout_height="56dp">
+
+                <ImageView
+                    android:id="@+id/ring_sleep"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:importantForAccessibility="no" />
+
+                <TextView
+                    android:id="@+id/val_sleep"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:paddingStart="7dp"
+                    android:paddingEnd="7dp"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="8sp"
+                    android:autoSizeMaxTextSize="13sp"
+                    android:autoSizeStepGranularity="1sp"
+                    android:textSize="15sp"
+                    android:textStyle="bold"
+                    android:maxLines="1" />
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/cap_sleep"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="5dp"
+                android:text="SLEEP"
+                android:textSize="9sp"
+                android:textStyle="bold"
+                android:letterSpacing="0.09"
+                android:maxLines="1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
+
+            <FrameLayout
+                android:layout_width="56dp"
+                android:layout_height="56dp">
+
+                <ImageView
+                    android:id="@+id/ring_hrv"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:importantForAccessibility="no" />
+
+                <TextView
+                    android:id="@+id/val_hrv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:textSize="15sp"
+                    android:textStyle="bold"
+                    android:maxLines="1" />
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/cap_hrv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="5dp"
+                android:text="HRV"
+                android:textSize="9sp"
+                android:textStyle="bold"
+                android:letterSpacing="0.09"
+                android:maxLines="1" />
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/android/app/src/main/res/layout/widget_openstrap_small.xml
+++ b/android/app/src/main/res/layout/widget_openstrap_small.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Small metrics widget: 2x2 ring grid (Ready · Strain / Sleep · HRV) — mirrors
+  SmallView in OpenStrapWidget.swift, sized for a 2x2 Android cell (~110-140dp).
+  Colours/backgrounds set at render time.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
+
+            <FrameLayout
+                android:layout_width="40dp"
+                android:layout_height="40dp">
+
+                <ImageView
+                    android:id="@+id/ring_readiness"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:importantForAccessibility="no" />
+
+                <TextView
+                    android:id="@+id/val_readiness"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    android:maxLines="1" />
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/cap_readiness"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="3dp"
+                android:text="READY"
+                android:textSize="9sp"
+                android:textStyle="bold"
+                android:letterSpacing="0.09"
+                android:maxLines="1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
+
+            <FrameLayout
+                android:layout_width="40dp"
+                android:layout_height="40dp">
+
+                <ImageView
+                    android:id="@+id/ring_strain"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:importantForAccessibility="no" />
+
+                <TextView
+                    android:id="@+id/val_strain"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    android:maxLines="1" />
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/cap_strain"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="3dp"
+                android:text="STRAIN"
+                android:textSize="9sp"
+                android:textStyle="bold"
+                android:letterSpacing="0.09"
+                android:maxLines="1" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
+
+            <FrameLayout
+                android:layout_width="40dp"
+                android:layout_height="40dp">
+
+                <ImageView
+                    android:id="@+id/ring_sleep"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:importantForAccessibility="no" />
+
+                <TextView
+                    android:id="@+id/val_sleep"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:paddingStart="7dp"
+                    android:paddingEnd="7dp"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="8sp"
+                    android:autoSizeMaxTextSize="11sp"
+                    android:autoSizeStepGranularity="1sp"
+                    android:textSize="11sp"
+                    android:textStyle="bold"
+                    android:maxLines="1" />
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/cap_sleep"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="3dp"
+                android:text="SLEEP"
+                android:textSize="9sp"
+                android:textStyle="bold"
+                android:letterSpacing="0.09"
+                android:maxLines="1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
+
+            <FrameLayout
+                android:layout_width="40dp"
+                android:layout_height="40dp">
+
+                <ImageView
+                    android:id="@+id/ring_hrv"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:importantForAccessibility="no" />
+
+                <TextView
+                    android:id="@+id/val_hrv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:textSize="11sp"
+                    android:textStyle="bold"
+                    android:maxLines="1" />
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/cap_hrv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="3dp"
+                android:text="HRV"
+                android:textSize="9sp"
+                android:textStyle="bold"
+                android:letterSpacing="0.09"
+                android:maxLines="1" />
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/android/app/src/main/res/values/widget_strings.xml
+++ b/android/app/src/main/res/values/widget_strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Widget-picker labels/descriptions. -->
+<resources>
+    <string name="widget_openstrap_label">Edge</string>
+    <string name="widget_openstrap_description">Readiness, strain, sleep and HRV at a glance.</string>
+    <string name="widget_battery_label">Band battery</string>
+    <string name="widget_battery_description">Your strap\'s battery, from the last connection.</string>
+</resources>

--- a/android/app/src/main/res/xml/widget_band_battery_info.xml
+++ b/android/app/src/main/res/xml/widget_band_battery_info.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Band-battery widget metadata. Renders the app's last BLE battery snapshot
+  (never fetches); the 30-min re-render exists so the >24 h staleness mute can
+  flip without the app running.
+-->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="110dp"
+    android:minHeight="110dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="2"
+    android:resizeMode="none"
+    android:updatePeriodMillis="1800000"
+    android:initialLayout="@layout/widget_band_battery"
+    android:previewLayout="@layout/widget_band_battery"
+    android:description="@string/widget_battery_description"
+    android:widgetCategory="home_screen|keyguard" />

--- a/android/app/src/main/res/xml/widget_openstrap_info.xml
+++ b/android/app/src/main/res/xml/widget_openstrap_info.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Metrics widget metadata. minResizeWidth allows squeezing down to the 2×2 ring
+  grid; the provider swaps layouts by live size (12+) or min width (below).
+  updatePeriodMillis only re-renders the cached snapshot (no network on Android)
+  so the theme and staleness stay honest when the app hasn't run for a while.
+-->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="110dp"
+    android:minResizeWidth="110dp"
+    android:minResizeHeight="110dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="2"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="1800000"
+    android:initialLayout="@layout/widget_openstrap"
+    android:previewLayout="@layout/widget_openstrap"
+    android:description="@string/widget_openstrap_description"
+    android:widgetCategory="home_screen" />

--- a/lib/widget/widget_service.dart
+++ b/lib/widget/widget_service.dart
@@ -28,6 +28,9 @@ class WidgetService {
   static const String _batteryIOSName = 'OpenStrapBatteryWidget';
   static const String _androidName = 'OpenStrapWidgetProvider';
 
+  /// Android provider class for the Band Battery widget.
+  static const String _batteryAndroidName = 'OpenStrapBatteryWidgetProvider';
+
   static bool _inited = false;
   static Future<void> init() async {
     if (_inited) return;
@@ -124,7 +127,7 @@ class WidgetService {
       await HomeWidget.saveWidgetData<int>(
           'batt_at', DateTime.now().millisecondsSinceEpoch ~/ 1000);
       await HomeWidget.updateWidget(
-          iOSName: _batteryIOSName, androidName: _androidName);
+          iOSName: _batteryIOSName, androidName: _batteryAndroidName);
       await _syncWatch();
     } catch (_) {/* widgets unavailable / not configured yet — ignore */}
   }
@@ -140,6 +143,11 @@ class WidgetService {
       await HomeWidget.updateWidget(
         iOSName: _iOSName,
         androidName: _androidName,
+      );
+      // The battery widget shares the Ember/Char surface — retheme it too.
+      await HomeWidget.updateWidget(
+        iOSName: _batteryIOSName,
+        androidName: _batteryAndroidName,
       );
     } catch (_) {
       /* widgets unavailable — ignore */


### PR DESCRIPTION
The iOS side has a lovely set of WidgetKit widgets; Android had none — even though `WidgetService` already writes every snapshot key via `home_widget` and broadcasts to an (until now nonexistent) `OpenStrapWidgetProvider`. This adds the Android siblings as classic RemoteViews providers, **no new dependencies**.

![Rendered preview of the Android widgets](https://raw.githubusercontent.com/dannymcc/edge/assets/android-widget-preview.png)

*Rendered preview (not a device screenshot) — generated from the same palette, geometry and ring maths as the code, using the iOS placeholder values.*

## What's included

- **`OpenStrapWidgetProvider`** — Ready · Strain · Sleep · HRV rings. Two faces like the iOS families: a 2×2 grid when small, a single four-ring row when wide. The iOS medium stacks a readiness headline over the rings, but an Android 4×2 cell only gets ~110 dp of height (vs systemMedium's 155 pt), so the wide face puts the four rings in one row with the readiness value carrying the readiness colour instead. Layout switching uses the RemoteViews size map on Android 12+, min-width fallback below.
- **`OpenStrapBatteryWidgetProvider`** — band battery ring from the last BLE snapshot (batt_pct/batt_charging/batt_name), charging bolt in the label, and the same >24 h staleness mute as the iOS widget. Never fetches — battery is a live BLE value only the app knows.
- **`StrapWidgets`** — shared palette, snapshot readers, and a Canvas arc renderer (RemoteViews can't draw arcs, so rings are pre-rendered bitmaps at the device density). All colour/threshold/format rules mirror the Swift widgets 1:1 — including Ember-on-Paper/Char theming via the `theme_dark` key the app already writes, HRV green-at-baseline shading, and the `hm()` sleep format.
- **Dart** — `pushBattery`/`setThemeDark` now also target the battery provider; the metrics provider name was already wired upstream.

## Notes for review

- **home_widget storage gotcha:** on Android the plugin stores Dart doubles as **raw long bits** (`putLong(doubleToRawLongBits(...))`), so `strain` must be read back with `Double.fromBits` — `StrapWidgets.readDouble` encodes this (and coerces defensively through `all[key]` so a type drift can never crash a widget).
- No self-refresh on Android (the iOS widgets fetch `/today` hourly with the stored JWT). `updatePeriodMillis` (30 min) just re-renders the cached snapshot so theming and battery staleness stay honest when the app hasn't run. Happy to add a WorkManager-free self-refresh in a follow-up if you want parity.
- The sleep value auto-sizes (`autoSizeTextType`) so "7h 17m" shrinks into its ring — the RemoteViews equivalent of the Swift `minimumScaleFactor(0.6)`.
- Tap anywhere on either widget opens the app.

## Testing

- `flutter analyze` clean for the touched files; full `flutter build apk --debug` compiles (their first CI compile would otherwise be at tag time, since build.yml only triggers on version tags).
- Not yet verified on a physical launcher — the preview above is a faithful rendering of the layouts, but I'd value a quick on-device check of the 2×2 sizing across OEM launchers before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android home-screen widgets displaying readiness, strain, sleep, and HRV metrics.
  * Added a band battery widget showing battery level, charging status, and last-connected name.
  * Added compact and expanded widget layouts with responsive sizing.
  * Added light and dark widget themes with automatic updates when theme or battery data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->