### PR TITLE
fix: step calibration counts 0 on Android — sticky standard-HR fallback suppressed the IMU stream

### DIFF
--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -2538,6 +2538,26 @@ class BleEngine {
     _log('Live streams enabled (optical: wrist-gated).');
   }
 
+  /// Clear the sticky standard-HR fallback and give the full live set another
+  /// chance. The fallback protects a struggling radio from the high-rate
+  /// flood, but it never resets and [enableLiveStreams] honours it silently —
+  /// so once tripped, every later step calibration / workout counted 0 steps
+  /// for the rest of the process lifetime (the IMU toggles were never sent).
+  /// Call this from EXPLICIT foreground user actions whose feature needs the
+  /// 100 Hz stream: there the flood is the point, and if the radio genuinely
+  /// can't sustain it the detectors re-trip (and re-downgrade) within seconds.
+  Future<void> retryFullLiveStreams() async {
+    if (state.standardHrFallback) {
+      _log('Radio fallback: cleared by explicit user action — retrying the '
+          'full live set.');
+      state.standardHrFallback = false;
+      _marginalRadio.reset();
+      _frameCorruption.reset();
+      onState(state);
+    }
+    await enableLiveStreams();
+  }
+
   /// Background live downgrade: keep ONLY the compact realtime-HR stream (0x28)
   /// armed and turn the high-rate R10/R11 + IMU + optical flood OFF. Used while
   /// backgrounded with no live consumer, so the radio isn't saturated by a raw

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2813,11 +2813,17 @@ class AppState extends ChangeNotifier {
     // open session still expects on. If the background downgrade left live in
     // HR-only, upgrade to full (the walk needs the 100 Hz IMU stream) without
     // taking ownership.
+    //
+    // retryFullLiveStreams (not enableLiveStreams): the walk NEEDS the 100 Hz
+    // IMU stream, and the sticky standard-HR fallback silently vetoes it —
+    // every calibration after a fallback trip counted 0 steps forever. An
+    // explicit user-initiated walk is exactly the moment to give the full
+    // flood another chance; the detectors re-trip if the radio can't cope.
     if (!engine.liveEnabled) {
-      await engine.enableLiveStreams();
+      await engine.retryFullLiveStreams();
       _stepCalEnabledStreams = true;
-    } else if (engine.liveHrOnly) {
-      await engine.enableLiveStreams();
+    } else if (engine.liveHrOnly || device.standardHrFallback) {
+      await engine.retryFullLiveStreams();
     }
     _resetLivePedometer(); // count this walk from 0
     notifyListeners();
@@ -2917,6 +2923,13 @@ class AppState extends ChangeNotifier {
     if (activeWorkout != null) return;
     final start = DateTime.now();
     final id = workoutId ?? 'w${start.millisecondsSinceEpoch}';
+    // The workout screen's live step count rides the 100 Hz IMU stream, which
+    // the sticky standard-HR fallback silently suppresses (same starvation as
+    // the calibration walk). A deliberate workout start is an explicit user
+    // action — retry the full live set; detectors re-trip if it can't hold.
+    if (isConnected && device.standardHrFallback) {
+      unawaited(engine.retryFullLiveStreams());
+    }
     _workoutRawBase = _liveRaw;
     activeWorkout = LiveWorkoutState(
       startTime: start,

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2925,9 +2925,16 @@ class AppState extends ChangeNotifier {
     final id = workoutId ?? 'w${start.millisecondsSinceEpoch}';
     // The workout screen's live step count rides the 100 Hz IMU stream, which
     // the sticky standard-HR fallback silently suppresses (same starvation as
-    // the calibration walk). A deliberate workout start is an explicit user
-    // action — retry the full live set; detectors re-trip if it can't hold.
-    if (isConnected && device.standardHrFallback) {
+    // the calibration walk) — and which may simply be off (spot-check cleanup
+    // restores streams to OFF when they were off before) or still in the
+    // background HR-only downgrade. A deliberate workout start is an explicit
+    // user action — retry the full live set; detectors re-trip if it can't
+    // hold. No ownership flag: the background downgrade / session close
+    // manage the stream lifecycle exactly as for openSession's arming.
+    if (isConnected &&
+        (!engine.liveEnabled ||
+            engine.liveHrOnly ||
+            device.standardHrFallback)) {
       unawaited(engine.retryFullLiveStreams());
     }
     _workoutRawBase = _liveRaw;

--- a/lib/ui/today/step_calibration_screen.dart
+++ b/lib/ui/today/step_calibration_screen.dart
@@ -81,6 +81,12 @@ class _StepCalibrationScreenState extends State<StepCalibrationScreen> {
   @override
   Widget build(BuildContext context) {
     final steps = context.select<AppState, int>((a) => a.liveSteps);
+    // The standard-HR radio fallback suppresses the 100 Hz IMU stream this
+    // walk counts on. startStepCalibration clears it and retries; if it
+    // TRIPS AGAIN mid-walk the radio genuinely can't sustain the stream —
+    // say so instead of showing "Keep walking…" over a count of 0 forever.
+    final radioDegraded =
+        context.select<AppState, bool>((a) => a.device.standardHrFallback);
     final done = _learnedCadence != null;
     final t = (_target > 0 ? steps / _target : 0.0).clamp(0.0, 1.0).toDouble();
     final ready = steps >= _target;
@@ -144,6 +150,19 @@ class _StepCalibrationScreenState extends State<StepCalibrationScreen> {
                 : Text(_started ? 'Keep walking…' : 'Starting…',
                     style: AppText.label.copyWith(color: AppColors.inkSoft)),
           ),
+          if (radioDegraded && _started && !ready) ...[
+            const SizedBox(height: Sp.x4),
+            StateCard(
+              icon: OsIcon.bluetooth,
+              title: "Bluetooth can't keep up",
+              message:
+                  'The connection to your strap is struggling to carry the '
+                  'high-rate motion stream, so steps aren\'t coming through. '
+                  'Bring your phone closer to the strap and retry.',
+              actionLabel: 'Retry stream',
+              onAction: _start,
+            ),
+          ],
           const SizedBox(height: Sp.x6),
           SurfaceCard(
             entranceIndex: 1,


### PR DESCRIPTION
## Symptom

Android users (myself included) run the step-calibration walk and the gauge never moves off **0 of 250**, no matter how far they walk. iOS users don't hit it. The same starvation affects the workout screen's live step count.

## Root cause — traced on a real device

I debugged this on a Pixel with a field bug report. At the exact moment calibration started, the app logged:

```
07-19 19:50:40.372  I flutter : [OpenStrap] Live streams: standard-HR only (marginal-radio fallback).
```

That's the early-out at the top of `enableLiveStreams`: when `state.standardHrFallback` is set, it arms realtime HR (0x28) only and **silently skips the R10/R11 + IMU (0x33) toggles**. The calibration pedometer counts exclusively over those high-rate accel frames, so it has literally nothing to count — while the screen keeps saying "Keep walking…".

The flag is set by two radio-health detectors (`MarginalRadioDetector`: 2 consecutive arm→quick-timeout cycles; `FrameCorruptionDetector`: ≥20% CRC failures over a 50-frame window). The design flaw is the combination of three properties:

1. **It never resets** — nothing clears `standardHrFallback` short of killing the app process.
2. **It degrades silently** — no UI anywhere reflects it; `enableLiveStreams` callers can't tell they got the degraded set.
3. **Android trips it far more readily than iOS** — Android BLE stacks handle the high-rate flood less gracefully (connection-interval and buffering differences make CRC corruption and post-arm drops much more common), which is why this presents as an Android-only bug.

So one rough patch of radio early in a session permanently kills step calibration and workout step counts until the next app restart. The fallback itself is doing its job — protecting a struggling link from a flood it can't sustain — but it's over-scoped: it also vetoes a deliberate, foreground, user-initiated action where the flood is the entire point.

## The fix

- **`BleEngine.retryFullLiveStreams()`** — clears `standardHrFallback`, resets both detectors, and re-arms the full live set. If the radio genuinely can't sustain it, the detectors re-trip (and re-downgrade) within seconds — the protection isn't weakened, it just gets re-evaluated when the user explicitly asks for the stream.
- **`startStepCalibration` and `startWorkout` use it** — these are the two features that need the 100 Hz accel. Spot check and breathing only consume 0x28 RR frames, which the fallback still delivers, so they're deliberately unchanged.
- **The calibration screen surfaces a re-trip** — if the fallback trips again mid-walk, the user now sees a "Bluetooth can't keep up" card with a retry action (which re-runs the same clear-and-retry path) instead of "Keep walking…" over a count that will never move.

## Testing

Verified the mechanism end-to-end on-device via logs (fallback line firing at calibration start on v0.9.15, Pixel). I couldn't run the app from this machine, so the changes are intentionally minimal and pattern-matched to the surrounding code: both detectors already had `reset()`, the engine already mutates+broadcasts `state` the same way on the trip path, and the screen reuses the existing `StateCard`. Would appreciate a maintainer smoke-test of: trip the fallback (walk out of range mid-live twice), then start a calibration — pre-patch it counts 0, post-patch it should re-arm and count.

Happy to split the UI card into a separate PR if you'd rather keep the engine change alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Retry stream” action during step calibration when Bluetooth performance is degraded.
  * Workouts and step calibration now automatically retry full live sensor streaming when the device is in a standard-HR fallback state or otherwise not running the expected full-IMU stream.

* **Bug Fixes**
  * Restored full-rate live sensor streams after a temporary Bluetooth fallback, improving live step counting and calibration reliability.
  * Provided clearer on-screen guidance when Bluetooth can’t keep up during calibration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->