### PR TITLE
fix(briefing): stop the briefing page rendering content twice

### DIFF
--- a/lib/ai/briefing_engine.dart
+++ b/lib/ai/briefing_engine.dart
@@ -204,7 +204,11 @@ String buildBriefingUserPrompt(
   one = one.replaceFirst(RegExp(r'^\s*[-*#>]+\s*'), '').trim();
   if (one.length > 200) one = '${one.substring(0, 199)}…';
   rest = rest.trim();
-  if (rest.isEmpty) rest = '- $one';
+  // A model that returns a single line (no bullets) has no distinct breakdown.
+  // Leave it EMPTY rather than echoing the one-liner back as a lone bullet —
+  // the breakdown card would then render the same sentence a second time
+  // (the "duplicates on the briefing page" bug). The UI hides an empty
+  // breakdown, so the one-liner shows exactly once.
   return (oneLiner: one, breakdownMd: rest);
 }
 

--- a/lib/ui/ai/ai_breakdown_screen.dart
+++ b/lib/ui/ai/ai_breakdown_screen.dart
@@ -185,6 +185,12 @@ class _AiBreakdownScreenState extends State<AiBreakdownScreen> {
     final at = DateTime.fromMillisecondsSinceEpoch(b.generatedAtMs);
     final hh = at.hour.toString().padLeft(2, '0');
     final mm = at.minute.toString().padLeft(2, '0');
+    final md = b.breakdownMd.trim();
+    // Hide the breakdown when it is empty or merely restates the one-liner —
+    // older cached briefings stored the one-liner back as a lone bullet, so the
+    // hero sentence rendered a second time (issue #107).
+    final breakdownBody = md.replaceFirst(RegExp(r'^[-*]\s*'), '').trim();
+    final showBreakdown = md.isNotEmpty && breakdownBody != b.oneLiner.trim();
     return [
       // Hero — the one-liner, numbers-first tone, glow like the Today slot.
       SurfaceCard(
@@ -194,30 +200,33 @@ class _AiBreakdownScreenState extends State<AiBreakdownScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Row(children: [
-              Container(
-                // Art carries its own padding: 2 + 28 ≈ the old 8 + 17 chip.
-                padding: const EdgeInsets.all(2),
-                decoration: BoxDecoration(
-                  color: AppColors.accentSoft,
-                  borderRadius: BorderRadius.circular(R.chip),
-                ),
-                child: const OsAppIcon(OsIcon.ai, size: 28),
+            // The AppScaffold title already names the screen ("Morning
+            // briefing"), so no overline label here — it just repeated the
+            // title (issue #107). The icon chip stays as the visual anchor.
+            Container(
+              // Art carries its own padding: 2 + 28 ≈ the old 8 + 17 chip.
+              padding: const EdgeInsets.all(2),
+              decoration: BoxDecoration(
+                color: AppColors.accentSoft,
+                borderRadius: BorderRadius.circular(R.chip),
               ),
-              const SizedBox(width: Sp.x3),
-              Text(b.period.title.toUpperCase(), style: AppText.overline),
-            ]),
+              child: const OsAppIcon(OsIcon.ai, size: 28),
+            ),
             const SizedBox(height: Sp.x4),
             Text(b.oneLiner, style: AppText.h2),
           ],
         ),
       ).dsEnter(index: 0),
-      const SizedBox(height: Sp.x3),
 
-      // The short structured breakdown (markdown bullets).
-      SurfaceCard(
-        child: GptMarkdown(b.breakdownMd, style: AppText.body),
-      ).dsEnter(index: 1),
+      // The short structured breakdown (markdown bullets). Hidden when the
+      // model returned only a one-liner (no distinct breakdown) — otherwise it
+      // echoes the hero sentence a second time (issue #107).
+      if (showBreakdown) ...[
+        const SizedBox(height: Sp.x3),
+        SurfaceCard(
+          child: GptMarkdown(md, style: AppText.body),
+        ).dsEnter(index: 1),
+      ],
       const SizedBox(height: Sp.x5),
 
       // Exactly what the model saw — the inputs snapshot as glanceable tiles.

--- a/test/ai_breakdown_widget_test.dart
+++ b/test/ai_breakdown_widget_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -118,5 +119,36 @@ void main() {
     await t.pump();
     await t.pump(const Duration(milliseconds: 700));
     expect(find.text('A solid, active day.'), findsOneWidget);
+  });
+
+  testWidgets('cached briefing that only echoes the one-liner renders it once',
+      (t) async {
+    // Older builds cached the one-liner back as a lone bullet, so the hero and
+    // the breakdown card showed the same sentence twice (issue #107). The guard
+    // must drop the breakdown card and render the sentence exactly once.
+    BriefingStore.write(Briefing(
+      day: todayLabel(),
+      period: BriefingPeriod.morning,
+      oneLiner: 'User Safety: safe',
+      breakdownMd: '- User Safety: safe',
+      generatedAtMs: DateTime.now().millisecondsSinceEpoch,
+      inputs: const {'readiness': 50},
+    ));
+    final engine = BriefingEngine(
+      config: CoachConfig(),
+      repo: _FakeRepo(),
+      complete: ({required system, required user}) async =>
+          throw StateError('should not generate when cached'),
+    );
+    await t.pumpWidget(_host(AiBreakdownScreen(
+      period: BriefingPeriod.morning,
+      engineOverride: engine,
+    )));
+    await t.pump();
+    await t.pump(const Duration(milliseconds: 700));
+
+    // Hero shows it once; the breakdown card (the only GptMarkdown) is gone.
+    expect(find.text('User Safety: safe'), findsOneWidget);
+    expect(find.byType(GptMarkdown), findsNothing);
   });
 }

--- a/test/ai_briefing_test.dart
+++ b/test/ai_briefing_test.dart
@@ -145,6 +145,14 @@ void main() {
       expect(r.oneLiner, 'Solid day.');
       expect(r.breakdownMd, contains('Good strain'));
     });
+
+    test('a single-line reply leaves the breakdown empty (no echo — #107)', () {
+      // A model that ignores the format and returns one line must NOT have that
+      // line copied back as a lone bullet, or the UI renders it twice.
+      final r = parseBriefingResponse('User Safety: safe');
+      expect(r.oneLiner, 'User Safety: safe');
+      expect(r.breakdownMd, isEmpty);
+    });
   });
 
   group('BriefingEngine + cache', () {


### PR DESCRIPTION
Fixes #107

## The bug

On the briefing page, content renders **twice** — the reporter's screenshot shows *"User Safety: safe"* as the hero headline **and** again as a bullet below it, plus *"Morning Briefing"* in both the screen title and the card overline.

## Root cause

Two independent duplications:

**A — content echoed (the real bug).** The user's BYOK model ignored the output format and returned a single line (`User Safety: safe`) instead of `one-liner / --- / bullets`. `parseBriefingResponse` then hit its empty-breakdown fallback:

```dart
if (rest.isEmpty) rest = '- $one';   // briefing_engine.dart
```

…which **copies the one-liner into the breakdown as a lone bullet**. `AiBreakdownScreen` renders the one-liner in the hero card *and* the breakdown card, so the same sentence appears twice.

**B — title echoed (cosmetic).** The hero card drew an overline `b.period.title.toUpperCase()` directly under the `AppScaffold` title, which is already `widget.period.title` — "Morning briefing" / "MORNING BRIEFING".

## The fix

- **`parseBriefingResponse`** now leaves `breakdownMd` **empty** when the model gave no distinct breakdown, instead of echoing the one-liner.
- **`AiBreakdownScreen`** hides the breakdown card when it is empty *or merely restates the one-liner* — so **already-cached** briefings (which stored the echoed `- one-liner`) also stop double-rendering, with no regeneration needed.
- **Drops the hero overline** (duplication B); the icon chip stays as the visual anchor.

Happy-path briefings (proper one-liner + bullets) are unchanged.

## Tests

Adds a parser regression: a single-line reply yields the one-liner with an **empty** breakdown (no echo). Existing separator/code-fence parse tests still pass (they have distinct bullet content, so they're unaffected).

https://claude.ai/code/session_016q4RHdYkMAWuvDMFYNJbqp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented briefing summaries from showing the same sentence twice.
  * Improved handling for cached briefings so one-liners that were stored as single bullets don’t duplicate the hero text.
  * Breakdown markdown now renders only when it contains meaningful, non-duplicative content.
  * Removed the period title overline from the briefing hero display.
* **Tests**
  * Added parser coverage for single-line AI briefing responses.
  * Added widget coverage to ensure cached briefings don’t render a breakdown card when it would duplicate content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->