### PR TITLE
fix(android): restore monotonic versionCode and guard releases (v0.9.17 = uninstallable)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,58 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need all tags so the versionCode guard can read prior releases' pubspec
+
+      # Fail the release BEFORE building if the Android versionCode is missing or
+      # would go backwards. Flutter derives versionCode from the `+BUILD` suffix
+      # of pubspec's `version:` and silently falls back to 1 when it's absent, so
+      # `version: 0.9.17+1` shipped v0.9.17 with versionCode 1 — a downgrade from
+      # 0.9.15/0.9.16 (versionCode 48). Android then refuses every upgrade install
+      # (INSTALL_FAILED_VERSION_DOWNGRADE, shown to users as "App not installed").
+      # This guard turns that class of mistake into a red build instead of a
+      # broken release.
+      - name: Guard — versionCode present, matches tag, and strictly increasing
+        run: |
+          set -euo pipefail
+          ver=$(grep -E '^version:' pubspec.yaml | head -1 | awk '{print $2}')
+          name=${ver%%+*}
+          build=${ver#*+}
+
+          if [ "$build" = "$ver" ]; then
+            echo "::error::pubspec version '$ver' has no +BUILD suffix — versionCode would fall back to 1 and break upgrades."
+            exit 1
+          fi
+          if ! printf '%s' "$build" | grep -qE '^[0-9]+$'; then
+            echo "::error::pubspec build number '$build' is not an integer."
+            exit 1
+          fi
+
+          # The tag being released must match the versionName, so the user-facing
+          # version can't drift from the tag (v0.9.16 shipped bytes identical to
+          # v0.9.15 because pubspec was never bumped). Suffixed tags such as
+          # v0.9.14-whoop5-experimental are allowed against name 0.9.14.
+          tag=${GITHUB_REF_NAME#v}
+          case "$tag" in
+            "$name"|"$name"-*) : ;;
+            *) echo "::error::tag '$GITHUB_REF_NAME' does not match pubspec versionName '$name'."; exit 1 ;;
+          esac
+
+          # versionCode must exceed the highest already-released versionCode, or
+          # the new APK can't install over existing devices.
+          max=0
+          for t in $(git tag -l 'v*'); do
+            [ "$t" = "$GITHUB_REF_NAME" ] && continue
+            pv=$(git show "$t:pubspec.yaml" 2>/dev/null | grep -E '^version:' | head -1 | awk '{print $2}' || true)
+            b=${pv#*+}
+            printf '%s' "$b" | grep -qE '^[0-9]+$' || continue
+            [ "$b" -gt "$max" ] && max=$b
+          done
+          if [ "$build" -le "$max" ]; then
+            echo "::error::versionCode $build is not greater than the highest released versionCode $max — installs would be blocked as a downgrade."
+            exit 1
+          fi
+          echo "versionCode $build (versionName $name) OK — exceeds prior max $max."
 
       - uses: actions/setup-java@v4
         with:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 # Watch App" targets in ios/Runner.xcodeproj/project.pbxproj — they aren't wired
 # to FLUTTER_BUILD_NAME/FLUTTER_BUILD_NUMBER. See guides/IOS_INSTALLATION.md
 # "Version Numbers".
-version: 0.9.17+1
+version: 0.9.18+49
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
## Problem

Installing the **v0.9.17** release fails on-device with a bare **"App not installed"** dialog. It isn't a signing issue — every official release is signed with the same keystore from CI secrets. It's a **versionCode downgrade**.

Actual values baked into the shipped APKs:

| Release | versionCode | versionName |
|---------|-------------|-------------|
| v0.9.15 | 48 | 0.9.15 |
| v0.9.16 | 48 | 0.9.15 |
| **v0.9.17** | **1** | **0.9.17** |

`android/app/build.gradle.kts` sets `versionCode = flutter.versionCode`, and Flutter derives that from the `+BUILD` suffix in `pubspec.yaml`. Commit `c8d75af` set `version: 0.9.17+1`, so versionCode collapsed 48 → **1**. Android refuses to install an APK whose versionCode is lower than the installed one (`INSTALL_FAILED_VERSION_DOWNGRADE`), shown to users as "App not installed".

(Two supporting clues: v0.9.16 is byte-for-byte identical to v0.9.15 and still reports versionName `0.9.15` — pubspec wasn't bumped for that tag either; and the release trigger is just `push: tags: ['v*']`, so a bad pubspec sails straight to a published release with no gate.)

## Fix

1. **`pubspec.yaml` → `0.9.18+49`** — restores a monotonic versionCode (49 > 48). A fresh patch release rather than re-cutting the burned `v0.9.17` tag; `49` upgrades cleanly over *both* the versionCode-48 installs and anyone who grabbed the broken versionCode-1 build.
2. **Release-time CI guard** in `build.yml` (runs before the build) that fails the release when the versionCode is:
   - missing the `+BUILD` suffix (the exact v0.9.17 footgun — Flutter would silently fall back to 1),
   - non-integer,
   - mismatched with the release tag's versionName, or
   - not strictly greater than the highest already-released versionCode.

   Needs `fetch-depth: 0` on checkout so it can read prior tags' pubspec. Verified locally: passes for `0.9.18+49`, and correctly rejects the `0.9.17+1` case (`versionCode 1 <= prior max 48`).

## Note for release cutter

`v0.9.17` is already published with versionCode 1 and can't be fixed in place — cut **v0.9.18** from this branch once merged. Anyone who installed the broken v0.9.17 will be able to upgrade to v0.9.18 normally.

> Heads-up from the pubspec comment: a version bump also needs the iOS `MARKETING_VERSION`/`CURRENT_PROJECT_VERSION` updated for the widget/watch targets in `project.pbxproj`. Left out of this PR to keep it Android-focused — flag if you'd like it folded in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release validation to ensure Android version numbers match release tags and increase consistently.
  * Releases now stop early when version information is missing, invalid, mismatched, or not higher than previous releases.

* **Chores**
  * Updated the app version to 0.9.18 (build 49).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->