### PR TITLE
fix(notify): deep-link detected-workout notification to the log/adjust review (#113)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -195,6 +195,9 @@ class _ShellState extends State<_Shell> {
       kRouteAiEvening =>
         const AiBreakdownScreen(period: BriefingPeriod.evening),
       kRouteJournalCompose => const JournalComposeScreen(),
+      // "Did you work out?" auto-detect tap → focused log/adjust review, on top
+      // of the Workouts tab (issue #113). WorkoutsScreen is already imported.
+      kRouteWorkoutSuggestion => const WorkoutSuggestionScreen(),
       // Siri/Shortcuts "start breathing" App Intent — see StartBreathingIntent
       // in OpenStrapIntents.swift, which writes this route into the App Group
       // for WidgetService.consumePendingRoute() to pick up on launch/resume.

--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -34,6 +34,7 @@ import '../data/db.dart';
 import '../data/day_label.dart';
 import '../notify/notification_center.dart';
 import '../notify/notification_event.dart';
+import '../notify/tap_router.dart' show kRouteWorkoutSuggestion;
 import '../telemetry/telemetry_service.dart';
 import 'crossday_pipeline.dart';
 import 'derive_prepare.dart';
@@ -1559,7 +1560,7 @@ class DerivationEngine {
             body: 'We spotted ~${nb.durationMin} min of elevated activity. '
                 'Tap to log it.',
             date: day.date,
-            route: '/workouts',
+            route: kRouteWorkoutSuggestion,
           ),
           // This runs from headless background derivation too — never prompt
           // for permission from a background context (violates the OS

--- a/lib/notify/tap_router.dart
+++ b/lib/notify/tap_router.dart
@@ -11,6 +11,12 @@ const String kRouteAiEvening = '/ai/evening';
 const String kRouteJournalCompose = '/journal/compose';
 const String kRouteBreathing = '/breathing';
 
+/// "Did you work out?" auto-detect notification. Lands on the Workouts tab and
+/// pushes a focused review of the detected activity (log or adjust) — the plain
+/// `/workouts` route only selected the tab, leaving the suggestion buried in the
+/// history list (issue #113).
+const String kRouteWorkoutSuggestion = '/workouts/suggestion';
+
 class TapTarget {
   /// Shell tab index to land on (always valid; unknown → 0 = Today).
   final int tab;
@@ -30,16 +36,21 @@ const Map<String, int> _tabRoutes = {
   '/workouts': 4,
 };
 
-const Set<String> _screenRoutes = {
-  kRouteAiMorning,
-  kRouteAiEvening,
-  kRouteJournalCompose,
-  kRouteBreathing,
+// Sub-screen routes → the shell tab they sit on top of. Most briefing/journal
+// deep links live over Today (0); the detected-workout review sits over the
+// Workouts tab (4) so the tab underneath is the natural place to land on close.
+const Map<String, int> _screenRoutes = {
+  kRouteAiMorning: 0,
+  kRouteAiEvening: 0,
+  kRouteJournalCompose: 0,
+  kRouteBreathing: 0,
+  kRouteWorkoutSuggestion: 4,
 };
 
 TapTarget resolveTapRoute(String route) {
   final tab = _tabRoutes[route];
   if (tab != null) return TapTarget(tab);
-  if (_screenRoutes.contains(route)) return TapTarget(0, route);
+  final base = _screenRoutes[route];
+  if (base != null) return TapTarget(base, route);
   return const TapTarget(0); // unknown (e.g. /recap) → Today
 }

--- a/lib/ui/workouts/workouts_screen.dart
+++ b/lib/ui/workouts/workouts_screen.dart
@@ -198,19 +198,7 @@ class _WorkoutsScreenState extends State<WorkoutsScreen> {
   /// Confirm an auto-detected suggestion → create a completed session, then
   /// drop the suggestion and refresh.
   Future<void> _confirmSuggestion(Map<String, dynamic> s) async {
-    final start = (s['start_ts'] as num?)?.toInt() ?? 0;
-    await LocalDb.putSession({
-      'id': 'auto:$start',
-      'start_ts': start,
-      'end_ts': (s['end_ts'] as num?)?.toInt(),
-      'type': (s['sport'] as String?) ?? 'cardio',
-      'status': 'done',
-      'duration_min': (s['duration_min'] as num?)?.toInt(),
-      'max_hr': (s['peak_bpm'] as num?)?.toInt(),
-      'source': 'auto',
-      'created_at': DateTime.now().millisecondsSinceEpoch,
-    });
-    await LocalDb.dismissWorkoutSuggestion(s['id'] as String);
+    await _logDetectedSession(s);
     await _load();
   }
 
@@ -501,6 +489,26 @@ class _StartButton extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Log an auto-detected suggestion as a completed session and drop the
+/// suggestion. Shared by the Workouts tab card and the deep-linked
+/// [WorkoutSuggestionScreen] so both write an identical session. Never logs
+/// silently — only called from an explicit "Log it" tap.
+Future<void> _logDetectedSession(Map<String, dynamic> s) async {
+  final start = (s['start_ts'] as num?)?.toInt() ?? 0;
+  await LocalDb.putSession({
+    'id': 'auto:$start',
+    'start_ts': start,
+    'end_ts': (s['end_ts'] as num?)?.toInt(),
+    'type': (s['sport'] as String?) ?? 'cardio',
+    'status': 'done',
+    'duration_min': (s['duration_min'] as num?)?.toInt(),
+    'max_hr': (s['peak_bpm'] as num?)?.toInt(),
+    'source': 'auto',
+    'created_at': DateTime.now().millisecondsSinceEpoch,
+  });
+  await LocalDb.dismissWorkoutSuggestion(s['id'] as String);
 }
 
 /// An opt-in auto-detected workout the user can confirm (→ logs a session) or
@@ -1543,4 +1551,94 @@ class WorkoutDetailContent extends StatelessWidget {
       ],
     ),
   );
+}
+
+/// Focused review of auto-detected workout suggestions, deep-linked from the
+/// "Did you work out?" notification (route [kRouteWorkoutSuggestion], resolved
+/// in tap_router.dart). The notification used to route to plain `/workouts`,
+/// which only selected the Workouts tab and left the suggestion as one card in
+/// the history list — so tapping it never clearly took the user to where the
+/// detected activity could be logged or adjusted (issue #113). This lands them
+/// straight on that log/adjust affordance, on top of the Workouts tab.
+class WorkoutSuggestionScreen extends StatefulWidget {
+  const WorkoutSuggestionScreen({super.key});
+
+  @override
+  State<WorkoutSuggestionScreen> createState() =>
+      _WorkoutSuggestionScreenState();
+}
+
+class _WorkoutSuggestionScreenState extends State<WorkoutSuggestionScreen> {
+  List<Map<String, dynamic>> _suggestions = const [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final sug = await LocalDb.activeWorkoutSuggestions();
+      if (mounted) {
+        setState(() {
+          _suggestions = sug;
+          _loading = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _confirm(Map<String, dynamic> s) async {
+    await _logDetectedSession(s);
+    await _afterAction();
+  }
+
+  Future<void> _dismiss(Map<String, dynamic> s) async {
+    await LocalDb.dismissWorkoutSuggestion(s['id'] as String);
+    await _afterAction();
+  }
+
+  // Reload; once there's nothing left to review, close back to the Workouts tab
+  // underneath (which lists the now-logged session).
+  Future<void> _afterAction() async {
+    await _load();
+    if (mounted && _suggestions.isEmpty) Navigator.of(context).maybePop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppScaffold(
+      title: 'Detected activity',
+      children: [
+        if (_loading)
+          const Padding(
+            padding: EdgeInsets.only(top: Sp.x6),
+            child: Center(child: CircularProgressIndicator()),
+          )
+        else if (_suggestions.isEmpty)
+          Padding(
+            padding: const EdgeInsets.only(top: Sp.x6),
+            child: Text(
+              'Nothing to review right now — this activity may already have '
+              'been logged or dismissed.',
+              style: AppText.captionMuted,
+            ),
+          )
+        else
+          for (final s in _suggestions)
+            Padding(
+              padding: const EdgeInsets.only(bottom: Sp.x3),
+              child: _SuggestionCard(
+                s: s,
+                onConfirm: () => _confirm(s),
+                onDismiss: () => _dismiss(s),
+              ),
+            ),
+      ],
+    );
+  }
 }

--- a/lib/ui/workouts/workouts_screen.dart
+++ b/lib/ui/workouts/workouts_screen.dart
@@ -1571,6 +1571,11 @@ class WorkoutSuggestionScreen extends StatefulWidget {
 class _WorkoutSuggestionScreenState extends State<WorkoutSuggestionScreen> {
   List<Map<String, dynamic>> _suggestions = const [];
   bool _loading = true;
+  // Tracked SEPARATELY from `_suggestions` — a failed query must not be
+  // rendered as "nothing to review": that tells the user a still-active
+  // suggestion was already handled. Only a successful query with zero
+  // results earns the empty state; a failure gets a retryable error card.
+  bool _error = false;
 
   @override
   void initState() {
@@ -1579,6 +1584,10 @@ class _WorkoutSuggestionScreenState extends State<WorkoutSuggestionScreen> {
   }
 
   Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = false;
+    });
     try {
       final sug = await LocalDb.activeWorkoutSuggestions();
       if (mounted) {
@@ -1588,25 +1597,52 @@ class _WorkoutSuggestionScreenState extends State<WorkoutSuggestionScreen> {
         });
       }
     } catch (_) {
-      if (mounted) setState(() => _loading = false);
+      // Deliberately leave `_suggestions` untouched — we don't know whether
+      // it's really empty, only that we failed to find out.
+      if (mounted) {
+        setState(() {
+          _loading = false;
+          _error = true;
+        });
+      }
     }
   }
 
   Future<void> _confirm(Map<String, dynamic> s) async {
-    await _logDetectedSession(s);
+    try {
+      await _logDetectedSession(s);
+    } catch (_) {
+      _showActionFailure('Could not log this workout — try again.');
+      return;
+    }
     await _afterAction();
   }
 
   Future<void> _dismiss(Map<String, dynamic> s) async {
-    await LocalDb.dismissWorkoutSuggestion(s['id'] as String);
+    try {
+      await LocalDb.dismissWorkoutSuggestion(s['id'] as String);
+    } catch (_) {
+      _showActionFailure('Could not dismiss this suggestion — try again.');
+      return;
+    }
     await _afterAction();
+  }
+
+  // A failed confirm/dismiss must be visible — the suggestion is still
+  // active, but silently doing nothing reads as "it worked".
+  void _showActionFailure(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
   }
 
   // Reload; once there's nothing left to review, close back to the Workouts tab
   // underneath (which lists the now-logged session).
   Future<void> _afterAction() async {
     await _load();
-    if (mounted && _suggestions.isEmpty) Navigator.of(context).maybePop();
+    if (mounted && !_error && _suggestions.isEmpty) {
+      Navigator.of(context).maybePop();
+    }
   }
 
   @override
@@ -1618,6 +1654,17 @@ class _WorkoutSuggestionScreenState extends State<WorkoutSuggestionScreen> {
           const Padding(
             padding: EdgeInsets.only(top: Sp.x6),
             child: Center(child: CircularProgressIndicator()),
+          )
+        else if (_error)
+          Padding(
+            padding: const EdgeInsets.only(top: Sp.x6),
+            child: StateCard(
+              icon: OsIcon.sync,
+              title: "Couldn't load",
+              message: 'Check your connection and try again.',
+              actionLabel: 'Retry',
+              onAction: _load,
+            ),
           )
         else if (_suggestions.isEmpty)
           Padding(

--- a/test/tap_router_test.dart
+++ b/test/tap_router_test.dart
@@ -24,6 +24,22 @@ void main() {
     expect(resolveTapRoute(kRouteJournalCompose).screen, kRouteJournalCompose);
   });
 
+  test(
+      'kRouteWorkoutSuggestion lands on the Workouts tab + the suggestion '
+      'sub-screen (issue #113)', () {
+    final t = resolveTapRoute(kRouteWorkoutSuggestion);
+    expect(t.tab, 4); // Workouts tab underneath
+    expect(t.screen, kRouteWorkoutSuggestion); // focused log/adjust review
+  });
+
+  test('plain /workouts still resolves to the tab with no sub-screen', () {
+    // The auto-detect notification now uses kRouteWorkoutSuggestion, but the
+    // bare tab route must keep working for any other caller.
+    final t = resolveTapRoute('/workouts');
+    expect(t.tab, 4);
+    expect(t.screen, isNull);
+  });
+
   test('an unknown/stale route falls back to Today, never crashes', () {
     final t = resolveTapRoute('/recap');
     expect(t.tab, 0);


### PR DESCRIPTION
## Problem

Fixes #113. When an activity is auto-detected, tapping the **"Did you work out?"** notification doesn't take you to where the detected activity can be logged or adjusted.

Root cause: the notification is emitted with `route: '/workouts'` (`lib/compute/derivation_engine.dart`), and `/workouts` resolves to the **Workouts tab only** (`tap_router.dart`) — no focused screen. The suggestion *does* render as a `_SuggestionCard` on that tab, but it's one card in the history list, so the tap never clearly lands the user on the log/adjust affordance. The other deep links (`/ai/morning`, `/journal/compose`, `/breathing`) each push a focused sub-screen; the detected-workout tap didn't.

## Fix

Add a dedicated **`/workouts/suggestion`** sub-screen deep link that opens a focused review of the active suggestion(s) — the existing **Log it / Dismiss** actions — sitting on top of the Workouts tab, consistent with the existing sub-screen pattern.

- **`tap_router.dart`** — new `kRouteWorkoutSuggestion`. `_screenRoutes` becomes a `route → base tab` map so a sub-screen can sit over any tab (briefing/journal stay over Today `0`; the suggestion review sits over Workouts `4`, so closing it lands you on the Workouts tab).
- **`derivation_engine.dart`** — the auto-detect notification now uses `kRouteWorkoutSuggestion`.
- **`app.dart`** — `_onScreenRequest` pushes `WorkoutSuggestionScreen` for the new route.
- **`workouts_screen.dart`** — extract a shared `_logDetectedSession` (so the tab card and the new screen write an identical session) and add `WorkoutSuggestionScreen`, which reuses the existing `_SuggestionCard`. Confirming/dismissing the last suggestion pops back to the Workouts tab.
- **`test/tap_router_test.dart`** — covers the new route + a regression guard that plain `/workouts` still resolves to the tab with no sub-screen.

## Behaviour after

Tap the "Did you work out?" notification → land directly on a **Detected activity** screen with Log it / Dismiss, over the Workouts tab. Works on both warm and cold start (the shell already replays the launch route via a post-frame callback).

## Notes / limitations

- **No parameterised payload.** The review shows *all* currently-active suggestions rather than one specific id (the route string carries no id, matching the existing param-less sub-screen routes). In practice there's normally a single fresh suggestion; showing any others pending is fine.
- **Underlying tab refresh.** After confirming, the Workouts tab beneath keeps its cached suggestion list until its next load (pull-to-refresh / re-open). Pre-existing coarseness, left out of scope to keep the change focused.
- **Couldn't run the analyzer/tests locally** (no Flutter SDK on my machine, and CI only runs on tag push, not PRs). The change is self-contained and I've reviewed it against the surrounding code + conventions; a maintainer running `flutter analyze` / `flutter test` before merge would be the final check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated screen for reviewing automatically detected workout suggestions.
  * Tapping workout suggestion notifications now opens directly to the Workouts tab and focused review view.
  * Users can confirm to log completed sessions or dismiss workout suggestions from the review screen.
* **Bug Fixes**
  * Improved deep-link routing to place workout suggestion links on the correct tab while keeping existing navigation behavior for other routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->