### PR TITLE
Fix readiness_absent Crashlytics noise and map-tile FATAL misclassification

### DIFF
--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -1451,6 +1451,7 @@ class DerivationEngine {
         if (v == null) continue;
         flat['${key}_value'] = v['value'];
         flat['${key}_baseline_n'] = v['baseline_n'];
+        flat['${key}_baseline_sd'] = v['baseline_sd'];
       }
       flat['note'] = diag['note'];
       TelemetryService.instance.record(
@@ -1465,14 +1466,26 @@ class DerivationEngine {
       // with sleep present" is diagnosable from the per-input flags WITHOUT GA4
       // access. Cold-start (need_baseline) absences stay Analytics-only so this
       // stays low-noise (and, post the MAD/SD-z fallback, rare).
+      //
+      // GATE: only fire the Crashlytics non-fatal when at least one input
+      // actually HAD a value with an adequate baseline (`value == true` — the
+      // "should have computed" case) — a day with literally no sleep session
+      // and no day-HR (every input false) is an honest, unremarkable miss, not
+      // a surprise, and was previously alarming here just as loudly as a real
+      // regression (analytics-only note above still records it either way).
       final note = (diag['note'] as String?) ?? '';
-      if (!note.startsWith('need_baseline')) {
+      final anyValuePresent = ['hrv', 'rhr', 'resp', 'temp'].any((key) {
+        final v = (diag[key] as Map?)?.cast<String, dynamic>();
+        return v != null && v['value'] == true;
+      });
+      if (!note.startsWith('need_baseline') && anyValuePresent) {
         final summary = StringBuffer('readiness_absent');
         for (final key in ['hrv', 'rhr', 'resp', 'temp']) {
           final v = (diag[key] as Map?)?.cast<String, dynamic>();
           if (v == null) continue;
           summary.write(
-              ' $key=${v['value'] == true ? 'Y' : 'n'}/${v['baseline_n']}');
+              ' $key=${v['value'] == true ? 'Y' : 'n'}/${v['baseline_n']}'
+              '(sd=${v['baseline_sd']})');
         }
         summary.write(' | $note');
         TelemetryService.instance.recordNonFatal(

--- a/lib/compute/onehz_pipeline.dart
+++ b/lib/compute/onehz_pipeline.dart
@@ -379,13 +379,34 @@ Map<String, dynamic> deriveDayBundle(Map<String, dynamic> inputJson) {
   // "no value" / "baseline too short" from "everything present but MAD was
   // degenerate" by elimination (readinessComposite doesn't surface the last
   // case in its own note — see readiness_composite.dart's robustZ() null path).
+  // `baseline_sd` additionally distinguishes a TRULY zero-dispersion baseline
+  // (readinessComposite's documented, intentional "never fabricate against
+  // zero dispersion" abstain — see its rescue-vs-flat test) from some other,
+  // unexplained cause of a null z — so a future Crashlytics hit is diagnosable
+  // instead of another round of guessing from value/baseline_n alone.
   Map<String, dynamic>? readinessAbsentDiag;
   if (!composite.present) {
     readinessAbsentDiag = {
-      'hrv': {'value': lnToday != null, 'baseline_n': d.lnRmssdHistory.length},
-      'rhr': {'value': rhrToday != null, 'baseline_n': d.rhrHistory.length},
-      'resp': {'value': respToday != null, 'baseline_n': d.respHistory.length},
-      'temp': {'value': skinTempAdc != null, 'baseline_n': d.skinTempAdcHistory.length},
+      'hrv': {
+        'value': lnToday != null,
+        'baseline_n': d.lnRmssdHistory.length,
+        'baseline_sd': _stddev(d.lnRmssdHistory),
+      },
+      'rhr': {
+        'value': rhrToday != null,
+        'baseline_n': d.rhrHistory.length,
+        'baseline_sd': _stddev(d.rhrHistory),
+      },
+      'resp': {
+        'value': respToday != null,
+        'baseline_n': d.respHistory.length,
+        'baseline_sd': _stddev(d.respHistory),
+      },
+      'temp': {
+        'value': skinTempAdc != null,
+        'baseline_n': d.skinTempAdcHistory.length,
+        'baseline_sd': _stddev(d.skinTempAdcHistory),
+      },
       'note': composite.note,
     };
   }

--- a/lib/telemetry/telemetry_service.dart
+++ b/lib/telemetry/telemetry_service.dart
@@ -77,7 +77,22 @@ class TelemetryService {
       prior?.call(details);
       try {
         if (Firebase.apps.isNotEmpty && _enabled) {
-          FirebaseCrashlytics.instance.recordFlutterFatalError(details);
+          // Flutter itself marks a FlutterErrorDetails `silent: true` for
+          // errors it considers expected/non-actionable noise — e.g. an
+          // image/tile network fetch that fails after the requesting widget
+          // (a workout-route map tile) was already disposed: the framework's
+          // own ImageStreamCompleter.reportError falls through to this global
+          // handler only because no listener remained to catch it, NOT
+          // because the app crashed (see image_stream.dart's `silent: true`
+          // call sites — "resolving an image codec" / "loading an image").
+          // Treating every FlutterError as FATAL misclassified these as
+          // fatal crashes (inflating crash-free-users) even though the app
+          // kept running fine. Still fully captured — just filed as
+          // non-fatal so it doesn't count against crash-free-rate.
+          FirebaseCrashlytics.instance.recordFlutterError(
+            details,
+            fatal: !details.silent,
+          );
         }
       } catch (_) {}
       record(
@@ -85,7 +100,7 @@ class TelemetryService {
         level: 'error',
         message: details.exceptionAsString(),
         stack: details.stack?.toString(),
-        context: {'library': details.library ?? 'flutter'},
+        context: {'library': details.library ?? 'flutter', 'silent': details.silent},
       );
     };
     PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {

--- a/lib/telemetry/telemetry_service.dart
+++ b/lib/telemetry/telemetry_service.dart
@@ -116,10 +116,13 @@ class TelemetryService {
 
   // ── observability surface: breadcrumbs, context, non-fatals, traces ────────
   //
-  // Crashlytics only ever sees FATAL errors on its own (installErrorHandlers
-  // above) — it has zero visibility into freezes/jank or into errors that get
-  // caught-and-swallowed today. These helpers are how we get real signal out
-  // of Firebase for exactly those blind spots:
+  // Crashlytics only ever sees framework-reported errors on its own
+  // (installErrorHandlers above) — PlatformDispatcher.onError is always fatal,
+  // and FlutterError.onError is fatal unless the framework itself flagged the
+  // FlutterErrorDetails `silent` (then non-fatal). Either way it has zero
+  // visibility into freezes/jank or into errors that get caught-and-swallowed
+  // today. These helpers are how we get real signal out of Firebase for
+  // exactly those blind spots:
   //   - breadcrumb()/setContext(): attached automatically to whatever crash OR
   //     ANR report comes next from this session — the log() calls and the
   //     currently-set custom keys both ride along, no extra wiring needed.


### PR DESCRIPTION
- Gate the readiness_absent Crashlytics non-fatal to only fire when at least one input genuinely had a value with an adequate baseline (the true "should have computed" case), not on an honest no-sleep/no-HR day where every input is legitimately absent. Also record each input's baseline stddev in the diagnostic so a future hit is immediately distinguishable from readinessComposite's intentional zero-dispersion abstain (see wellness_test.dart) instead of another round of guessing.
- Respect Flutter's FlutterErrorDetails.silent flag in the global FlutterError.onError hook: errors the framework itself marks silent (e.g. an image/tile network fetch failing after its widget was disposed — seen live as a FATAL crash while viewing a workout route map with no connectivity) are now recorded as non-fatal instead of unconditionally fatal, so they stop inflating the crash-free-users metric.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced readiness diagnostics by adding `baseline_sd` to readiness “absent” details for each input, improving interpretation of missing readiness results.
  - Reduced non-fatal crash alert noise by only emitting “readiness absent” reports when readiness is not the expected baseline-needed case and at least one input indicates a true value.
  - Improved error classification by recording silent framework issues as non-fatal and marking silence in the stored error context for more accurate troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->