### PR TITLE
fix(today): don't flash a stale readiness before today's settles

### DIFF
--- a/lib/compute/onehz_pipeline.dart
+++ b/lib/compute/onehz_pipeline.dart
@@ -33,6 +33,40 @@ const MetricCfg _skinTempAdcCfg = MetricCfg(
   halfLifeS: 21.0,
 );
 
+/// Physiological cap on the readiness composite z, above which the score is a
+/// degenerate-baseline artefact rather than a real reading — so it is abstained
+/// from the HEADLINE scalar rather than persisted.
+///
+/// The composite maps its weighted, sign-oriented z to a 0–100 score via a
+/// logistic (`readiness_composite.dart`): `score = 100 / (1 + exp(-z))`. That
+/// curve only approaches the 100 rail as z → ∞: a real composite z is a weighted
+/// mean of per-input robust-z's, so even a flawless morning (every input at +2 z)
+/// lands at z=2 → score 88, and +3 z all-round is z=3 → 95. Reaching z=5
+/// (score 99.3) is physiologically unreachable by a genuine reading — it only
+/// happens when an input's robust-z explodes because its baseline MAD is tiny.
+///
+/// robustZ (`util.dart`) returns null only on EXACT-zero MAD (fully-quantised
+/// baseline) → the composite abstains and the ring shows a blank '—'. But a
+/// baseline that is near-degenerate — e.g. duplicate-day pollution collapsing the
+/// window toward one repeated value — has a tiny NON-zero MAD, so robustZ does
+/// NOT null: it returns a huge z, the logistic saturates, and the headline flashes
+/// ~100 before a cleaner re-derive snaps it back (the ready→ready bounce, #117).
+/// Capping at 5 suppresses ONLY that saturated rail and hides zero legitimate
+/// scores. This is the belt-and-braces guard; removing the degenerate baselines at
+/// source is the sibling `fix/readiness-baseline-pollution` work.
+const double kReadinessZCap = 5.0;
+
+/// The headline readiness scalar for a computed [composite], or null when it must
+/// abstain: absent composite, or one whose |z| exceeds [kReadinessZCap] (a
+/// saturated, degenerate-baseline artefact — see [kReadinessZCap]). Pure so the
+/// gate is unit-testable without the full pipeline.
+double? headlineReadinessScalar(Metric<Readiness> composite) {
+  if (!composite.present) return null;
+  final r = composite.value!;
+  if (r.compositeZ.abs() > kReadinessZCap) return null;
+  return r.score;
+}
+
 /// Serializable input to the isolate: one physiological day's decoded 1 Hz
 /// substrate (the day slice), the PRECOMPUTED single-source sleep segmentation,
 /// the profile, and trailing baseline history for the readiness pass.
@@ -599,7 +633,9 @@ Map<String, dynamic> deriveDayBundle(Map<String, dynamic> inputJson) {
   final rmssdWholeScalar = (hrvT.present && hrvT.value!.rmssd != null)
       ? hrvT.value!.rmssd
       : null;
-  final readinessScalar = composite.present ? composite.value!.score : null;
+  // Abstain from a saturated, degenerate-baseline readiness rather than persist a
+  // bogus ~100 that a cleaner re-derive would then snap back down (#117 bounce).
+  final readinessScalar = headlineReadinessScalar(composite);
   final strainScalar = strainMetric.present ? strainMetric.value : null;
 
   // ── STRESS: Baevsky SI → a transparent 0–100 score (log-mapped over the

--- a/lib/models/payloads.dart
+++ b/lib/models/payloads.dart
@@ -127,6 +127,27 @@ class TodayData {
   Metric get recovery => metricOf(_daily, 'recovery');
   // Composite Readiness (HRV ∩ sleep ∩ dip ∩ arousal) — the Today/widget headline.
   Metric get readiness => metricOf(_daily, 'readiness');
+
+  /// The rounded readiness score to HEADLINE for today — present only once
+  /// today's overnight has actually settled (`overnight_state == 'ready'`).
+  ///
+  /// While the overnight is still building, `getToday` surfaces the LAST settled
+  /// night's readiness (`showing_prior_overnight`) so the rest of the screen has
+  /// something to show. Rendering that stale value as the big readiness ring made
+  /// it flash the prior night's score for the split second before today's real
+  /// score landed and the ring snapped to it. Withhold the number until today's
+  /// value is settled so the hero shows its honest empty/loading state instead of
+  /// a bogus figure. Null when readiness is absent OR not yet settled for today.
+  int? get settledReadinessScore {
+    if (readiness.isEmpty) return null;
+    // getToday always stamps `status`; when it says the overnight has NOT
+    // settled (building / missing) any readiness present is a held-over prior
+    // night, so withhold it. Absent status (synthetic payloads) → show.
+    final s = status;
+    if (s != null && !s.overnightReady) return null;
+    return readiness.value!.round();
+  }
+
   Metric get vo2max => metricOf(_daily, 'vo2max');
   Metric get fitness => metricOf(_daily, 'fitness');
   Metric get form => metricOf(_daily, 'form');

--- a/lib/ui/today/today_screen.dart
+++ b/lib/ui/today/today_screen.dart
@@ -51,10 +51,10 @@ class _TodayScreenState extends State<TodayScreen>
   /// null = no data that day (incl. future days), best-effort.
   List<double?> _stepsWeek = const [];
 
-  /// Show the once-a-morning recovery story: only with a real readiness score,
-  /// and only if it hasn't already been shown for today's date.
+  /// Show the once-a-morning recovery story: only with a real, settled readiness
+  /// score for today, and only if it hasn't already been shown for today's date.
   bool _showStory(TodayData t) {
-    if (_storyDismissed || t.readiness.isEmpty) return false;
+    if (_storyDismissed || t.settledReadinessScore == null) return false;
     return Prefs.getString('ui.recovery_story_date', '') != _todayStr();
   }
 
@@ -238,7 +238,7 @@ class _TodayScreenState extends State<TodayScreen>
         KeyedSubtree(
           key: const ValueKey('today-story'),
           child: _RecoveryStory(
-            recoveredPct: t.readiness.value!.round(),
+            recoveredPct: t.settledReadinessScore!,
             sleptMin: t.sleepDuration.isEmpty
                 ? null
                 : t.sleepDuration.value!.round(),
@@ -738,7 +738,10 @@ class TodayVitals extends StatelessWidget {
 
   Widget _orbitHero() {
     final r = t.readiness;
-    final score = r.isEmpty ? null : r.value!.round();
+    // Only headline today's SETTLED readiness — never a prior night's value
+    // held over while today's overnight is still building (that made the ring
+    // flash a stale score before snapping to today's real one).
+    final score = t.settledReadinessScore;
     final fill = _baselineFill(r);
     final accent = score == null
         ? AppColors.accent

--- a/test/readiness_flash_test.dart
+++ b/test/readiness_flash_test.dart
@@ -1,0 +1,86 @@
+// Regression tests for the READINESS ring flashing a wrong score (e.g. 100)
+// before snapping to the true value on load/refresh.
+//
+// Root cause: while today's overnight is still building, getToday surfaces the
+// LAST settled night's readiness (`showing_prior_overnight`) so the rest of the
+// Today screen has data to show. The orbit hero rendered that held-over value as
+// the big readiness number, so for the split second before today's real score
+// landed the ring showed the prior night's figure and then snapped to today's.
+//
+// The fix routes the hero (and the once-a-morning recovery story) through
+// `TodayData.settledReadinessScore`, which withholds the number until today's
+// overnight has actually settled (`overnight_state == 'ready'`). These tests pin
+// that gate.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/models/payloads.dart';
+
+TodayData _today({
+  Object? readiness,
+  String? overnightState,
+  bool showingPrior = false,
+}) {
+  return TodayData.fromJson({
+    'daily': {if (readiness != null) 'readiness': readiness},
+    'sleep': const <String, dynamic>{},
+    if (overnightState != null)
+      'status': {
+        'overnight_state': overnightState,
+        'showing_prior_overnight': showingPrior,
+      },
+  });
+}
+
+void main() {
+  group('TodayData.settledReadinessScore', () {
+    test('today overnight SETTLED → the real score is surfaced', () {
+      final t = _today(
+        readiness: {'value': 73, 'confidence': 0.8, 'tier': 'HIGH'},
+        overnightState: 'ready',
+      );
+      expect(t.settledReadinessScore, 73);
+      // Rounds like the hero does.
+      final t2 = _today(
+        readiness: {'value': 72.6, 'confidence': 0.8},
+        overnightState: 'ready',
+      );
+      expect(t2.settledReadinessScore, 73);
+    });
+
+    test('overnight still BUILDING → held-over prior value is withheld (the bug)',
+        () {
+      // This is the flash: a prior night's 100 surfaced while today computes.
+      final t = _today(
+        readiness: {'value': 100, 'confidence': 0.8, 'tier': 'HIGH'},
+        overnightState: 'building',
+        showingPrior: true,
+      );
+      expect(t.settledReadinessScore, isNull);
+    });
+
+    test('overnight MISSING → nothing settled for today → withheld', () {
+      final t = _today(
+        readiness: {'value': 88, 'confidence': 0.8},
+        overnightState: 'missing',
+        showingPrior: true,
+      );
+      expect(t.settledReadinessScore, isNull);
+    });
+
+    test('absent readiness → null regardless of overnight state', () {
+      expect(_today(overnightState: 'ready').settledReadinessScore, isNull);
+      expect(
+        _today(
+          readiness: {'note': 'need_baseline:have=2,need=5'},
+          overnightState: 'ready',
+        ).settledReadinessScore,
+        isNull,
+      );
+    });
+
+    test('no status block (synthetic payload) → shows, unchanged behaviour', () {
+      final t = _today(readiness: {'value': 82, 'confidence': 0.9});
+      expect(t.settledReadinessScore, 82);
+    });
+  });
+}

--- a/test/readiness_saturation_test.dart
+++ b/test/readiness_saturation_test.dart
@@ -1,0 +1,72 @@
+// Regression tests for the READINESS ring BOUNCING to ~100 and back (#117, the
+// ready→ready case).
+//
+// Root cause: the composite maps its weighted robust-z to a 0–100 score via a
+// logistic `score = 100 / (1 + exp(-z))`. `robustZ` (analytics util) only nulls
+// on EXACT-zero MAD; a near-degenerate baseline (e.g. duplicate-day pollution
+// collapsing the window toward one value) has a tiny NON-zero MAD, so robustZ
+// returns a huge z, the logistic saturates, and today's headline flashes ~100
+// until a cleaner re-derive snaps it back — a ready→ready bounce the
+// `overnight_state == 'ready'` gate can't catch (the state is `ready` throughout).
+//
+// The fix (`headlineReadinessScalar` / `kReadinessZCap`) abstains from a
+// saturated, physiologically-impossible readiness rather than persisting the
+// bogus ~100, so no wrong value is ever headlined on any surface. These tests pin
+// the saturation → abstain behaviour and prove a clean derive is unaffected.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_analytics/onehz.dart';
+import 'package:openstrap_edge/compute/onehz_pipeline.dart';
+
+void main() {
+  // A near-constant but strictly-increasing baseline: tiny NON-zero MAD, exactly
+  // the shape duplicate-day pollution produces (not the exact-zero-MAD blank).
+  final degenerate = [for (var i = 0; i < 28; i++) 60.0 + i * 0.001];
+  // A healthy, well-spread baseline: a real robust-z, well within the cap.
+  final clean = [for (var i = 0; i < 28; i++) 50.0 + i.toDouble()];
+
+  group('headlineReadinessScalar', () {
+    test('a near-degenerate baseline saturates the logistic → abstained', () {
+      final sat = readinessComposite([hrvInput(61.0, degenerate)]);
+      // The bug precondition: it computes, and it saturates the rail.
+      expect(sat.present, isTrue);
+      expect(sat.value!.score, greaterThan(99),
+          reason: 'tiny-MAD baseline → huge z → logistic pinned near 100');
+      expect(sat.value!.compositeZ.abs(), greaterThan(kReadinessZCap));
+      // The guard withholds it instead of headlining ~100.
+      expect(headlineReadinessScalar(sat), isNull);
+    });
+
+    test('a clean baseline yields a real score, surfaced unchanged', () {
+      final ok = readinessComposite([hrvInput(70.0, clean)]);
+      expect(ok.present, isTrue);
+      expect(ok.value!.compositeZ.abs(), lessThanOrEqualTo(kReadinessZCap));
+      final score = headlineReadinessScalar(ok);
+      expect(score, isNotNull);
+      expect(score, closeTo(ok.value!.score, 1e-9),
+          reason: 'a legitimate score passes through untouched');
+      expect(score!, lessThan(95),
+          reason: 'a real composite never approaches the saturated rail');
+    });
+
+    test('ready→ready bounce: the headline never takes the saturated value', () {
+      final sat = readinessComposite([hrvInput(61.0, degenerate)]);
+      final ok = readinessComposite([hrvInput(70.0, clean)]);
+      // Two consecutive re-derives of the SAME already-`ready` day: a saturated
+      // pass then a clean pass. What the ring would headline for each:
+      final surfaced = [sat, ok].map(headlineReadinessScalar).toList();
+      expect(surfaced.first, isNull, reason: 'saturated derive → no number');
+      expect(surfaced.last, isNotNull, reason: 'clean derive → the real score');
+      // The saturated ~100 is never surfaced (no bounce to a bogus green 100).
+      expect(surfaced.contains(sat.value!.score), isFalse);
+      expect(surfaced.whereType<double>().every((v) => v < 95), isTrue);
+    });
+
+    test('exact-zero MAD stays the honest blank path (unchanged)', () {
+      // Fully-quantised baseline → robustZ null → composite absent → '—', not 100.
+      final flat = readinessComposite([hrvInput(61.0, List.filled(28, 60.0))]);
+      expect(flat.present, isFalse);
+      expect(headlineReadinessScalar(flat), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

On the Today screen the big READINESS ring shows a wrong score on load/refresh: it flashes **100** ("Primed", green) and then snaps to the true value (e.g. **73**, orange) — and, when today is still settling, it can keep **jumping to ~100 and back**. The settled score is correct; the transient 100 is the bug.

## Root cause

Two distinct paths both let a not-yet-final readiness reach the headline ring:

1. **Held-over prior night (building window).** While today's overnight is still building, `getToday` deliberately surfaces the **last settled night's** readiness (`showing_prior_overnight`) so the rest of the screen has data. The orbit hero rendered `t.readiness.value` directly, so it headlined the prior night's number until today's settled, then snapped.

2. **Ready→ready saturation bounce.** A day stays recomputable for ~48h and re-derives on every BLE drain, so today's readiness can change value between renders while `overnight_state` stays `ready` the whole time — a gate on the ready state alone can't catch it. The composite maps its weighted robust-z to a score via a logistic, `score = 100 / (1 + exp(-z))`. `robustZ` only returns null on **exact-zero** MAD (fully-quantised baseline → the honest blank `—`). A **near-degenerate** baseline — duplicate-day pollution collapsing the trailing window toward one repeated value — has a **tiny non-zero** MAD, so `robustZ` does *not* null: it returns a huge z, the logistic **saturates to ~100**, and that bogus value is persisted and headlined until a cleaner re-derive snaps it back. That is the observed "keeps jumping to 100 and back".

## Fix

Two complementary guards, both on the compute→render seam:

- **Building-window guard (UI model).** `TodayData.settledReadinessScore` only returns a score once today's overnight has settled (`overnight_state == 'ready'`); while building/missing, any readiness present is a held-over prior night and is withheld. The orbit hero **and** the once-a-morning recovery story route through it. Status-less synthetic payloads keep their previous behaviour, so existing Today widget tests are unaffected.

- **Saturation guard (compute seam).** `headlineReadinessScalar` / `kReadinessZCap` (`onehz_pipeline.dart`) abstain from a saturated readiness: if the composite is present but `|composite z|` exceeds the cap it persists **absent** (null) instead of the ~100. The cap is `5`, chosen physiologically — a real composite z is a weighted mean of per-input robust-z's, so even a flawless morning (every input at +2 z) lands at z=2 → score 88, and +3 z all-round is z=3 → 95; z=5 is score 99.3, unreachable by a genuine reading. So the cap suppresses **only** the degenerate rail and hides **zero** legitimate scores, on every surface (ring, home-screen widget, AI briefing).

## Tests

- `test/readiness_flash_test.dart` — the building-window gate: settled → surfaced; building/missing → withheld; absent → null; status-less → unchanged.
- `test/readiness_saturation_test.dart` — the saturation gate: a near-degenerate (tiny-non-zero-MAD) baseline saturates the composite to >99 and is abstained; a clean baseline surfaces its real score untouched; a ready→ready sequence (saturated derive then clean) never headlines the saturated value; exact-zero MAD stays the honest blank path.

## Notes

- **flutter/dart were not available in the environment this was developed in**, so `flutter analyze`/`flutter test` were not run here and the runtime flash was not reproduced on a device — verified by inspection and the unit tests above. CI is the gate.
- **Known remaining gap:** these guards guarantee no *wrong* saturated headline on any surface. A residual value↔`—` flicker is still possible if degenerate and clean derives alternate (the number briefly disappears rather than showing a wrong value). Fully removing that requires the sibling `fix/readiness-baseline-pollution` branch, which eliminates the degenerate baselines at source (de-duplicates the rolling window so MAD never collapses). The two are complementary.

Closes #117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the Readiness score from briefly displaying outdated or pending overnight values.
  * Readiness now appears only when overnight data is settled and valid.
  * Suppressed implausibly saturated scores instead of displaying misleading near-100 values.
  * Updated recovery insights to use the confirmed Readiness score, improving consistency across the Today screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->