### PR TITLE
fix(ble): arm wake alarm in the strap's RTC frame so it actually fires

### DIFF
--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -1074,6 +1074,11 @@ class BleEngine {
       // clock; SET_CLOCK is non-destructive (it's what the official app does each
       // connect). Records stamped after this carry real unix time.
       _clockCorrectTries = 0; // fresh retry budget for this connection
+      // Drop the previous session's clock correlation so an alarm armed before
+      // THIS session's GET_CLOCK reply lands falls back to the raw wall epoch
+      // (drift 0) instead of the stale strap-RTC frame. setClock()→getClock()
+      // below repopulates it for this connection.
+      _clockRef = null;
       await setClock();
       _lastClockVerifyAt = DateTime.now();
       // Per-connection policy reset. Marginal-radio + post-bond-loop are NOT reset
@@ -2474,7 +2479,9 @@ class BleEngine {
   /// short-form attempts silently failed for exactly this reason. The strap
   /// confirms the alarm latched via event 56 (STRAP_DRIVEN_ALARM_SET) and reports
   /// firing via events 57/58 + 60. Byte layout lives in the pure [AlarmPayloads].
-  Future<void> setAlarm(
+  /// Returns whether the arm write actually reached the band, so the caller can
+  /// avoid persisting / confirming a phantom alarm on a failed write.
+  Future<bool> setAlarm(
     DateTime when, {
     int index = 0,
     List<int>? haptics,
@@ -2485,10 +2492,11 @@ class BleEngine {
     // never (a raw wall epoch is decades ahead of a strap clock still near its
     // factory epoch, which is exactly why an immediate RUN_ALARM buzz works but a
     // scheduled alarm never fires). Shift the target by the GET_CLOCK drift; fall
-    // back to the raw epoch when we have no correlation yet. Byte layout + the
-    // frame conversion both live in the pure [AlarmPayloads].
+    // back to the raw epoch when we have no correlation yet (e.g. just after a
+    // reconnect, before this session's GET_CLOCK reply). Byte layout + the frame
+    // conversion both live in the pure [AlarmPayloads].
     final ref = _clockRef;
-    final driftSec = ref != null ? ref.wall - ref.device : 0;
+    final driftSec = ref?.driftSec ?? 0;
     final armWhen = AlarmPayloads.toStrapFrame(when, driftSec);
     final ok = await _send(
       Cmd.setAlarmTime,
@@ -2498,6 +2506,7 @@ class BleEngine {
         'strapSec=${armWhen.millisecondsSinceEpoch ~/ 1000} drift=${driftSec}s '
         'correlated=${ref != null} subsec=${AlarmPayloads.subsecOf(armWhen)} '
         'write=${ok ? 'ok' : 'FAILED'}');
+    return ok;
   }
 
   /// Time-only alarm (SET_ALARM_TIME = 0x42), SHORT 7-byte form:
@@ -2682,6 +2691,11 @@ class BleEngine {
     final device = session.device;
     await session.teardown();
     _session = null;
+    // The strap-RTC↔wall correlation belongs to the session that measured it —
+    // drop it so it can't leak into the next connection's alarm arming before a
+    // fresh GET_CLOCK. (Connection setup also re-nulls it; this covers the gap
+    // between teardown and the next connect.)
+    _clockRef = null;
     _offloadFrames.clear();
     _drainingOffloadFrames = false;
     _setOffloadActive(false);

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -1009,8 +1009,13 @@ class BleEngine {
       // Larger MTU + a fast connection interval for the drain (Android-only levers;
       // no-ops on iOS, which picks a fast interval itself when data is pending).
       try {
-        await device.requestMtu(247);
-      } catch (_) {}
+        final negotiated = await device.requestMtu(247);
+        // Log the RESULT: a low MTU here (e.g. 23) is the tell for the 32B alarm
+        // write failing, and was previously invisible (the call was swallowed).
+        _log('MTU negotiated: $negotiated (requested 247).');
+      } catch (e) {
+        _log('requestMtu failed: $e — MTU stays at the connection default.');
+      }
       if (Platform.isAndroid) {
         try {
           await device.requestConnectionPriority(
@@ -1417,7 +1422,14 @@ class BleEngine {
           _log('write skipped: link not ready.');
           return;
         }
-        await cmd.write(raw, withoutResponse: false).timeout(_writeTimeout);
+        // allowLongWrite: the rich SET_ALARM_TIME frame is 32B — the only write
+        // that exceeds the 20B ATT limit of a default (23B) MTU. Without a long
+        // write, flutter_blue_plus throws "value > mtu-3" if the negotiated MTU
+        // never rose, and _send would swallow the alarm silently. Long writes are
+        // a no-op for the small (<=20B) frames every other command uses.
+        await cmd
+            .write(raw, withoutResponse: false, allowLongWrite: true)
+            .timeout(_writeTimeout);
         ok = true;
       } on TimeoutException {
         _log('write timeout: no GATT response in ${_writeTimeout.inSeconds}s.');
@@ -1450,13 +1462,18 @@ class BleEngine {
     }
   }
 
-  Future<void> _send(int opcode, List<int> payload) async {
+  Future<bool> _send(int opcode, List<int> payload) async {
     if (dangerousCmds.contains(opcode)) {
       _log('REFUSED dangerous opcode 0x${opcode.toRadixString(16)}');
-      return;
+      return false;
     }
     final frame = buildCommand(_seq.nextLive(), opcode, payload);
-    await _write(frame);
+    final ok = await _write(frame);
+    if (!ok) {
+      _log('WRITE FAILED for opcode 0x${opcode.toRadixString(16)} — '
+          'command not delivered.');
+    }
+    return ok;
   }
 
   Future<void> applyHighFreqWakeWindow({
@@ -2462,12 +2479,25 @@ class BleEngine {
     int index = 0,
     List<int>? haptics,
   }) async {
-    await _send(
+    // Arm in the STRAP's RTC frame. The strap fires the wake alarm autonomously
+    // on its OWN clock, so if that clock is offset from wall time (SET_CLOCK not
+    // latched / drift) the raw wall epoch fires at the wrong strap-time — or
+    // never (a raw wall epoch is decades ahead of a strap clock still near its
+    // factory epoch, which is exactly why an immediate RUN_ALARM buzz works but a
+    // scheduled alarm never fires). Shift the target by the GET_CLOCK drift; fall
+    // back to the raw epoch when we have no correlation yet. Byte layout + the
+    // frame conversion both live in the pure [AlarmPayloads].
+    final ref = _clockRef;
+    final driftSec = ref != null ? ref.wall - ref.device : 0;
+    final armWhen = AlarmPayloads.toStrapFrame(when, driftSec);
+    final ok = await _send(
       Cmd.setAlarmTime,
-      AlarmPayloads.rich(when, index: index, haptics: haptics),
+      AlarmPayloads.rich(armWhen, index: index, haptics: haptics),
     );
-    _log('SET_ALARM_TIME (rich 20B) → sec=${when.millisecondsSinceEpoch ~/ 1000} '
-        'subsec=${AlarmPayloads.subsecOf(when)}');
+    _log('SET_ALARM_TIME (rich 20B) → wallSec=${when.millisecondsSinceEpoch ~/ 1000} '
+        'strapSec=${armWhen.millisecondsSinceEpoch ~/ 1000} drift=${driftSec}s '
+        'correlated=${ref != null} subsec=${AlarmPayloads.subsecOf(armWhen)} '
+        'write=${ok ? 'ok' : 'FAILED'}');
   }
 
   /// Time-only alarm (SET_ALARM_TIME = 0x42), SHORT 7-byte form:

--- a/lib/ble/ble_state.dart
+++ b/lib/ble/ble_state.dart
@@ -470,6 +470,24 @@ class AlarmPayloads {
 
   /// DISABLE_ALARM (0x45) body — cancel the on-device alarm.
   static const List<int> disable = <int>[0x01];
+
+  /// Convert a WALL-CLOCK alarm target into the strap's own RTC frame.
+  ///
+  /// The strap runs the wake alarm autonomously and fires when ITS RTC reaches
+  /// the armed epoch — so the epoch we send must be in the strap's clock frame,
+  /// not ours. If SET_CLOCK never latched (some firmware rejects the payload) the
+  /// strap RTC is offset from wall time; arming the raw wall epoch then fires at
+  /// the wrong strap-time, or effectively NEVER (a raw 2026 epoch is decades in
+  /// the future of a strap clock still near its factory epoch). This is why an
+  /// immediate RUN_ALARM buzz works but a scheduled alarm never fires.
+  ///
+  /// [driftSec] is `wall - device` from the GET_CLOCK correlation (positive when
+  /// the strap RTC is BEHIND wall). At wall-time `W` the strap RTC reads
+  /// `W - driftSec`, so we shift the target back by the drift; the sub-second part
+  /// is preserved (whole-second shift). Pass `0` when uncorrelated to arm the raw
+  /// wall epoch unchanged.
+  static DateTime toStrapFrame(DateTime when, int driftSec) =>
+      when.subtract(Duration(seconds: driftSec));
 }
 
 /// Effect of a strap alarm-lifecycle event, for the caller to act on.

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2135,10 +2135,12 @@ class AppState extends ChangeNotifier {
     switch (effect) {
       case AlarmEffect.confirmed:
         _alarmGraceTimer?.cancel();
-        _log('[alarm] confirmed set (event $id).');
+        // Diagnostic: ALARM_SET (event 56) means the arm LATCHED on the band.
+        // Its absence after a SET is the tell that the write never took.
+        _log('[alarm] strap CONFIRMED arm — ALARM_SET (event $id) received.');
         break;
       case AlarmEffect.fired:
-        _log('[alarm] fired (event $id).');
+        _log('[alarm] strap FIRED — EXECUTED (event $id) received.');
         unawaited(_notifyAlarmFired());
         break;
       case AlarmEffect.cleared:

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2079,7 +2079,15 @@ class AppState extends ChangeNotifier {
     // Pass the DateTime through so the engine computes REAL sub-seconds for the
     // rich 20-byte firing form (a hardcoded 0 subsec would still fire, but the
     // engine owns the exact on-wire layout).
-    await engine.setAlarm(when);
+    final ok = await engine.setAlarm(when);
+    if (!ok) {
+      // The arm write never reached the band — do NOT persist or start the
+      // confirmation machine, or we'd strand a phantom alarm "waiting for the
+      // strap to confirm" that can never fire. Surface it so the UI reflects
+      // "couldn't send" (the coach/profile callers snackbar on a throw).
+      _log('[alarm] arm write FAILED — not persisting; alarm not set.');
+      throw Exception('Alarm not sent — the strap did not accept the write');
+    }
     _savedAlarm = epoch;
     device.alarmEpoch = epoch; // optimistic display
     _alarm.set(epoch, DateTime.now().millisecondsSinceEpoch); // await event 56

--- a/lib/sync/sync_policy.dart
+++ b/lib/sync/sync_policy.dart
@@ -97,6 +97,11 @@ class ClockRef {
   final int device; // strap RTC epoch at correlation time
   final int wall; // wall unix seconds at that same instant
   const ClockRef({required this.device, required this.wall});
+
+  /// How far the strap RTC lags wall-clock (positive = strap behind). This is the
+  /// offset used to arm the on-device alarm in the strap's own clock frame; a
+  /// caller with no correlation yet should treat it as 0 (`ref?.driftSec ?? 0`).
+  int get driftSec => wall - device;
 }
 
 /// The dedup grid the record-time correction snaps to. Repeated re-syncs of the

--- a/test/alarm_test.dart
+++ b/test/alarm_test.dart
@@ -6,6 +6,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openstrap_edge/ble/ble_state.dart';
+import 'package:openstrap_edge/sync/sync_policy.dart' show ClockRef;
 import 'package:openstrap_protocol/openstrap_protocol.dart' as proto;
 
 void main() {
@@ -98,6 +99,38 @@ void main() {
       final p = AlarmPayloads.rich(AlarmPayloads.toStrapFrame(wall, 90));
       final sec = p[2] | (p[3] << 8) | (p[4] << 16) | (p[5] << 24);
       expect(sec, 1750000000 - 90);
+    });
+  });
+
+  group('ClockRef.driftSec + reconnect fallback (stale-correlation guard)', () {
+    final wall = DateTime.fromMillisecondsSinceEpoch(1750000000 * 1000,
+        isUtc: true);
+
+    test('driftSec = wall − device (positive when the strap RTC is behind)', () {
+      expect(const ClockRef(device: 1000, wall: 1090).driftSec, 90);
+      expect(const ClockRef(device: 1100, wall: 1070).driftSec, -30);
+      expect(const ClockRef(device: 1000, wall: 1000).driftSec, 0);
+    });
+
+    test('no correlation yet (just after reconnect) → drift 0 → raw wall epoch', () {
+      // On reconnect _clockRef is nulled until THIS session's GET_CLOCK reply, so
+      // the arm must fall back to the raw epoch rather than reuse the previous
+      // session's offset. This mirrors engine.setAlarm's `_clockRef?.driftSec ?? 0`.
+      const ClockRef? ref = null;
+      final driftSec = ref?.driftSec ?? 0;
+      expect(driftSec, 0);
+      expect(
+          AlarmPayloads.toStrapFrame(wall, driftSec).millisecondsSinceEpoch ~/ 1000,
+          1750000000);
+    });
+
+    test('correlated session → arms in the strap frame using the offset', () {
+      const ref = ClockRef(device: 1749999910, wall: 1750000000); // strap 90s behind
+      final driftSec = ref.driftSec; // 90
+      expect(driftSec, 90);
+      expect(
+          AlarmPayloads.toStrapFrame(wall, driftSec).millisecondsSinceEpoch ~/ 1000,
+          1750000000 - 90);
     });
   });
 

--- a/test/alarm_test.dart
+++ b/test/alarm_test.dart
@@ -69,6 +69,38 @@ void main() {
     });
   });
 
+  group('AlarmPayloads.toStrapFrame (RTC-frame arming)', () {
+    // Wall-clock target with a non-zero sub-second so we can assert it survives.
+    final wall = DateTime.fromMillisecondsSinceEpoch(1750000000 * 1000 + 250,
+        isUtc: true);
+
+    test('uncorrelated (drift 0) → wall target unchanged', () {
+      expect(AlarmPayloads.toStrapFrame(wall, 0).millisecondsSinceEpoch,
+          wall.millisecondsSinceEpoch);
+    });
+
+    test('strap RTC behind wall (drift +90) → armed epoch = wall − 90', () {
+      final r = AlarmPayloads.toStrapFrame(wall, 90);
+      expect(r.millisecondsSinceEpoch ~/ 1000, 1750000000 - 90);
+      // whole-second shift keeps the sub-second remainder intact
+      expect(AlarmPayloads.subsecOf(r), AlarmPayloads.subsecOf(wall));
+    });
+
+    test('strap RTC ahead of wall (drift −30) → armed epoch = wall + 30', () {
+      expect(AlarmPayloads.toStrapFrame(wall, -30).millisecondsSinceEpoch ~/ 1000,
+          1750000000 + 30);
+    });
+
+    test('rich() encodes the strap-frame epoch, not the raw wall epoch', () {
+      // On a strap whose RTC is 90s behind, arming the raw wall epoch would fire
+      // 90s late (or never, for a large offset); the rich payload must carry the
+      // shifted (wall − drift) seconds.
+      final p = AlarmPayloads.rich(AlarmPayloads.toStrapFrame(wall, 90));
+      final sec = p[2] | (p[3] << 8) | (p[4] << 16) | (p[5] << 24);
+      expect(sec, 1750000000 - 90);
+    });
+  });
+
   group('AlarmConfirmation state machine', () {
     test('event ids match the protocol EventId names', () {
       expect(AlarmConfirmation.kEvtSet, proto.EventId.strapDrivenAlarmSet);


### PR DESCRIPTION
Closes #119

## Symptom (confirmed on-device)

The smart / cycle-aligned wake alarm never buzzes at the scheduled time. On a
real band we confirmed the split:

- Immediate `RUN_ALARM` "test buzz" → **fires**
- Tasker immediate buzz → **fires**
- A scheduled alarm set ~2 min out → **never fires**

So the delivery / haptics / BLE-write path is healthy; only the **clock-dependent
scheduled path** is broken.

## Root cause

The wake alarm is **band-autonomous**: `SET_ALARM_TIME` arms the strap and it
fires on its **own RTC**, with no phone needed at fire time (no AlarmManager /
background task / foreground BLE is involved — verified). The app armed it with
the **raw wall-clock epoch** (`when.millisecondsSinceEpoch ~/ 1000`).

If `SET_CLOCK` never latched (some firmware rejects the payload) the strap RTC is
offset from wall time, so:

- the strap fires when *its* clock reaches the armed epoch → the wrong wall time,
- and if the strap clock is far behind (e.g. still near its factory epoch), a
  2026 wall epoch is **decades** in the strap's future → it effectively never fires.

History sync is immune to a wrong RTC because records carry their **own embedded
timestamps** (`ble_engine.dart` clock-correlation comment), which is exactly why
everything except the alarm worked and why "sync works" did **not** prove the RTC
had latched.

## Fix

**Primary** — arm in the strap's RTC frame. Convert the wall-clock target using
the `GET_CLOCK` correlation (`_clockRef`, strap-RTC↔wall) before arming, and fall
back to the raw epoch when uncorrelated. At wall-time `W` the strap RTC reads
`W - (wall - device)`, so we shift the target back by that drift (sub-second part
preserved). It's a **no-op when the clock latched** (drift ≈ 0), so no regression
on conforming firmware. The conversion is a pure, unit-tested helper
`AlarmPayloads.toStrapFrame`.

**Secondary hardening**
- `allowLongWrite: true` on the write — the 32-byte rich `SET_ALARM_TIME` frame is
  the only write that exceeds the 20-byte ATT limit of a default (23-byte) MTU;
  without a long write flutter_blue_plus throws and `_send` swallowed it silently.
- `_send` now returns and logs `_write`'s result instead of dropping a failed
  alarm write.

**Diagnostics** (so the next on-device test is conclusive) — log the negotiated
MTU (was swallowed), the `GET_CLOCK` drift, the armed wall vs strap epochs + offset
+ write success, and `ALARM_SET` (event 56) arrival.

## Verification status — please read

This is opened as a **draft** because it **cannot be runtime-verified without a
physical WHOOP band**, and `flutter`/`dart` are not available in the dev
environment used here.

- Verified by inspection + a new unit test (`test/alarm_test.dart`):
  `toStrapFrame` shifts by the drift in both directions, is a no-op when
  uncorrelated, preserves sub-seconds, and `rich()` encodes the strap-frame epoch.
- **Pending:** Danny to build locally and re-test the 2-min alarm on-device. The
  new logs will **confirm the mechanism or redirect us**: if the `GET_CLOCK` drift
  is large, this fix resolves it; if the drift is ~0 yet the alarm still doesn't
  fire, the RTC frame isn't the whole story and we follow the `ALARM_SET`/MTU logs.

Nothing about the actual strap buzz is verifiable from CI/inspection alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Alarm scheduling now accounts for app vs device clock drift when arming, using a converted device RTC time frame for more accurate timing.
  - Larger alarm payloads are supported during Bluetooth writes.
  - Connection and alarm operations now report more reliable success/failure status and clearer confirmation/fired event messages.

- **Bug Fixes**
  - MTU negotiation now captures the negotiated MTU and reports explicit failure reasons instead of hiding errors.
  - Alarm arming now fails fast: it won’t persist alarm state or proceed to confirmation when the arm write fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->