### PR TITLE
fix(splash): don't interrupt other apps' audio on cold start

### DIFF
--- a/lib/ui/splash/boot_splash.dart
+++ b/lib/ui/splash/boot_splash.dart
@@ -80,7 +80,13 @@ class _BootSplashState extends State<BootSplash> {
   Future<void> _initVideo() async {
     try {
       final c = (widget.controllerFactory ??
-          () => VideoPlayerController.asset('assets/splash/splashscreen.mp4'))();
+          () => VideoPlayerController.asset(
+                'assets/splash/splashscreen.mp4',
+                // Don't grab audio focus for the (muted) splash video — a bare
+                // controller pauses whatever the user is already playing on a
+                // cold start. mixWithOthers lets their audio keep going.
+                videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true),
+              ))();
       _video = c;
       await c.initialize();
       await c.setVolume(0); // always muted


### PR DESCRIPTION
Fixes #124 (thanks @batram for the report and the fix).

## Problem
On a cold start Edge plays the splash video (`assets/splash/splashscreen.mp4`). Even though it's muted, the `VideoPlayerController` still requests audio focus, so it pauses whatever the user is already playing (music, podcast, etc.).

## Fix
Pass `VideoPlayerOptions(mixWithOthers: true)` to the splash controller so it mixes with existing audio instead of interrupting it.

```dart
() => VideoPlayerController.asset(
      'assets/splash/splashscreen.mp4',
      videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true),
    )
```

One line, no behavioural change to the splash itself (still muted, still freezes on the last frame).

## Testing
Verified by inspection — reproduces the reporter's fix. Not runtime-tested (no device/Flutter SDK to hand); the change is confined to the splash controller options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved splash video playback behavior by allowing it to mix with other audio sources.
  * Preserved existing reduced-motion handling and fallback behavior when video playback fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->