### PR TITLE
fix(actions): stop 'ring my phone' ringing until force-close

### DIFF
--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/NativeChannels.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/NativeChannels.kt
@@ -8,9 +8,12 @@ import android.content.ActivityNotFoundException
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.media.AudioManager
+import android.media.Ringtone
 import android.media.RingtoneManager
 import android.net.Uri
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.os.PowerManager
 import android.os.VibrationEffect
 import android.os.Vibrator
@@ -34,6 +37,14 @@ object NativeChannels {
     private const val TASKER_TOKEN_KEY = "tasker_auth_token"
 
     private var torchOn = false
+
+    // "Ring my phone" (find-my-phone). The ringtone must be retained so it can be
+    // stopped — without a held reference the default TYPE_RINGTONE loops until the
+    // process dies, which is why it rang until force-close (#115).
+    private const val RING_TIMEOUT_MS = 30_000L
+    private var activeRingtone: Ringtone? = null
+    private val ringHandler = Handler(Looper.getMainLooper())
+    private var ringStopRunnable: Runnable? = null
 
     fun register(engine: FlutterEngine, context: Context) {
         val app = context.applicationContext
@@ -351,9 +362,32 @@ object NativeChannels {
     }
 
     private fun ringPhone(ctx: Context) {
+        // Toggle: a second double-tap while it's ringing stops it early.
+        if (activeRingtone?.isPlaying == true) {
+            stopRing()
+            return
+        }
         val uri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
-        RingtoneManager.getRingtone(ctx.applicationContext, uri)?.play()
+            ?: RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
+        val rt = RingtoneManager.getRingtone(ctx.applicationContext, uri) ?: return
+        // Loop for the whole find-my-phone window (API 28+); older versions loop a
+        // TYPE_RINGTONE by default. Either way the timeout below guarantees it stops.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) rt.isLooping = true
+        activeRingtone = rt
+        rt.play()
         vibrate(ctx)
+        // Never ring forever: auto-stop after RING_TIMEOUT_MS.
+        ringStopRunnable?.let { ringHandler.removeCallbacks(it) }
+        val stop = Runnable { stopRing() }
+        ringStopRunnable = stop
+        ringHandler.postDelayed(stop, RING_TIMEOUT_MS)
+    }
+
+    private fun stopRing() {
+        ringStopRunnable?.let { ringHandler.removeCallbacks(it) }
+        ringStopRunnable = null
+        activeRingtone?.let { if (it.isPlaying) it.stop() }
+        activeRingtone = null
     }
 
     // Torch via CameraManager.setTorchMode — no CAMERA permission required (API 23+).

--- a/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/NativeChannels.kt
+++ b/android/app/src/main/kotlin/wtf/openstrap/openstrap_edge/NativeChannels.kt
@@ -375,12 +375,14 @@ object NativeChannels {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) rt.isLooping = true
         activeRingtone = rt
         rt.play()
-        vibrate(ctx)
-        // Never ring forever: auto-stop after RING_TIMEOUT_MS.
+        // Register the fail-safe stop BEFORE vibrating: vibrate() can throw and
+        // perform() swallows it, which must never leave the ring without a
+        // scheduled stop (that was the original ring-forever failure mode).
         ringStopRunnable?.let { ringHandler.removeCallbacks(it) }
         val stop = Runnable { stopRing() }
         ringStopRunnable = stop
         ringHandler.postDelayed(stop, RING_TIMEOUT_MS)
+        vibrate(ctx)
     }
 
     private fun stopRing() {


### PR DESCRIPTION
Fixes #115.

## Problem
The double-tap *ring my phone* action played the default system ringtone but never held a reference to it and never stopped it. `TYPE_RINGTONE` loops by design, so it rang until the app was force-closed. Repeated taps stacked more unstoppable ringtones on top.

## Fix (native, `NativeChannels.kt`)
- Retain the `Ringtone` in `activeRingtone` so it can actually be stopped.
- **Auto-stop after 30 s** (`Handler.postDelayed`) — it can never ring forever again.
- A **second double-tap** while ringing **stops it early** (toggle).
- Stop any in-progress ring before starting a new one (no stacking).

Find-my-phone norm: rings ~30 s, or until you double-tap again.

## Testing
Verified by inspection — native Kotlin, and there's no CI/SDK here to run a build. Needs on-device confirmation: double-tap rings the phone, auto-stops at 30 s, and a second double-tap stops it early.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “find my phone” ring behavior with more reliable ringtone selection, including an alarm fallback when needed.
  * Updated the ring action to act as a toggle: re-triggering stops the currently playing ringtone.
  * Added controlled auto-stop after a fixed timeout.
  * Preserved vibration alerts and enabled looping playback on supported Android versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->