### PR TITLE
fix(readiness): freeze the morning headline once the overnight is complete

### DIFF
--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -276,6 +276,49 @@ const int _finalizationSec = 48 * 3600;
 /// How many trailing derived days feed readiness/composite baselines.
 const int _baselineWindowDays = 28;
 
+/// Readiness is meant to be a stable MORNING score, but a day stays recomputable
+/// for ~48 h (`_finalizationSec`) and every re-derive overwrites the persisted
+/// readiness scalar. As the night's flash finishes draining and the trailing
+/// 28-day baseline shifts, the surfaced value legitimately drifts through the
+/// day (#128: "morning it was 49, now 45"). Once today's overnight is genuinely
+/// COMPLETE we PIN the first such readiness as the headline so it stops moving.
+///
+/// "Complete" must be stronger than `overnight_state == 'ready'` — that flips as
+/// soon as the FIRST sleep-bearing row lands (mid-drain), so pinning on it could
+/// freeze a partial-night value. We instead require the drained data edge to
+/// have moved at least this far PAST the sleep offset (wake): the whole sleep
+/// window is then decoded and the segmentation-placed wake is settled, so the
+/// overnight inputs are final. Same "edge past the window" model finalisation
+/// uses, anchored at wake+margin rather than wake+48 h. Conservative but still
+/// reached within the first post-wake sync in practice; raise it to trade a
+/// slightly later freeze for more safety margin.
+const int _headlineFreezeMarginSec = 60 * 60;
+
+/// The frozen morning readiness headline that should be persisted/surfaced for
+/// [today], given the current pin and a fresh look at today's live readiness and
+/// whether today's overnight is genuinely COMPLETE. Pure so the freeze semantics
+/// are unit-tested without the derive/DB machinery.
+///
+/// - Not yet a complete overnight → no pin (the headline tracks the live value).
+/// - First complete overnight → pin the live value.
+/// - Later same-day looks → keep the FIRST pin (the whole point: no daytime
+///   drift — a re-derive that would RAISE or LOWER the score is ignored).
+/// - A new day → the prior day's pin no longer applies; re-pins once the new
+///   day's overnight completes.
+@visibleForTesting
+({String day, int value})? nextFrozenHeadline({
+  required String today,
+  required bool overnightComplete,
+  required int? liveReadiness,
+  required ({String day, int value})? current,
+}) {
+  if (current != null && current.day == today) return current; // pinned; hold
+  if (overnightComplete && liveReadiness != null) {
+    return (day: today, value: liveReadiness); // first complete settle → pin
+  }
+  return null; // nothing to pin yet for today
+}
+
 /// Test seam: the rolling baseline window the readiness computation actually
 /// runs against, loaded exactly as production does. Exposed to assert the read
 /// path ignores a polluted `rolling_artifact` and rebuilds from `metric_series`.
@@ -1684,6 +1727,41 @@ class DerivationEngine {
       'derived ${day.date} v$kAlgoVersion '
       '(sleep=${day.sleepOffsetSec > day.sleepOnsetSec}, final=$finalized)',
     );
+    await _maybeFreezeHeadlineReadiness(day, dataNowSec, sc('readiness'));
+  }
+
+  /// Pin today's morning readiness headline once its overnight is genuinely
+  /// COMPLETE, so the Today hero + recovery story stop drifting through the day
+  /// (#128). Only the headline is pinned — this row's `day_result`, the
+  /// baselines, trends and finalisation all keep updating on later re-derives.
+  Future<void> _maybeFreezeHeadlineReadiness(
+    PreparedDerivationDay day,
+    int dataNowSec,
+    double? readiness,
+  ) async {
+    // Only today's headline is pinned. Historical/backfill + imported days never
+    // reach the Today hero, and imports are immutable snapshots anyway.
+    if (day.date != todayLabel()) return;
+    final hasSleep = day.sleepOffsetSec > day.sleepOnsetSec;
+    if (!hasSleep) return;
+    final overnightComplete =
+        dataNowSec >= day.sleepOffsetSec + _headlineFreezeMarginSec;
+    final current = await LocalDb.frozenHeadline();
+    final next = nextFrozenHeadline(
+      today: day.date,
+      overnightComplete: overnightComplete,
+      liveReadiness: readiness?.round(),
+      current: current,
+    );
+    if (next == null) return;
+    // Already pinned to this exact value → skip the redundant write.
+    if (current != null &&
+        current.day == next.day &&
+        current.value == next.value) {
+      return;
+    }
+    await LocalDb.setFrozenHeadline(next.day, next.value);
+    _log('froze headline readiness ${next.value} for ${next.day}');
   }
 
   void _logSpo2Diagnostics(

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -668,6 +668,32 @@ class LocalDb {
     }, conflictAlgorithm: ConflictAlgorithm.replace);
   }
 
+  /// Cursor holding the FROZEN morning readiness headline (see #128): the
+  /// day-tagged value pinned once today's overnight first settles on a genuinely
+  /// complete night, so the Today hero + recovery story stop drifting through
+  /// the day. Day-tagged so it survives restarts and is ignored on a new day.
+  static const String kFrozenHeadlineCursor = 'frozen_headline';
+
+  /// The pinned morning readiness headline (day + value), or null if unset /
+  /// unparseable. The `day` must be compared to today's label by the caller — a
+  /// pin left over from a previous day must NOT be surfaced.
+  static Future<({String day, int value})?> frozenHeadline() async {
+    final raw = await getCursor(kFrozenHeadlineCursor);
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      final d = jsonDecode(raw);
+      if (d is Map && d['day'] is String && d['value'] is num) {
+        return (day: d['day'] as String, value: (d['value'] as num).round());
+      }
+    } catch (_) {/* malformed → treat as unset */}
+    return null;
+  }
+
+  /// Pin [value] as the frozen readiness headline for [day] (overwrites any
+  /// prior pin — first-complete-settle-per-day is enforced by the caller).
+  static Future<void> setFrozenHeadline(String day, int value) =>
+      setCursor(kFrozenHeadlineCursor, jsonEncode({'day': day, 'value': value}));
+
   /// Persist a sync batch atomically: the raw records, their samples, AND the
   /// continuation cursor in ONE transaction. This is the durable half of the
   /// safe-trim invariant — it MUST return before the engine writes the ACK frame.

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -238,9 +238,22 @@ class LocalRepositoryImpl extends LocalRepository {
     // Readiness/recovery: when the composite abstains for lack of baseline, the
     // envelope carries a `need_baseline:have=H,need=N` note. Pass that note
     // through so the hero can render "Need N more nights" instead of a number.
-    final readinessScalar = showOvernight
+    var readinessScalar = showOvernight
         ? _scalar(sleepBundle, 'readiness')
         : null;
+    // FROZEN MORNING HEADLINE (#128): once today's overnight first settled on a
+    // genuinely complete night, the derive pinned that readiness. Surface the
+    // pin so the hero + once-a-morning recovery story stop drifting as the day's
+    // re-derives (more daytime data, a shifting baseline) move the live scalar.
+    // ONLY the headline is pinned — every other metric below still reflects the
+    // latest re-derive. Gated to today's OWN overnight (`ready`, matching day)
+    // so a prior-night fallback or a stale yesterday pin can never leak in.
+    if (overnightState == 'ready') {
+      final pin = await LocalDb.frozenHeadline();
+      if (pin != null && pin.day == todayDay) {
+        readinessScalar = pin.value.toDouble();
+      }
+    }
     final readinessNote = readinessScalar == null && showOvernight
         ? _needNote(sleepBundle, 'clinical.readiness_composite')
         : null;

--- a/test/readiness_freeze_test.dart
+++ b/test/readiness_freeze_test.dart
@@ -1,0 +1,137 @@
+// Regression tests for readiness DRIFTING through the day (#128 — "morning it
+// was 49, now 45").
+//
+// Root cause: a day stays recomputable for ~48 h and every re-derive overwrites
+// the persisted readiness scalar; as the night's flash finishes draining and the
+// trailing 28-day baseline shifts, the surfaced value legitimately moves. The fix
+// FREEZES the morning headline once today's overnight is genuinely COMPLETE and
+// pins that first value for the rest of the day.
+//
+// `nextFrozenHeadline` is the pure decision at the heart of that freeze. These
+// tests pin its semantics: the headline does NOT move after the first
+// complete-overnight settle, and a new day resets it.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/compute/derivation_engine.dart';
+
+void main() {
+  group('nextFrozenHeadline', () {
+    const d1 = '2026-07-21';
+    const d2 = '2026-07-22';
+
+    test('before a complete overnight → no pin (headline tracks the live value)',
+        () {
+      final pin = nextFrozenHeadline(
+        today: d1,
+        overnightComplete: false,
+        liveReadiness: 49,
+        current: null,
+      );
+      expect(pin, isNull);
+    });
+
+    test('first complete overnight → pins the live value', () {
+      final pin = nextFrozenHeadline(
+        today: d1,
+        overnightComplete: true,
+        liveReadiness: 49,
+        current: null,
+      );
+      expect(pin, isNotNull);
+      expect(pin!.day, d1);
+      expect(pin.value, 49);
+    });
+
+    test('absent readiness at completion → still no pin', () {
+      final pin = nextFrozenHeadline(
+        today: d1,
+        overnightComplete: true,
+        liveReadiness: null,
+        current: null,
+      );
+      expect(pin, isNull);
+    });
+
+    test(
+        'ready→ready with a changing value → the frozen headline does NOT move '
+        'after the first complete settle', () {
+      // Morning: the overnight completes and 49 is pinned.
+      var frozen = nextFrozenHeadline(
+        today: d1,
+        overnightComplete: true,
+        liveReadiness: 49,
+        current: null,
+      );
+      expect(frozen, isNotNull);
+      expect(frozen!.value, 49);
+
+      // Midday re-derive: baseline shifted, the live value dropped to 45 — the
+      // exact drift from #128. The pin must hold.
+      frozen = nextFrozenHeadline(
+        today: d1,
+        overnightComplete: true,
+        liveReadiness: 45,
+        current: frozen,
+      );
+      expect(frozen!.value, 49, reason: 'a lower re-derive must not move it');
+
+      // Afternoon re-derive that would RAISE it: still pinned (product call —
+      // stability wins over a same-day improvement).
+      frozen = nextFrozenHeadline(
+        today: d1,
+        overnightComplete: true,
+        liveReadiness: 53,
+        current: frozen,
+      );
+      expect(frozen!.value, 49, reason: 'a higher re-derive must not move it');
+    });
+
+    test('a new day → the prior pin is dropped and re-pins on completion', () {
+      final day1Pin = (day: d1, value: 49);
+
+      // New day, overnight not complete yet → the day-1 pin no longer applies
+      // (getToday also guards by day, but the decision drops it too).
+      var frozen = nextFrozenHeadline(
+        today: d2,
+        overnightComplete: false,
+        liveReadiness: 61,
+        current: day1Pin,
+      );
+      expect(frozen, isNull, reason: 'yesterday\'s pin must not carry over');
+
+      // Day-2 overnight completes → a fresh pin for the new day.
+      frozen = nextFrozenHeadline(
+        today: d2,
+        overnightComplete: true,
+        liveReadiness: 61,
+        current: day1Pin,
+      );
+      expect(frozen, isNotNull);
+      expect(frozen!.day, d2);
+      expect(frozen.value, 61);
+    });
+
+    test(
+        'settling before completion then completing → pins the COMPLETE-night '
+        'value, not the partial one', () {
+      // Early morning: overnight present but not yet complete → no pin; the live
+      // partial-night 70 is shown but never frozen.
+      var frozen = nextFrozenHeadline(
+        today: d1,
+        overnightComplete: false,
+        liveReadiness: 70,
+        current: null,
+      );
+      expect(frozen, isNull);
+
+      // Once the night is genuinely complete the (now different) value pins.
+      frozen = nextFrozenHeadline(
+        today: d1,
+        overnightComplete: true,
+        liveReadiness: 66,
+        current: frozen,
+      );
+      expect(frozen!.value, 66, reason: 'the complete-night value is pinned');
+    });
+  });
+}


### PR DESCRIPTION
## Problem (#128, user RR)

Readiness DRIFTS during the day — "morning it was 49, now 45." It's meant to be a stable morning score.

A day stays recomputable for ~48h (`_finalizationSec`) and `selectLightDeriveDays` re-targets today on every BLE drain; each derive OVERWRITES the persisted `readiness` scalar. As the night's overnight flash finishes draining and the trailing 28-day baseline shifts, the value legitimately moves.

PR #121's `TodayData.settledReadinessScore` only *withheld* the number while the overnight was still building. Once `overnight_state == 'ready'` it passed the latest re-derived value straight through, so it could not stop a ready→ready drift.

## Fix (Option A — freeze the headline)

Once today's overnight is **genuinely COMPLETE**, pin the first settled readiness and surface that pinned value for the two headline surfaces — the orbit hero (`today_screen`) and the once-a-morning recovery story. Later re-derives keep updating the full `day_result`, baselines, trends and finalisation exactly as before; **only the headline number is pinned.**

### "Complete" ≠ `overnight_state == 'ready'`

`ready` flips as soon as the first sleep-bearing row lands (mid-drain), so pinning on it could freeze a partial-night value. Instead the freeze trigger requires the drained data edge to have moved a margin **past the sleep offset (wake)**:

```
overnightComplete = hasSleep && dataNowSec >= sleepOffsetSec + _headlineFreezeMarginSec  // 60 min
```

This is the same "edge past the window" model the engine already uses for finalisation (`day.endSec + 48h < dataNowSec`), anchored at wake+margin instead of wake+48h: the whole sleep window is then decoded and the segmentation-placed wake is settled, so the overnight inputs are final. Below that margin we might still be looking at a partial night, so we do **not** pin.

### Persistence + reset

The pin is a day-tagged cursor (`frozen_headline` = `{day, value}`) via the existing `sync_cursor` store — survives restarts; a new day's first complete overnight overwrites it, and `getToday` only surfaces a pin whose `day` matches today.

### Same-day improvement → does NOT move the headline

Default and shipped behaviour: once pinned, a later same-day re-derive that would RAISE the score is ignored, same as one that lowers it. Stability is the whole point. Flagged as a product call for RR.

## Files

- `lib/compute/derivation_engine.dart` — `_headlineFreezeMarginSec`, the pure `nextFrozenHeadline` decision (`@visibleForTesting`), and `_maybeFreezeHeadlineReadiness` called at the end of `_derivePreparedDay` (writes the pin on the first complete-overnight settle for today; rescan/baseline re-derives hit the "already pinned" guard and hold).
- `lib/data/db.dart` — `frozenHeadline()` / `setFrozenHeadline()` cursor accessors.
- `lib/data/local_repository_impl.dart` — `getToday` surfaces the pin as the `readiness`/`recovery` headline metric when it belongs to today's own overnight (`overnight_state == 'ready'`, matching day). Both the hero and the story read it via `settledReadinessScore`.
- `test/readiness_freeze_test.dart` — ready→ready with a changing value → headline holds; a new day resets; a partial night settles to the complete-night value.

## Unverified without a device

No Flutter/Dart SDK or hardware in this environment — verified by inspection + the pure-function unit test only. **On-device confirmation needed** that: the freeze fires in the morning (the data edge reaches wake+60min on a normal post-wake sync), the pinned hero/story stay put across the day while trends/baselines keep moving, and the pin resets cleanly the next morning. The 60-minute margin is the tunable conservatism knob if the freeze proves too early/late in the field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Today’s morning readiness headline now stays consistent after the overnight sleep is fully complete.
  - Underlying readiness calculations continue updating without changing the displayed headline.
  - Headlines reset appropriately for each new day and update once the new overnight is complete.

- **Bug Fixes**
  - Prevented readiness headlines from drifting during the day or carrying over from a previous day.

- **Tests**
  - Added coverage for incomplete nights, missing readiness values, day transitions, and recalculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #128
