### PR TITLE
fix(workout): suppress PPG spikes in the workout max HR (#127)

### DIFF
--- a/lib/compute/hr_max.dart
+++ b/lib/compute/hr_max.dart
@@ -1,0 +1,129 @@
+// Spike-suppressed workout peak heart rate (issue #127).
+//
+// The Heart-rate page reports the max of per-MINUTE-averaged HR, so a brief PPG
+// motion spike is averaged away (true peak ~143 bpm). The workout summary used
+// to take a raw `hr.reduce(math.max)` over the 1 Hz samples with no artefact
+// rejection, so a single transient could define the whole session's "max HR"
+// (RR's report: 160 bpm summary vs a real 143 bpm peak). These helpers compute
+// a peak that steps over such transients while STILL preserving a genuine brief
+// effort peak — which a minute-mean would wrongly flatten. They are the single
+// definition shared by all three producers (live tick, on-read recompute, and
+// the workout-list fill) so the surfaces agree.
+//
+// Method:
+//   1. Physiological reject — drop samples outside [kHrFloorBpm, ceiling]; the
+//      ceiling is age-derived with headroom (real maxes exceed 220 − age) and
+//      hard-capped. These are impossible readings, never effort.
+//   2. Rolling median over a short odd window (~5 s at 1 Hz) — a 1–2 s spike can
+//      never be the median of five samples, so the median steps over it; a
+//      sustained climb survives because most of the window sits at the raised
+//      level.
+//   3. Peak = the maximum of that smoothed series.
+
+import 'dart:math' as math;
+
+/// Below this a sample is sensor dropout/garbage, not a heartbeat.
+const int kHrFloorBpm = 30;
+
+/// No human sustains a heart rate above this; anything higher is an artefact.
+const int kHrHardCeilBpm = 220;
+
+/// Rolling-median window (samples ≈ seconds at 1 Hz). Five is the smallest odd
+/// window that fully rejects a 1–2 s transient (a two-sample spike can never be
+/// the median of five) while preserving a genuine ≥3 s effort peak.
+const int kHrSmoothWindow = 5;
+
+/// Upper plausibility bound for a single HR sample, given [age]. Uses the
+/// 220 − age estimate plus headroom (genuine maxes run above the estimate),
+/// floored so a low estimate never clips real effort and capped at the hard
+/// human ceiling. Unknown age → the hard ceiling.
+int hrCeilingForAge(int? age) {
+  if (age == null) return kHrHardCeilBpm;
+  final withHeadroom = (220 - age) + 25;
+  return math.min(kHrHardCeilBpm, math.max(200, withHeadroom));
+}
+
+/// Spike-suppressed peak HR over a raw 1 Hz [hr] series, as `(value, index)`:
+/// the peak bpm and the index in [hr] at which it occurs (the centre of the
+/// winning window — for time-to-peak). Null when no plausible sample survives
+/// the physiological reject.
+(int, int)? smoothedMaxHrAt(
+  List<int> hr, {
+  int? age,
+  int window = kHrSmoothWindow,
+}) {
+  if (hr.isEmpty) return null;
+  final ceil = hrCeilingForAge(age);
+
+  // Physiological reject, keeping the ORIGINAL index of each kept sample so the
+  // returned peak index maps back onto the caller's raw series (time-to-peak).
+  final vals = <int>[];
+  final srcIdx = <int>[];
+  for (var i = 0; i < hr.length; i++) {
+    if (hr[i] >= kHrFloorBpm && hr[i] <= ceil) {
+      vals.add(hr[i]);
+      srcIdx.add(i);
+    }
+  }
+  if (vals.isEmpty) return null;
+
+  final w = window.isOdd ? window : window + 1;
+  // Too short to form a full window — fall back to the plausible max (already
+  // artefact-bounded by the reject above).
+  if (vals.length < w) {
+    var best = vals[0], bi = 0;
+    for (var i = 1; i < vals.length; i++) {
+      if (vals[i] > best) {
+        best = vals[i];
+        bi = i;
+      }
+    }
+    return (best, srcIdx[bi]);
+  }
+
+  final half = w ~/ 2;
+  final scratch = List<int>.filled(w, 0);
+  var bestMed = -1, bestIdx = srcIdx[half];
+  for (var c = half; c < vals.length - half; c++) {
+    for (var k = 0; k < w; k++) {
+      scratch[k] = vals[c - half + k];
+    }
+    scratch.sort();
+    final med = scratch[half];
+    if (med > bestMed) {
+      bestMed = med;
+      bestIdx = srcIdx[c];
+    }
+  }
+  return (bestMed, bestIdx);
+}
+
+/// Spike-suppressed peak HR (value only) — see [smoothedMaxHrAt].
+int? smoothedMaxHr(List<int> hr, {int? age, int window = kHrSmoothWindow}) =>
+    smoothedMaxHrAt(hr, age: age, window: window)?.$1;
+
+/// Streaming counterpart of [smoothedMaxHr] for the live workout tick: feed each
+/// 1 Hz sample with [add] and read [max], the spike-suppressed running peak.
+/// Uses the identical window + physiological reject so the live "new max!" value
+/// and the persisted session max agree with the on-read recompute.
+class RollingMaxHr {
+  RollingMaxHr({this.age, int window = kHrSmoothWindow})
+      : _window = window.isOdd ? window : window + 1;
+
+  final int? age;
+  final int _window;
+  final List<int> _buf = <int>[];
+
+  /// Spike-suppressed peak seen so far (bpm); 0 until a full window has passed.
+  int max = 0;
+
+  void add(int hr) {
+    if (hr < kHrFloorBpm || hr > hrCeilingForAge(age)) return; // reject
+    _buf.add(hr);
+    if (_buf.length > _window) _buf.removeAt(0);
+    if (_buf.length < _window) return; // wait for a full window before trusting
+    final sorted = List<int>.of(_buf)..sort();
+    final med = sorted[_window ~/ 2];
+    if (med > max) max = med;
+  }
+}

--- a/lib/compute/hr_max.dart
+++ b/lib/compute/hr_max.dart
@@ -43,12 +43,14 @@ int hrCeilingForAge(int? age) {
   return math.min(kHrHardCeilBpm, math.max(200, withHeadroom));
 }
 
-/// Spike-suppressed peak HR over a raw 1 Hz [hr] series, as `(value, index)`:
-/// the peak bpm and the index in [hr] at which it occurs (the centre of the
-/// winning window — for time-to-peak). Null when no plausible sample survives
-/// the physiological reject.
-(int, int)? smoothedMaxHrAt(
+/// Spike-suppressed extreme HR over a raw 1 Hz [hr] series. [wantMax] selects
+/// the peak (largest smoothed value) vs the trough (smallest). The min side is
+/// symmetric to the max: a 1–2 s LOW dropout can no more be the median of the
+/// window than a high spike, and the same physiological reject drops garbage
+/// (a stray <30 bpm reading) before it can define the trough.
+(int, int)? _smoothedExtremeHrAt(
   List<int> hr, {
+  required bool wantMax,
   int? age,
   int window = kHrSmoothWindow,
 }) {
@@ -56,7 +58,7 @@ int hrCeilingForAge(int? age) {
   final ceil = hrCeilingForAge(age);
 
   // Physiological reject, keeping the ORIGINAL index of each kept sample so the
-  // returned peak index maps back onto the caller's raw series (time-to-peak).
+  // returned index maps back onto the caller's raw series (time-to-peak).
   final vals = <int>[];
   final srcIdx = <int>[];
   for (var i = 0; i < hr.length; i++) {
@@ -68,12 +70,12 @@ int hrCeilingForAge(int? age) {
   if (vals.isEmpty) return null;
 
   final w = window.isOdd ? window : window + 1;
-  // Too short to form a full window — fall back to the plausible max (already
-  // artefact-bounded by the reject above).
+  // Too short to form a full window — fall back to the plausible extreme
+  // (already artefact-bounded by the reject above).
   if (vals.length < w) {
     var best = vals[0], bi = 0;
     for (var i = 1; i < vals.length; i++) {
-      if (vals[i] > best) {
+      if (wantMax ? vals[i] > best : vals[i] < best) {
         best = vals[i];
         bi = i;
       }
@@ -83,24 +85,43 @@ int hrCeilingForAge(int? age) {
 
   final half = w ~/ 2;
   final scratch = List<int>.filled(w, 0);
-  var bestMed = -1, bestIdx = srcIdx[half];
+  int? bestMed;
+  var bestIdx = srcIdx[half];
   for (var c = half; c < vals.length - half; c++) {
     for (var k = 0; k < w; k++) {
       scratch[k] = vals[c - half + k];
     }
     scratch.sort();
     final med = scratch[half];
-    if (med > bestMed) {
+    if (bestMed == null || (wantMax ? med > bestMed : med < bestMed)) {
       bestMed = med;
       bestIdx = srcIdx[c];
     }
   }
-  return (bestMed, bestIdx);
+  return (bestMed!, bestIdx);
 }
+
+/// Spike-suppressed peak HR over a raw 1 Hz [hr] series, as `(value, index)`:
+/// the peak bpm and the index in [hr] at which it occurs (the centre of the
+/// winning window — for time-to-peak). Null when no plausible sample survives
+/// the physiological reject.
+(int, int)? smoothedMaxHrAt(List<int> hr,
+        {int? age, int window = kHrSmoothWindow}) =>
+    _smoothedExtremeHrAt(hr, wantMax: true, age: age, window: window);
+
+/// Spike-suppressed trough HR — the min counterpart of [smoothedMaxHrAt], so a
+/// single low PPG dropout can't define the workout min.
+(int, int)? smoothedMinHrAt(List<int> hr,
+        {int? age, int window = kHrSmoothWindow}) =>
+    _smoothedExtremeHrAt(hr, wantMax: false, age: age, window: window);
 
 /// Spike-suppressed peak HR (value only) — see [smoothedMaxHrAt].
 int? smoothedMaxHr(List<int> hr, {int? age, int window = kHrSmoothWindow}) =>
     smoothedMaxHrAt(hr, age: age, window: window)?.$1;
+
+/// Spike-suppressed trough HR (value only) — see [smoothedMinHrAt].
+int? smoothedMinHr(List<int> hr, {int? age, int window = kHrSmoothWindow}) =>
+    smoothedMinHrAt(hr, age: age, window: window)?.$1;
 
 /// Streaming counterpart of [smoothedMaxHr] for the live workout tick: feed each
 /// 1 Hz sample with [add] and read [max], the spike-suppressed running peak.

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -3735,14 +3735,22 @@ class LocalDb {
   /// One indexed range join — powers the workout list's avg-bpm / no-data
   /// heuristic without a query per row. Sessions whose window has been pruned
   /// (14-day raw retention) simply don't appear.
+  /// [maxHrCeiling] physiologically bounds the SQL MAX(d.hr): a coarse guard so
+  /// a gross artefact can't define a session that has no on-read smoothed max
+  /// (imported/legacy rows). Spike-suppressed peaks come from
+  /// [sessionHrSamplesBySession] + the shared smoother; this MAX is a last
+  /// fallback only. 0/unset disables the bound.
   static Future<Map<String, Map<String, num>>> sessionHrStats(
     int fromTs,
-    int toTs,
-  ) async {
+    int toTs, {
+    int maxHrCeiling = 0,
+  }) async {
     final db = await instance;
+    final ceilClause = maxHrCeiling > 0 ? 'AND d.hr <= $maxHrCeiling ' : '';
     final rows = await db.rawQuery(
       'SELECT s.id AS id, COUNT(d.rec_ts) AS n, AVG(d.hr) AS avg_hr, '
-      '       MIN(d.hr) AS min_hr, MAX(d.hr) AS max_hr '
+      '       MIN(d.hr) AS min_hr, '
+      '       MAX(CASE WHEN 1=1 $ceilClause THEN d.hr END) AS max_hr '
       'FROM sessions s '
       'JOIN decoded_onehz d ON d.rec_ts >= s.start_ts '
       '  AND d.rec_ts <= COALESCE(s.end_ts, s.start_ts) AND d.hr > 0 '
@@ -3760,6 +3768,35 @@ class LocalDb {
             'max_hr': (r['max_hr'] as num?) ?? 0,
           },
     };
+  }
+
+  /// Worn 1 Hz HR samples for every session in [fromTs, toTs] (epoch SECONDS),
+  /// grouped {session_id: [hr, …]} in ascending time — one indexed range join.
+  /// Feeds the workout list's spike-suppressed max (the shared smoother runs in
+  /// the repo, not here). Sessions whose window has been pruned (14-day raw
+  /// retention) simply don't appear, and the caller falls back to the stored
+  /// column.
+  static Future<Map<String, List<int>>> sessionHrSamplesBySession(
+    int fromTs,
+    int toTs,
+  ) async {
+    final db = await instance;
+    final rows = await db.rawQuery(
+      'SELECT s.id AS id, d.hr AS hr '
+      'FROM sessions s '
+      'JOIN decoded_onehz d ON d.rec_ts >= s.start_ts '
+      '  AND d.rec_ts <= COALESCE(s.end_ts, s.start_ts) AND d.hr > 0 '
+      'WHERE s.start_ts >= ? AND s.start_ts <= ? '
+      'ORDER BY s.id, d.rec_ts ASC',
+      [fromTs, toTs],
+    );
+    final out = <String, List<int>>{};
+    for (final r in rows) {
+      final id = r['id'] as String?;
+      if (id == null) continue;
+      (out[id] ??= <int>[]).add((r['hr'] as num).toInt());
+    }
+    return out;
   }
 
   /// Backfill a session's heart-rate-recovery (bpm), computed retrospectively

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -3735,21 +3735,23 @@ class LocalDb {
   /// One indexed range join — powers the workout list's avg-bpm / no-data
   /// heuristic without a query per row. Sessions whose window has been pruned
   /// (14-day raw retention) simply don't appear.
-  /// [maxHrCeiling] physiologically bounds the SQL MAX(d.hr): a coarse guard so
-  /// a gross artefact can't define a session that has no on-read smoothed max
-  /// (imported/legacy rows). Spike-suppressed peaks come from
-  /// [sessionHrSamplesBySession] + the shared smoother; this MAX is a last
-  /// fallback only. 0/unset disables the bound.
+  /// [maxHrCeiling] / [minHrFloor] physiologically bound the SQL MAX/MIN(d.hr):
+  /// a coarse guard so a gross artefact can't define a session that has no
+  /// on-read smoothed extreme (imported/legacy rows). Spike-suppressed
+  /// max/min come from [sessionHrSamplesBySession] + the shared smoother; these
+  /// aggregates are a last fallback only. 0/unset disables each bound.
   static Future<Map<String, Map<String, num>>> sessionHrStats(
     int fromTs,
     int toTs, {
     int maxHrCeiling = 0,
+    int minHrFloor = 0,
   }) async {
     final db = await instance;
     final ceilClause = maxHrCeiling > 0 ? 'AND d.hr <= $maxHrCeiling ' : '';
+    final floorClause = minHrFloor > 0 ? 'AND d.hr >= $minHrFloor ' : '';
     final rows = await db.rawQuery(
       'SELECT s.id AS id, COUNT(d.rec_ts) AS n, AVG(d.hr) AS avg_hr, '
-      '       MIN(d.hr) AS min_hr, '
+      '       MIN(CASE WHEN 1=1 $floorClause THEN d.hr END) AS min_hr, '
       '       MAX(CASE WHEN 1=1 $ceilClause THEN d.hr END) AS max_hr '
       'FROM sessions s '
       'JOIN decoded_onehz d ON d.rec_ts >= s.start_ts '

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -1670,26 +1670,32 @@ class LocalRepositoryImpl extends LocalRepository {
     // "no data" (avg_hr == 0) even when the window is full of worn HR.
     try {
       final age = _profileAge();
-      final stats =
-          await LocalDb.sessionHrStats(fromTs, nowSec, maxHrCeiling: hrCeilingForAge(age));
-      // Spike-suppressed max per session (issue #127): smooth the raw 1 Hz over
-      // one batched join so the list agrees with getWorkout's on-read recompute.
+      final stats = await LocalDb.sessionHrStats(fromTs, nowSec,
+          maxHrCeiling: hrCeilingForAge(age), minHrFloor: kHrFloorBpm);
+      // Spike-suppressed max/min per session (issue #127): smooth the raw 1 Hz
+      // over one batched join so the list agrees with getWorkout's on-read
+      // recompute.
       final rawBySession = await LocalDb.sessionHrSamplesBySession(fromTs, nowSec);
       for (final w in workouts) {
         final s = stats[w['id']];
+        final raw = rawBySession[w['id']];
         if (s != null && (s['n'] ?? 0) != 0) {
           w['avg_hr'] = (s['avg_hr'] as num).round();
-          w['min_hr'] = (s['min_hr'] as num).toInt();
         }
-        final raw = rawBySession[w['id']];
-        final smoothed = raw == null ? null : smoothedMaxHr(raw, age: age);
-        if (smoothed != null) {
-          // Authoritative — matches the detail screen's recompute exactly.
-          w['max_hr'] = smoothed;
+        // Peak: smoothed-from-raw (authoritative, matches the detail screen);
+        // else stored column, else the ceiling-bounded SQL max.
+        final smax = raw == null ? null : smoothedMaxHr(raw, age: age);
+        if (smax != null) {
+          w['max_hr'] = smax;
         } else if (s != null && (s['n'] ?? 0) != 0) {
-          // Raw pruned: stored column (live smoothed) first, else the
-          // ceiling-bounded SQL max as a coarse last resort.
           w['max_hr'] ??= (s['max_hr'] as num).toInt();
+        }
+        // Trough: same treatment. Raw pruned → the floor-bounded SQL min.
+        final smin = raw == null ? null : smoothedMinHr(raw, age: age);
+        if (smin != null) {
+          w['min_hr'] = smin;
+        } else if (s != null && (s['n'] ?? 0) != 0) {
+          w['min_hr'] = (s['min_hr'] as num).toInt();
         }
       }
     } catch (_) {
@@ -1767,7 +1773,9 @@ class LocalRepositoryImpl extends LocalRepository {
         w['hr'] = _minuteHrCurve(ts, hr);
         final avg = hr.reduce((a, b) => a + b) / hr.length;
         w['avg_hr'] = avg.round();
-        w['min_hr'] = hr.reduce(math.min);
+        // Spike-suppressed trough (issue #127): a lone low PPG dropout must not
+        // define the min, symmetric to the max recompute below.
+        w['min_hr'] = smoothedMinHr(hr, age: _profileAge()) ?? hr.reduce(math.min);
         // Spike-suppressed peak (issue #127). RECOMPUTE from the smoothed raw —
         // do NOT floor against the stored column: the live path may already have
         // written a spiked max there, and math.max() would preserve it.

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -18,6 +18,7 @@ import 'dart:isolate';
 import 'dart:math' as math;
 
 import '../compute/derivation_engine.dart';
+import '../compute/hr_max.dart';
 import 'package:openstrap_protocol/openstrap_protocol.dart' as proto;
 import 'package:openstrap_analytics/onehz.dart' as ana;
 
@@ -1668,13 +1669,28 @@ class LocalRepositoryImpl extends LocalRepository {
     // Sessions have no avg_hr column — without this every workout looked like
     // "no data" (avg_hr == 0) even when the window is full of worn HR.
     try {
-      final stats = await LocalDb.sessionHrStats(fromTs, nowSec);
+      final age = _profileAge();
+      final stats =
+          await LocalDb.sessionHrStats(fromTs, nowSec, maxHrCeiling: hrCeilingForAge(age));
+      // Spike-suppressed max per session (issue #127): smooth the raw 1 Hz over
+      // one batched join so the list agrees with getWorkout's on-read recompute.
+      final rawBySession = await LocalDb.sessionHrSamplesBySession(fromTs, nowSec);
       for (final w in workouts) {
         final s = stats[w['id']];
-        if (s == null || (s['n'] ?? 0) == 0) continue;
-        w['avg_hr'] = (s['avg_hr'] as num).round();
-        w['min_hr'] = (s['min_hr'] as num).toInt();
-        w['max_hr'] ??= (s['max_hr'] as num).toInt();
+        if (s != null && (s['n'] ?? 0) != 0) {
+          w['avg_hr'] = (s['avg_hr'] as num).round();
+          w['min_hr'] = (s['min_hr'] as num).toInt();
+        }
+        final raw = rawBySession[w['id']];
+        final smoothed = raw == null ? null : smoothedMaxHr(raw, age: age);
+        if (smoothed != null) {
+          // Authoritative — matches the detail screen's recompute exactly.
+          w['max_hr'] = smoothed;
+        } else if (s != null && (s['n'] ?? 0) != 0) {
+          // Raw pruned: stored column (live smoothed) first, else the
+          // ceiling-bounded SQL max as a coarse last resort.
+          w['max_hr'] ??= (s['max_hr'] as num).toInt();
+        }
       }
     } catch (_) {
       /* stats are an enrichment — the list still renders without them */
@@ -1752,11 +1768,15 @@ class LocalRepositoryImpl extends LocalRepository {
         final avg = hr.reduce((a, b) => a + b) / hr.length;
         w['avg_hr'] = avg.round();
         w['min_hr'] = hr.reduce(math.min);
-        final peak = hr.reduce(math.max);
-        w['max_hr'] = math.max((w['max_hr'] as int?) ?? 0, peak);
+        // Spike-suppressed peak (issue #127). RECOMPUTE from the smoothed raw —
+        // do NOT floor against the stored column: the live path may already have
+        // written a spiked max there, and math.max() would preserve it.
+        final peakAt = smoothedMaxHrAt(hr, age: _profileAge());
+        if (peakAt != null) {
+          w['max_hr'] = peakAt.$1;
+          w['time_to_peak_min'] = ((ts[peakAt.$2] - startTs) / 60).round();
+        }
         w['zone_bands'] = _zoneBands(hr);
-        w['time_to_peak_min'] =
-            ((ts[hr.indexOf(peak)] - startTs) / 60).round();
         final drift = _hrDriftPct(ts, hr, startTs, endTs);
         if (drift != null) w['hr_drift_pct'] = drift;
       }
@@ -1885,6 +1905,10 @@ class LocalRepositoryImpl extends LocalRepository {
     final age = (getProfileMap()?['age'] as num?)?.toDouble() ?? 30.0;
     return (220 - age).round();
   }
+
+  /// Profile age in years, or null when unset — the input to the physiological
+  /// HR ceiling in the spike-suppressed max ([hrCeilingForAge]).
+  int? _profileAge() => (getProfileMap()?['age'] as num?)?.round();
 
   @override
   Future<void> deleteWorkout(String id) async => LocalDb.deleteSession(id);

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -36,6 +36,7 @@ import '../ble/ios_ble_restore.dart';
 import '../cloud/companion_client.dart';
 import '../compute/derivation_engine.dart';
 import '../compute/derive_scheduler.dart';
+import '../compute/hr_max.dart';
 import '../compute/profile.dart';
 import '../data/day_label.dart';
 import '../data/db.dart';
@@ -2953,6 +2954,7 @@ class AppState extends ChangeNotifier {
       targetKcal: targetKcal,
       workoutId: id,
       type: type,
+      age: (user?['age'] as num?)?.round(),
     );
     // Persist the live session (INSERT OR REPLACE — idempotent if repo already
     // inserted this id). Final stats are written on stop.
@@ -3232,7 +3234,9 @@ class AppState extends ChangeNotifier {
 
     w.elapsed = DateTime.now().difference(w.startTime);
     w.currentHr = device.liveHr ?? 0;
-    if (w.currentHr > w.maxHrSeen) w.maxHrSeen = w.currentHr;
+    // Smooth at accrual (issue #127): a raw `> maxHrSeen` would let a 1–2 s PPG
+    // spike define the session max. accrueHr feeds the rolling-median peak.
+    w.accrueHr(w.currentHr);
     // Per-zone time: one tick ≈ one second in the current zone (persisted as
     // zone_min at stop — this is what feeds the Time-in-Zones bar).
     if (w.currentHr > 0) w.zoneSeconds[_zoneFor(w.currentHr)] += 1;
@@ -3299,7 +3303,12 @@ class LiveWorkoutState {
   double calories = 0.0;
   double strain = 0.0;
   int currentHr = 0;
-  int maxHrSeen = 0; // peak live HR this session (for the "new max!" moment)
+  int maxHrSeen = 0; // spike-suppressed peak live HR this session (issue #127)
+
+  /// Rolling-median accumulator behind [maxHrSeen] — smooths the live 1 Hz HR
+  /// at accrual so a transient PPG motion spike can't set the session max (or
+  /// fire a spurious "new max!"). Same window + reject as the on-read recompute.
+  final RollingMaxHr _hrPeak;
 
   /// Seconds spent in each HR zone (index 0..5 = Z0 rest .. Z5 max), tallied at
   /// 1 Hz by _tickWorkout. Z1..Z5 are persisted as `zone_min` on stop.
@@ -3317,5 +3326,13 @@ class LiveWorkoutState {
     required this.targetKcal,
     this.workoutId,
     this.type = 'other',
-  });
+    int? age,
+  }) : _hrPeak = RollingMaxHr(age: age);
+
+  /// Feed a live 1 Hz HR sample; updates the spike-suppressed [maxHrSeen].
+  void accrueHr(int hr) {
+    if (hr <= 0) return;
+    _hrPeak.add(hr);
+    if (_hrPeak.max > maxHrSeen) maxHrSeen = _hrPeak.max;
+  }
 }

--- a/lib/ui/activity/live_session_screen.dart
+++ b/lib/ui/activity/live_session_screen.dart
@@ -196,8 +196,11 @@ class _LiveSessionScreenState extends State<LiveSessionScreen>
     if (mins > 0 && mins % 5 == 0) _milestone('t$mins', '$mins MINUTES', "Locked in. Keep going.", AppColors.good);
     final kcalStep = (w.calories ~/ 100) * 100;
     if (kcalStep >= 100) _milestone('k$kcalStep', '$kcalStep KCAL', "Burning clean.", AppColors.coral);
-    if (w.elapsed.inSeconds > 90 && hr > 0 && hr == w.maxHrSeen && hr >= (_maxHr * 0.8)) {
-      _milestone('mhr$hr', 'NEW MAX · $hr', "Highest your heart's gone today.", AppColors.coralDeep);
+    // Announce on a new SMOOTHED peak (not raw instantaneous hr), so a transient
+    // spike can't fire a spurious "NEW MAX"; the dedup key gates one per value.
+    if (w.elapsed.inSeconds > 90 && w.maxHrSeen > 0 && w.maxHrSeen >= (_maxHr * 0.8)) {
+      _milestone('mhr${w.maxHrSeen}', 'NEW MAX · ${w.maxHrSeen}',
+          "Highest your heart's gone today.", AppColors.coralDeep);
     }
 
     // Rotate the playful line ~every 11s (or on zone change).

--- a/test/workout_max_hr_spike_test.dart
+++ b/test/workout_max_hr_spike_test.dart
@@ -1,0 +1,195 @@
+// issue #127: the workout summary showed max HR 160 while the HR page (minute-
+// mean) peak was the true 143. Root cause was a raw `hr.reduce(math.max)` over
+// the 1 Hz samples, so a single 1–2 s PPG motion spike defined the session max.
+//
+// These tests pin the fix at two levels:
+//   • the shared smoother (compute/hr_max.dart) — a 1–2 s spike is excluded, a
+//     genuine sustained peak is preserved, and the streaming (live) accumulator
+//     agrees with the batch recompute;
+//   • the repo seam over the REAL LocalDb (sqflite_ffi) — getWorkout AND
+//     getWorkouts both report the smoothed peak, never the raw spike, so the
+//     detail screen and the workout list agree.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:openstrap_edge/compute/hr_max.dart';
+import 'package:openstrap_edge/data/db.dart';
+import 'package:openstrap_edge/data/local_repository_impl.dart';
+import 'package:openstrap_edge/data/models.dart';
+import 'package:openstrap_edge/state/app_state.dart' show LiveWorkoutState;
+
+RawRecord _raw(int ts, int counter) => RawRecord(
+      counter: counter,
+      packetType: 47,
+      hex: 'beef$counter',
+      capturedAt: ts * 1000,
+      recTs: ts,
+    );
+
+Sample _sample(int ts, int counter, int hr) => Sample(
+      tsEpoch: ts,
+      counter: counter,
+      hr: hr,
+      rrIntervalsMs: const [],
+      ax: 0,
+      ay: 0,
+      az: 0,
+      spo2RedRaw: 0,
+      spo2IrRaw: 0,
+      skinTempRaw: 0,
+    );
+
+Future<void> _insertHr(int fromTs, int toTs, int Function(int ts) hrOf,
+    {required int counterBase}) async {
+  final raws = <RawRecord>[];
+  final samples = <Sample?>[];
+  var c = counterBase;
+  for (var ts = fromTs; ts <= toTs; ts++) {
+    raws.add(_raw(ts, c));
+    samples.add(_sample(ts, c, hrOf(ts)));
+    c++;
+  }
+  await LocalDb.insertRecordsBatch(raws, samples);
+}
+
+void main() {
+  // ── The shared smoother: pure, no DB ─────────────────────────────────────
+  group('smoothedMaxHr', () {
+    test('excludes a 1–2 s transient spike (issue #127)', () {
+      // 40 s at 143 with a lone 2 s jump to 200 — the reported failure shape.
+      final hr = [
+        for (var i = 0; i < 40; i++) (i == 20 || i == 21) ? 200 : 143,
+      ];
+      expect(smoothedMaxHr(hr, age: 30), 143);
+    });
+
+    test('rejects an isolated single-sample spike', () {
+      final hr = [for (var i = 0; i < 30; i++) i == 15 ? 205 : 138];
+      expect(smoothedMaxHr(hr, age: 30), 138);
+    });
+
+    test('preserves a genuine sustained peak above the baseline', () {
+      // Baseline 140 with a real 15 s plateau at 158 — a brief peak that a
+      // minute-mean would flatten, so it must NOT be suppressed.
+      final hr = [
+        for (var i = 0; i < 60; i++) (i >= 20 && i < 35) ? 158 : 140,
+      ];
+      expect(smoothedMaxHr(hr, age: 30), 158);
+    });
+
+    test('reports the index at the smoothed peak (time-to-peak)', () {
+      final hr = [for (var i = 0; i < 60; i++) (i >= 30 && i < 45) ? 160 : 130];
+      final at = smoothedMaxHrAt(hr, age: 30);
+      expect(at, isNotNull);
+      expect(at!.$1, 160);
+      // First window whose median is 160 centres at the plateau's 3rd sample.
+      expect(at.$2, inInclusiveRange(30, 44));
+    });
+
+    test('physiological reject drops an impossible reading', () {
+      // 250 bpm is above the age-30 ceiling; the plausible max is 140.
+      final hr = [for (var i = 0; i < 20; i++) i == 10 ? 250 : 140];
+      expect(smoothedMaxHr(hr, age: 30), 140);
+    });
+
+    test('series shorter than a window falls back to the plausible max', () {
+      expect(smoothedMaxHr([150], age: 30), 150);
+      expect(smoothedMaxHr(const [], age: 30), isNull);
+    });
+
+    test('ceiling has headroom above 220 − age but hard-caps at 220', () {
+      expect(hrCeilingForAge(30), 215); // (220-30)+25
+      expect(hrCeilingForAge(70), 200); // floored, not (220-70)+25=175
+      expect(hrCeilingForAge(10), 220); // capped, not 235
+      expect(hrCeilingForAge(null), 220);
+    });
+  });
+
+  // ── The live accumulator agrees with the batch recompute ─────────────────
+  group('RollingMaxHr (live accrual)', () {
+    test('streaming max matches smoothedMaxHr over the same series', () {
+      final hr = [
+        for (var i = 0; i < 60; i++)
+          (i == 25 || i == 26) ? 205 : (i >= 40 && i < 55 ? 158 : 141),
+      ];
+      final live = RollingMaxHr(age: 30);
+      for (final v in hr) {
+        live.add(v);
+      }
+      expect(live.max, 158); // spike rejected, genuine plateau kept
+      expect(live.max, smoothedMaxHr(hr, age: 30));
+    });
+
+    test('LiveWorkoutState.accrueHr suppresses a spike in maxHrSeen', () {
+      final w = LiveWorkoutState(
+          startTime: DateTime.now(), targetKcal: 300, age: 30);
+      for (var i = 0; i < 40; i++) {
+        w.accrueHr((i == 18 || i == 19) ? 200 : 142);
+      }
+      expect(w.maxHrSeen, 142);
+    });
+  });
+
+  // ── Repo seam over the real DB: detail + list both smoothed and agree ─────
+  group('workout max HR over LocalDb', () {
+    late LocalRepositoryImpl repo;
+
+    setUpAll(() async {
+      sqfliteFfiInit();
+      databaseFactory = databaseFactoryFfi;
+      LocalDb.dbName = 'openstrap_max_hr_spike_test.db';
+      final dir = await databaseFactory.getDatabasesPath();
+      await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+      repo = LocalRepositoryImpl(getProfileMap: () => {'age': 30}); // maxHr 190
+    });
+
+    tearDownAll(() async {
+      await LocalDb.close();
+      final dir = await databaseFactory.getDatabasesPath();
+      await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+    });
+
+    const start = 800000;
+    const end = 800600; // 10 min
+
+    test('getWorkout reports the smoothed peak, not a 1–2 s spike', () async {
+      await LocalDb.putSession({
+        'id': 'w-spike',
+        'start_ts': start,
+        'end_ts': end,
+        'type': 'run',
+        'status': 'done',
+        'duration_min': 10,
+        // A spiked value already persisted by the (old) live path — the
+        // recompute must OVERRIDE it, not floor against it.
+        'max_hr': 160,
+        'source': 'manual',
+        'created_at': start * 1000,
+      });
+      // Baseline 143; a genuine 20 s plateau at 152; a 2 s spike to 200 and a
+      // 1 s spike to 210 elsewhere.
+      await _insertHr(start, end - 1, (ts) {
+        final o = ts - start;
+        if (o >= 200 && o < 220) return 152; // real brief peak
+        if (o == 400 || o == 401) return 200; // 2 s motion spike
+        if (o == 450) return 210; // 1 s motion spike
+        return 143;
+      }, counterBase: 40000);
+
+      final w = await repo.getWorkout('w-spike');
+      expect(w['max_hr'], 152); // genuine peak kept, spikes + stored 160 gone
+      expect(w['min_hr'], 143);
+      // time-to-peak lands on the real plateau (~200 s in → 3 min), not a spike.
+      expect(w['time_to_peak_min'], inInclusiveRange(3, 4));
+    });
+
+    test('getWorkouts list agrees with the detail screen', () async {
+      final res = await repo.getWorkouts(range: 'all');
+      final workouts = (res['workouts'] as List).cast<Map>();
+      final w = workouts.firstWhere((e) => e['id'] == 'w-spike');
+      expect(w['max_hr'], 152); // same smoothed peak as getWorkout
+    });
+  });
+}

--- a/test/workout_max_hr_spike_test.dart
+++ b/test/workout_max_hr_spike_test.dart
@@ -107,6 +107,37 @@ void main() {
     });
   });
 
+  // ── The min counterpart: symmetric spike suppression ─────────────────────
+  group('smoothedMinHr', () {
+    test('excludes a 1–2 s low dropout', () {
+      // 40 s at 138 with a lone 2 s dip to 45 — the low-side of issue #127.
+      final hr = [
+        for (var i = 0; i < 40; i++) (i == 20 || i == 21) ? 45 : 138,
+      ];
+      expect(smoothedMinHr(hr, age: 30), 138);
+    });
+
+    test('preserves a genuine sustained low below the baseline', () {
+      // Baseline 150 with a real 15 s trough at 132 — a brief genuine low that
+      // must NOT be smoothed away.
+      final hr = [
+        for (var i = 0; i < 60; i++) (i >= 20 && i < 35) ? 132 : 150,
+      ];
+      expect(smoothedMinHr(hr, age: 30), 132);
+    });
+
+    test('physiological floor drops sub-30 garbage before the min', () {
+      // 15 bpm is below the floor; the plausible min is 140.
+      final hr = [for (var i = 0; i < 20; i++) i == 10 ? 15 : 140];
+      expect(smoothedMinHr(hr, age: 30), 140);
+    });
+
+    test('series shorter than a window falls back to the plausible min', () {
+      expect(smoothedMinHr([132], age: 30), 132);
+      expect(smoothedMinHr(const [], age: 30), isNull);
+    });
+  });
+
   // ── The live accumulator agrees with the batch recompute ─────────────────
   group('RollingMaxHr (live accrual)', () {
     test('streaming max matches smoothedMaxHr over the same series', () {
@@ -140,9 +171,9 @@ void main() {
     const end = 800600; // 10 min
 
     // Seed once so each test is self-contained and order-independent: a session
-    // with baseline 143, a genuine 20 s plateau at 152, and 2 s / 1 s motion
-    // spikes to 200 / 210 — plus a spiked max_hr=160 already on the row (as the
-    // old live path would have left it).
+    // with baseline 143, a genuine 20 s plateau at 152, 2 s / 1 s HIGH motion
+    // spikes to 200 / 210, and a 2 s LOW dropout to 40 plus a 1 s garbage 20 —
+    // plus a spiked max_hr=160 already on the row (as the old live path left it).
     Future<void> seedSpikeSession() async {
       await LocalDb.putSession({
         'id': 'w-spike',
@@ -159,8 +190,10 @@ void main() {
       await _insertHr(start, end - 1, (ts) {
         final o = ts - start;
         if (o >= 200 && o < 220) return 152; // real brief peak
-        if (o == 400 || o == 401) return 200; // 2 s motion spike
-        if (o == 450) return 210; // 1 s motion spike
+        if (o == 400 || o == 401) return 200; // 2 s high motion spike
+        if (o == 450) return 210; // 1 s high motion spike
+        if (o == 300 || o == 301) return 40; // 2 s low dropout
+        if (o == 350) return 20; // 1 s sub-physiological garbage
         return 143;
       }, counterBase: 40000);
     }
@@ -184,7 +217,7 @@ void main() {
     test('getWorkout reports the smoothed peak, not a 1–2 s spike', () async {
       final w = await repo.getWorkout('w-spike');
       expect(w['max_hr'], 152); // genuine peak kept, spikes + stored 160 gone
-      expect(w['min_hr'], 143);
+      expect(w['min_hr'], 143); // 40 dropout + 20 garbage excluded, not the min
       // time-to-peak lands on the real plateau (~200 s in → 3 min), not a spike.
       expect(w['time_to_peak_min'], inInclusiveRange(3, 4));
     });
@@ -194,6 +227,7 @@ void main() {
       final workouts = (res['workouts'] as List).cast<Map>();
       final w = workouts.firstWhere((e) => e['id'] == 'w-spike');
       expect(w['max_hr'], 152); // same smoothed peak as getWorkout
+      expect(w['min_hr'], 143); // same smoothed trough as getWorkout
     });
   });
 }

--- a/test/workout_max_hr_spike_test.dart
+++ b/test/workout_max_hr_spike_test.dart
@@ -136,6 +136,35 @@ void main() {
   group('workout max HR over LocalDb', () {
     late LocalRepositoryImpl repo;
 
+    const start = 800000;
+    const end = 800600; // 10 min
+
+    // Seed once so each test is self-contained and order-independent: a session
+    // with baseline 143, a genuine 20 s plateau at 152, and 2 s / 1 s motion
+    // spikes to 200 / 210 — plus a spiked max_hr=160 already on the row (as the
+    // old live path would have left it).
+    Future<void> seedSpikeSession() async {
+      await LocalDb.putSession({
+        'id': 'w-spike',
+        'start_ts': start,
+        'end_ts': end,
+        'type': 'run',
+        'status': 'done',
+        'duration_min': 10,
+        // The recompute must OVERRIDE this, not floor against it.
+        'max_hr': 160,
+        'source': 'manual',
+        'created_at': start * 1000,
+      });
+      await _insertHr(start, end - 1, (ts) {
+        final o = ts - start;
+        if (o >= 200 && o < 220) return 152; // real brief peak
+        if (o == 400 || o == 401) return 200; // 2 s motion spike
+        if (o == 450) return 210; // 1 s motion spike
+        return 143;
+      }, counterBase: 40000);
+    }
+
     setUpAll(() async {
       sqfliteFfiInit();
       databaseFactory = databaseFactoryFfi;
@@ -143,6 +172,7 @@ void main() {
       final dir = await databaseFactory.getDatabasesPath();
       await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
       repo = LocalRepositoryImpl(getProfileMap: () => {'age': 30}); // maxHr 190
+      await seedSpikeSession();
     });
 
     tearDownAll(() async {
@@ -151,33 +181,7 @@ void main() {
       await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
     });
 
-    const start = 800000;
-    const end = 800600; // 10 min
-
     test('getWorkout reports the smoothed peak, not a 1–2 s spike', () async {
-      await LocalDb.putSession({
-        'id': 'w-spike',
-        'start_ts': start,
-        'end_ts': end,
-        'type': 'run',
-        'status': 'done',
-        'duration_min': 10,
-        // A spiked value already persisted by the (old) live path — the
-        // recompute must OVERRIDE it, not floor against it.
-        'max_hr': 160,
-        'source': 'manual',
-        'created_at': start * 1000,
-      });
-      // Baseline 143; a genuine 20 s plateau at 152; a 2 s spike to 200 and a
-      // 1 s spike to 210 elsewhere.
-      await _insertHr(start, end - 1, (ts) {
-        final o = ts - start;
-        if (o >= 200 && o < 220) return 152; // real brief peak
-        if (o == 400 || o == 401) return 200; // 2 s motion spike
-        if (o == 450) return 210; // 1 s motion spike
-        return 143;
-      }, counterBase: 40000);
-
       final w = await repo.getWorkout('w-spike');
       expect(w['max_hr'], 152); // genuine peak kept, spikes + stored 160 gone
       expect(w['min_hr'], 143);


### PR DESCRIPTION
## Problem

Closes #127. The workout summary shows **max HR 160 bpm** while the Heart-rate page peak is **143** (correct). The HR page peak is the max of per-**minute-averaged** HR (transient spikes averaged away), but the workout max was a raw `hr.reduce(math.max)` over the 1 Hz samples with **no artefact rejection** — so a single 1–2 s PPG motion spike defines the whole session's max.

## Fix

New shared smoother `lib/compute/hr_max.dart`:

- **Physiological reject** — drop samples outside a plausible band (floor 30 bpm; ceiling = `220 − age` + headroom, hard-capped at 220).
- **Rolling median** over a short odd window (~5 s at 1 Hz) — a 1–2 s spike can never be the median of five samples, so the median steps over it; a genuine sustained peak survives (most of the window sits at the raised level). This deliberately does **not** floor to the minute-mean — a real brief peak can legitimately exceed a minute average.

Applied consistently to **all three** producers that write the workout max, so the detail screen, the workout list, and the live session agree:

1. **`getWorkout`** (`local_repository_impl.dart`) — RECOMPUTE from the smoothed raw instead of `math.max(stored, peak)`. Flooring against the stored column would preserve a spike the old live path had already written. Time-to-peak follows the smoothed peak's index.
2. **`getWorkouts` list** (`local_repository_impl.dart` + `db.dart`) — fill `max_hr` from the batched raw 1 Hz via the shared smoother (one indexed join), so the list matches the detail recompute. The SQL `MAX(d.hr)` is now physiologically ceiling-bounded and used only as a coarse last fallback when raw has been pruned (14-day retention).
3. **Live tick** (`app_state.dart`) — `maxHrSeen` now accrues through a rolling-median accumulator (`RollingMaxHr`) rather than `> maxHrSeen`, so a spike can't set the session max or fire a spurious "new max!" callout. The live-session "NEW MAX" moment keys off the smoothed value.

The HR-page minute-mean path is unchanged.

## Tests

`test/workout_max_hr_spike_test.dart`:

- Pure smoother: a 1–2 s spike is excluded, a genuine sustained peak is preserved, time-to-peak index lands on the real peak, the physiological reject drops impossible readings, short-series fallback, ceiling boundaries.
- Live accumulator (`RollingMaxHr` / `LiveWorkoutState.accrueHr`) matches the batch recompute.
- Repo seam over the real `LocalDb` (sqflite_ffi): `getWorkout` and `getWorkouts` both report the smoothed peak (a persisted spiked `max_hr` of 160 is overridden), and the two agree.

## Not verified without a device

No Flutter/Dart SDK in this environment, so `flutter analyze`/`flutter test` were **not run** — the change is verified by inspection and the new tests are written to the existing `workout_enrichment_test.dart` harness. Please run the suite on a machine with the SDK.

On-device confirmation still wanted: inspect the raw `decoded_onehz` HR over the reported session to confirm the 160 was in fact a 1–2 s outlier (not a genuine short burst), and eyeball that the summary now matches the HR-page 143.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved max heart-rate detection by suppressing short sensor spikes and filtering implausible values using an age-aware physiological ceiling (and floor for minima).
  - Live sessions and completed workout summaries now compute smoothed max/min HR and more accurately determine time-to-peak from sustained plateaus, reducing false “NEW MAX” milestones.
  - Database session HR stats and samples are now bounded/filtered to avoid artifact-driven extrema.
- **Tests**
  - Added Flutter tests validating spike rejection, rolling live behavior, physiological bounds, and correct max/time-to-peak results via unit and integration coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->