### PR TITLE
fix(briefing): greet for the actual time of day, not the period

### DIFF
--- a/lib/ai/briefing_engine.dart
+++ b/lib/ai/briefing_engine.dart
@@ -247,9 +247,12 @@ class BriefingEngine {
     if (!configured) {
       throw CoachException('Add your AI key to enable briefings.');
     }
-    final day = todayLabel(now);
-    final tod = partOfDay(now ?? DateTime.now());
-    final inputs = await collectBriefingInputs(repo, period, now: now);
+    // One effective timestamp for the whole generation, so the day snapshot,
+    // greeting and generatedAt can't straddle midnight / a greeting boundary.
+    final effectiveNow = now ?? DateTime.now();
+    final day = todayLabel(effectiveNow);
+    final tod = partOfDay(effectiveNow);
+    final inputs = await collectBriefingInputs(repo, period, now: effectiveNow);
     final raw = await (complete ??
         (({required String system, required String user}) =>
             CoachEngine.completeText(
@@ -266,7 +269,7 @@ class BriefingEngine {
       period: period,
       oneLiner: parsed.oneLiner,
       breakdownMd: parsed.breakdownMd,
-      generatedAtMs: (now ?? DateTime.now()).millisecondsSinceEpoch,
+      generatedAtMs: effectiveNow.millisecondsSinceEpoch,
       inputs: inputs,
     );
     BriefingStore.write(b);

--- a/lib/ai/briefing_engine.dart
+++ b/lib/ai/briefing_engine.dart
@@ -134,13 +134,26 @@ Future<Map<String, dynamic>> collectBriefingInputs(
 
 // ── prompt building (PURE — unit-tested on sample data) ───────────────────────
 
-String briefingSystemPrompt(BriefingPeriod period) {
+/// The reader's local time of day — used only for the briefing's greeting, and
+/// deliberately distinct from [BriefingPeriod]: the morning briefing (last
+/// night's sleep + recovery) is shown right up to 17:00, so a reader opening it
+/// in the afternoon must be greeted for the afternoon, never the "morning".
+String partOfDay(DateTime now) {
+  final h = now.hour;
+  if (h < 12) return 'morning';
+  if (h < 17) return 'afternoon';
+  if (h < 21) return 'evening';
+  return 'night';
+}
+
+String briefingSystemPrompt(BriefingPeriod period, String timeOfDay) {
   final scope = period == BriefingPeriod.morning
-      ? 'last night\'s sleep and this morning\'s recovery, and what they mean '
-          'for the day ahead'
+      ? 'last night\'s sleep and recovery, and what they mean for the day ahead'
       : 'today\'s activity, strain and stress, and how the day landed';
-  return 'You write the ${period.id} health briefing for a local-first fitness '
-      'band app. Summarize $scope.\n'
+  return 'You write a health briefing for a local-first fitness band app. '
+      'It is currently $timeOfDay for the reader — if you open with a greeting, '
+      'greet for the $timeOfDay and never assume a different time of day. '
+      'Summarize $scope.\n'
       'HARD RULES:\n'
       '- Use ONLY the numbers provided. Never invent, estimate or mention a '
       'metric that is not in the data. No medical advice or diagnosis.\n'
@@ -158,11 +171,14 @@ String buildBriefingUserPrompt(
   BriefingPeriod period,
   String day,
   Map<String, dynamic> inputs,
+  String timeOfDay,
 ) {
   final b = StringBuffer()
     ..writeln(period == BriefingPeriod.morning
-        ? 'Morning briefing for $day. Overnight data:'
-        : 'Evening recap for $day. Today\'s data so far:');
+        ? 'Overnight briefing for $day (reader\'s local time: $timeOfDay). '
+            'Overnight data:'
+        : 'Evening recap for $day (reader\'s local time: $timeOfDay). '
+            'Today\'s data so far:');
   if (inputs.isEmpty) {
     b.writeln('(no metrics available yet)');
   } else {
@@ -232,13 +248,14 @@ class BriefingEngine {
       throw CoachException('Add your AI key to enable briefings.');
     }
     final day = todayLabel(now);
+    final tod = partOfDay(now ?? DateTime.now());
     final inputs = await collectBriefingInputs(repo, period, now: now);
     final raw = await (complete ??
         (({required String system, required String user}) =>
             CoachEngine.completeText(
                 config: config, system: system, user: user)))(
-      system: briefingSystemPrompt(period),
-      user: buildBriefingUserPrompt(period, day, inputs),
+      system: briefingSystemPrompt(period, tod),
+      user: buildBriefingUserPrompt(period, day, inputs, tod),
     );
     if (raw.trim().isEmpty) {
       throw CoachException('Empty response from provider.');

--- a/test/ai_briefing_test.dart
+++ b/test/ai_briefing_test.dart
@@ -114,19 +114,35 @@ void main() {
 
   group('prompt building (pure)', () {
     test('system prompt scopes by period and forbids invention', () {
-      final m = briefingSystemPrompt(BriefingPeriod.morning);
+      final m = briefingSystemPrompt(BriefingPeriod.morning, 'morning');
       expect(m, contains('ONLY the numbers provided'));
       expect(m.toLowerCase(), contains('sleep'));
-      final e = briefingSystemPrompt(BriefingPeriod.evening);
+      final e = briefingSystemPrompt(BriefingPeriod.evening, 'evening');
       expect(e.toLowerCase(), contains('strain'));
+    });
+
+    test('greeting follows the clock, not the period (issue #134)', () {
+      expect(partOfDay(DateTime(2026, 7, 22, 9)), 'morning');
+      expect(partOfDay(DateTime(2026, 7, 22, 15)), 'afternoon');
+      expect(partOfDay(DateTime(2026, 7, 22, 19)), 'evening');
+      expect(partOfDay(DateTime(2026, 7, 22, 23)), 'night');
+      // The morning briefing is shown until 17:00, so an afternoon reader must
+      // be told it's afternoon and the prompt must never say "morning".
+      final sys = briefingSystemPrompt(BriefingPeriod.morning, 'afternoon');
+      expect(sys, contains('currently afternoon'));
+      expect(sys.toLowerCase(), isNot(contains('morning')));
+      final usr = buildBriefingUserPrompt(
+          BriefingPeriod.morning, '2026-07-22', {'readiness': 74}, 'afternoon');
+      expect(usr, contains('afternoon'));
+      expect(usr.toLowerCase(), isNot(contains('morning')));
     });
 
     test('user prompt lists provided metrics and marks empty data', () {
       final p = buildBriefingUserPrompt(
-          BriefingPeriod.morning, '2026-07-04', {'readiness': 74});
+          BriefingPeriod.morning, '2026-07-04', {'readiness': 74}, 'morning');
       expect(p, contains('readiness: 74'));
       final empty = buildBriefingUserPrompt(
-          BriefingPeriod.evening, '2026-07-04', {});
+          BriefingPeriod.evening, '2026-07-04', {}, 'evening');
       expect(empty, contains('no metrics available'));
     });
   });


### PR DESCRIPTION
Fixes #134 (reported by @davidfleischmann).

## Problem
The AI briefing greeted with "morning" in the afternoon. The `morning` briefing period (last night's sleep + recovery) is shown right up until 17:00 by design, and the prompt hard-coded that framing — `briefingSystemPrompt` said "you write the **morning** health briefing … **this morning's** recovery" and the user prompt opened "**Morning briefing** for …". So a reader opening it at 3pm was handed "morning" and the model dutifully greeted with it.

## Fix
Separate the **greeting** (which should follow the clock) from the **period** (a data-scope concept). `generate()` already has the current time, so:
- New `partOfDay(now)` → `morning`/`afternoon`/`evening`/`night`.
- The prompt is told the reader's real local time of day and to greet for *that*, never assuming another time; the morning/evening scope wording is now time-neutral (no "this morning").
- No "morning" leaks into a morning-period prompt viewed in the afternoon.

The `morning`/`evening` period still drives which data the briefing summarises — only the greeting now tracks the clock.

## Tests
`test/ai_briefing_test.dart`: `partOfDay` boundaries, and that a morning-period prompt built for an afternoon reader says "currently afternoon" and never "morning".

Verified by inspection + unit tests (no SDK here to run `flutter test`); worth a quick on-device look that an afternoon briefing now reads right.

Closes #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Briefings now derive greeting and contextual header details from the reader’s local time of day.
  * Greeting guidance is generated for the current time-of-day bucket (morning/afternoon/evening/night) and stays consistent throughout the prompt.

* **Bug Fixes**
  * Prevented incorrect time-of-day greetings when the briefing period and local clock don’t match.
  * Briefings now use a single “effective now” timestamp for input collection and generation time.

* **Tests**
  * Updated prompt-building tests to cover explicit greeting inputs and clock-based behavior (including negative assertions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->