### PR TITLE
fix(notify): enforce fire-once dedupe for insight notifications

### DIFF
--- a/lib/notify/fired_keys.dart
+++ b/lib/notify/fired_keys.dart
@@ -1,0 +1,51 @@
+// fired_keys.dart — the persistent "already fired this key" record.
+//
+// A NotificationEvent's dedupeKey (by convention "$date:$kind") promises the
+// event fires at most once. The OS notification id alone does NOT enforce this:
+// re-showing the same id only REPLACES the prior post in the shade — it still
+// re-alerts (sound/buzz). Since derivation re-runs on every BLE sync, an insight
+// whose condition holds all day (e.g. today's irregular-rhythm flag) would fire
+// over and over (issue #136). This store makes emit() honour the promise: a key
+// that has already fired is skipped until a *new* key comes along.
+//
+// Reset is automatic: keys are date-prefixed, so tomorrow's "2026-07-24:irregular"
+// is a fresh key that fires once. No manual clearing is needed. The store is a
+// bounded FIFO of the most-recent [maxKeys] fired keys — format-agnostic and
+// safe: since a single day only ever mints a handful of distinct keys, the cap
+// is far larger than any one day's worth, so a same-day key can never be evicted
+// and re-fire.
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+class FiredKeyStore {
+  const FiredKeyStore();
+
+  static const String _prefsKey = 'notif_fired_keys';
+
+  /// How many most-recent fired keys to retain. Generous: a day mints only a
+  /// handful of distinct insight keys, so this spans many days — a same-day key
+  /// is never evicted (which would let it re-fire).
+  static const int maxKeys = 200;
+
+  /// Whether [dedupeKey] has already fired an OS notification.
+  Future<bool> hasFired(String dedupeKey) async {
+    final p = await SharedPreferences.getInstance();
+    final keys = p.getStringList(_prefsKey);
+    return keys != null && keys.contains(dedupeKey);
+  }
+
+  /// Record [dedupeKey] as fired. Bounded FIFO: the newest key is appended and
+  /// the oldest evicted once past [maxKeys]. A key already present is left
+  /// untouched — a repeated hit must NOT re-fire and must NOT refresh its
+  /// recency (otherwise a hot duplicate could keep a stale key pinned forever).
+  Future<void> recordFired(String dedupeKey) async {
+    final p = await SharedPreferences.getInstance();
+    final keys = List<String>.of(p.getStringList(_prefsKey) ?? const <String>[]);
+    if (keys.contains(dedupeKey)) return;
+    keys.add(dedupeKey);
+    if (keys.length > maxKeys) {
+      keys.removeRange(0, keys.length - maxKeys);
+    }
+    await p.setStringList(_prefsKey, keys);
+  }
+}

--- a/lib/notify/notification_center.dart
+++ b/lib/notify/notification_center.dart
@@ -8,6 +8,8 @@
 //   • either we're outside quiet hours, or the event is critical and the user
 //     allowed critical-overrides-quiet.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import '../ai/ai_prefs.dart';
@@ -23,6 +25,28 @@ class NotificationCenter {
 
   /// The persistent "already fired this dedupeKey" guard. See [FiredKeyStore].
   final FiredKeyStore _fired = const FiredKeyStore();
+
+  /// Tail of a chained-Future lock that serialises the check-present-record
+  /// critical section in [emit]. Without it two overlapping emits could both
+  /// pass [FiredKeyStore.hasFired] before either records (→ both present), and
+  /// their read-modify-write of the fired-key list could clobber each other
+  /// (losing a key). More likely now the UI-thread stress alert can race the
+  /// background derive loop. Dart is single-isolate, so this in-memory lock
+  /// fully orders the awaits within emit.
+  Future<void> _lock = Future<void>.value();
+
+  /// Run [action] after any in-flight critical section completes, exclusively.
+  Future<void> _synchronized(Future<void> Function() action) async {
+    final prev = _lock;
+    final done = Completer<void>();
+    _lock = done.future; // installed synchronously — orders concurrent callers
+    await prev;
+    try {
+      await action();
+    } finally {
+      done.complete();
+    }
+  }
 
   /// The OS presentation sink. Returns true when the event was actually shown
   /// (permission granted, no error). Overridable in tests to assert call counts
@@ -57,12 +81,18 @@ class NotificationCenter {
       // Skip a key that has already fired; record it only after a real present
       // (a permission-denied no-op must not consume the key). The guard resets
       // itself per new day via the date-prefixed keys.
-      if (await _fired.hasFired(e.dedupeKey)) return;
-      final shown = await presentSink(
-        e,
-        allowPermissionPrompt: allowPermissionPrompt,
-      );
-      if (shown) await _fired.recordFired(e.dedupeKey);
+      //
+      // Serialised: hasFired → present → recordFired runs one emit at a time,
+      // so overlapping emits can't both present the same key nor clobber the
+      // fired-key list (recordFired re-reads the latest list inside the lock).
+      await _synchronized(() async {
+        if (await _fired.hasFired(e.dedupeKey)) return;
+        final shown = await presentSink(
+          e,
+          allowPermissionPrompt: allowPermissionPrompt,
+        );
+        if (shown) await _fired.recordFired(e.dedupeKey);
+      });
     } catch (_) {/* OS present best-effort */}
   }
 

--- a/lib/notify/notification_center.dart
+++ b/lib/notify/notification_center.dart
@@ -8,8 +8,11 @@
 //   • either we're outside quiet hours, or the event is critical and the user
 //     allowed critical-overrides-quiet.
 
+import 'package:flutter/foundation.dart';
+
 import '../ai/ai_prefs.dart';
 import '../ai/reminder_plan.dart';
+import 'fired_keys.dart';
 import 'notification_event.dart';
 import 'notification_prefs.dart';
 import 'notification_service.dart';
@@ -17,6 +20,16 @@ import 'notification_service.dart';
 class NotificationCenter {
   NotificationCenter._();
   static final NotificationCenter instance = NotificationCenter._();
+
+  /// The persistent "already fired this dedupeKey" guard. See [FiredKeyStore].
+  final FiredKeyStore _fired = const FiredKeyStore();
+
+  /// The OS presentation sink. Returns true when the event was actually shown
+  /// (permission granted, no error). Overridable in tests to assert call counts
+  /// without a device; defaults to the real service.
+  @visibleForTesting
+  Future<bool> Function(NotificationEvent e, {bool allowPermissionPrompt})
+      presentSink = NotificationService.instance.presentEvent;
 
   /// Present to the OS (if allowed). Never throws.
   ///
@@ -36,12 +49,20 @@ class NotificationCenter {
       final prefs = await NotificationPrefs.load();
       final now = DateTime.now();
       final minuteOfDay = now.hour * 60 + now.minute;
-      if (prefs.shouldFireOs(e, minuteOfDay)) {
-        await NotificationService.instance.presentEvent(
-          e,
-          allowPermissionPrompt: allowPermissionPrompt,
-        );
-      }
+      if (!prefs.shouldFireOs(e, minuteOfDay)) return;
+      // Enforce the dedupeKey's "fires at most once" contract (issue #136).
+      // The OS id only REPLACES a prior post of the same key — it still
+      // re-alerts — and derivation re-runs on every BLE sync, so an insight
+      // whose condition holds all day would otherwise buzz over and over.
+      // Skip a key that has already fired; record it only after a real present
+      // (a permission-denied no-op must not consume the key). The guard resets
+      // itself per new day via the date-prefixed keys.
+      if (await _fired.hasFired(e.dedupeKey)) return;
+      final shown = await presentSink(
+        e,
+        allowPermissionPrompt: allowPermissionPrompt,
+      );
+      if (shown) await _fired.recordFired(e.dedupeKey);
     } catch (_) {/* OS present best-effort */}
   }
 

--- a/lib/notify/notification_service.dart
+++ b/lib/notify/notification_service.dart
@@ -222,14 +222,21 @@ class NotificationService {
   /// Present a NotificationEvent on its category channel. Same osId replaces, so
   /// re-firing the same logical event never stacks duplicates. Never throws.
   ///
+  /// Returns true when the event was actually shown (permission granted, no
+  /// error), false otherwise — [NotificationCenter.emit] uses this to record a
+  /// key as fired only on a real present, so a permission-denied no-op doesn't
+  /// permanently consume the dedupeKey.
+  ///
   /// [allowPermissionPrompt] — see [ensurePermission]'s doc. Pass `false` from
   /// any caller that knows it's running headless/in the background.
-  Future<void> presentEvent(
+  Future<bool> presentEvent(
     NotificationEvent e, {
     bool allowPermissionPrompt = true,
   }) async {
     try {
-      if (!await ensurePermission(allowPrompt: allowPermissionPrompt)) return;
+      if (!await ensurePermission(allowPrompt: allowPermissionPrompt)) {
+        return false;
+      }
       await _plugin.show(
         e.osId,
         e.title,
@@ -237,7 +244,10 @@ class NotificationService {
         _details(e.category),
         payload: e.route,
       );
-    } catch (_) {/* best-effort */}
+      return true;
+    } catch (_) {
+      return false; /* best-effort */
+    }
   }
 
   /// Legacy device-alert entry (battery/charging). Kept for device_alerts.dart.

--- a/lib/ui/stress/stress_screen.dart
+++ b/lib/ui/stress/stress_screen.dart
@@ -15,8 +15,8 @@ import '../../data/local_repository.dart';
 import '../../state/app_state.dart';
 import '../design/design.dart';
 import '../screens/metric_row.dart' show infoFor;
+import '../../notify/notification_center.dart';
 import '../../notify/notification_event.dart';
-import '../../notify/notification_service.dart';
 import 'calm_breathing_screen.dart';
 
 class StressScreen extends StatefulWidget {
@@ -77,7 +77,7 @@ class _StressScreenState extends State<StressScreen> {
         if (hasStress) {
           final score = (stress['score'] as num).toInt();
           if (score > 70) {
-            NotificationService.instance.presentEvent(
+            NotificationCenter.instance.emit(
               NotificationEvent(
                 dedupeKey: '${widget.date}:high_stress',
                 category: NotifCategory.health,

--- a/test/notification_dedupe_test.dart
+++ b/test/notification_dedupe_test.dart
@@ -31,14 +31,22 @@ class _FakeSink {
 /// A sink that parks inside the present call until [release] is called, so a
 /// test can hold one emit mid-critical-section and prove a second overlapping
 /// emit is serialised behind it. [calls] counts entries into present.
+///
+/// [entered] fires the moment an emit first reaches the parked point, so tests
+/// order on that signal rather than a scheduler-dependent delay.
 class _GatedSink {
   int calls = 0;
   final List<String> keys = [];
   final Completer<void> _gate = Completer<void>();
+  final Completer<void> _entered = Completer<void>();
+
+  /// Completes when the first emit reaches (enters) the present call.
+  Future<void> get entered => _entered.future;
 
   Future<bool> call(NotificationEvent e, {bool allowPermissionPrompt = true}) async {
     calls++;
     keys.add(e.dedupeKey);
+    if (!_entered.isCompleted) _entered.complete();
     await _gate.future;
     return true;
   }
@@ -194,9 +202,10 @@ void main() {
       final e = _ev('2026-07-23:irregular');
       final f1 = center.emit(e);
       final f2 = center.emit(e);
-      // Drain microtasks: the lock lets only the first emit reach the sink;
-      // the second is parked on the lock, not racing the fired-key check.
-      await Future<void>.delayed(Duration.zero);
+      // Order on the sink's entry signal, not a timer: once the first emit is
+      // parked inside present, the second is provably held on the lock (it
+      // can't have reached the fired-key check), so exactly one entered.
+      await sink.entered;
       expect(sink.calls, 1);
       sink.release();
       await Future.wait([f1, f2]);
@@ -212,7 +221,9 @@ void main() {
 
       final f1 = center.emit(_ev('2026-07-23:a'));
       final f2 = center.emit(_ev('2026-07-23:b'));
-      await Future<void>.delayed(Duration.zero);
+      // First emit is parked inside present; the second is held on the lock, so
+      // its record-key write can only run after the first's — no interleaving.
+      await sink.entered;
       sink.release();
       await Future.wait([f1, f2]);
 

--- a/test/notification_dedupe_test.dart
+++ b/test/notification_dedupe_test.dart
@@ -1,0 +1,204 @@
+// Tests for the persistent fire-once dedupe guard added for issue #136.
+//
+// NotificationCenter.emit must present a given dedupeKey to the OS at most once,
+// persisted across restarts, while a fresh (e.g. next-day) key still fires and
+// the existing category/quiet-hours gating is untouched. We inject a fake
+// present sink (counts calls, no device) and a mocked SharedPreferences.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:openstrap_edge/notify/fired_keys.dart';
+import 'package:openstrap_edge/notify/notification_center.dart';
+import 'package:openstrap_edge/notify/notification_event.dart';
+
+/// Records every event handed to the OS layer so tests can assert call counts.
+class _FakeSink {
+  final List<NotificationEvent> shown = [];
+  bool grant; // false simulates permission-denied (nothing actually shown)
+
+  _FakeSink({this.grant = true});
+
+  Future<bool> call(NotificationEvent e, {bool allowPermissionPrompt = true}) async {
+    if (!grant) return false;
+    shown.add(e);
+    return true;
+  }
+}
+
+NotificationEvent _ev(
+  String dedupeKey, {
+  NotifCategory category = NotifCategory.health,
+  NotifPriority priority = NotifPriority.critical,
+  String date = '2026-07-23',
+}) =>
+    NotificationEvent(
+      dedupeKey: dedupeKey,
+      category: category,
+      priority: priority,
+      title: 't',
+      body: 'b',
+      date: date,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final center = NotificationCenter.instance;
+  late Future<bool> Function(NotificationEvent, {bool allowPermissionPrompt})
+      original;
+
+  setUp(() {
+    // Quiet hours off + all categories on, so gating never interferes with the
+    // dedupe-focused tests (the gating tests set their own values).
+    SharedPreferences.setMockInitialValues({'notif_quiet_enabled': false});
+    original = center.presentSink;
+  });
+
+  tearDown(() {
+    center.presentSink = original;
+  });
+
+  group('emit dedupe (issue #136)', () {
+    test('same dedupeKey fires the OS notification exactly once', () async {
+      final sink = _FakeSink();
+      center.presentSink = sink.call;
+
+      final e = _ev('2026-07-23:irregular');
+      await center.emit(e);
+      await center.emit(e); // re-derive would re-emit the same key
+      await center.emit(e);
+
+      expect(sink.shown.length, 1);
+    });
+
+    test('a different (next-day) key fires again', () async {
+      final sink = _FakeSink();
+      center.presentSink = sink.call;
+
+      await center.emit(_ev('2026-07-23:irregular', date: '2026-07-23'));
+      await center.emit(_ev('2026-07-24:irregular', date: '2026-07-24'));
+
+      expect(sink.shown.length, 2);
+      expect(
+        sink.shown.map((e) => e.dedupeKey),
+        containsAll(['2026-07-23:irregular', '2026-07-24:irregular']),
+      );
+    });
+
+    test('the guard survives via SharedPreferences (restart-safe)', () async {
+      // First "session": key fires once and is recorded to SharedPreferences —
+      // the same on-disk store that survives an app restart on-device.
+      final sink1 = _FakeSink();
+      center.presentSink = sink1.call;
+      await center.emit(_ev('2026-07-23:illness'));
+      expect(sink1.shown.length, 1);
+
+      // Second "session": same persisted store — the key is still remembered,
+      // so it must NOT fire again.
+      final sink2 = _FakeSink();
+      center.presentSink = sink2.call;
+      await center.emit(_ev('2026-07-23:illness'));
+      expect(sink2.shown, isEmpty);
+    });
+
+    test('a permission-denied no-op does not consume the key', () async {
+      // Present fails (permission denied) → key not recorded → a later grant
+      // still lets it fire.
+      final denied = _FakeSink(grant: false);
+      center.presentSink = denied.call;
+      await center.emit(_ev('2026-07-23:temp'));
+
+      final granted = _FakeSink();
+      center.presentSink = granted.call;
+      await center.emit(_ev('2026-07-23:temp'));
+      expect(granted.shown.length, 1);
+    });
+  });
+
+  group('emit still respects gating', () {
+    test('a disabled category never presents (and is not recorded)', () async {
+      SharedPreferences.setMockInitialValues({'notif_health': false});
+      final sink = _FakeSink();
+      center.presentSink = sink.call;
+
+      await center.emit(_ev('2026-07-23:illness', category: NotifCategory.health));
+      expect(sink.shown, isEmpty);
+
+      // Re-enabling the category later must let the key fire — the gate, not the
+      // dedupe guard, suppressed it, so no key should have been recorded.
+      expect(await const FiredKeyStore().hasFired('2026-07-23:illness'), isFalse);
+    });
+
+    test('quiet hours suppress a non-critical event', () async {
+      // A window covering the whole day → now is always inside quiet hours.
+      SharedPreferences.setMockInitialValues({
+        'notif_quiet_enabled': true,
+        'notif_quiet_start': 0,
+        'notif_quiet_end': 1440,
+      });
+      final sink = _FakeSink();
+      center.presentSink = sink.call;
+
+      await center.emit(_ev(
+        '2026-07-23:recovery',
+        category: NotifCategory.recovery,
+        priority: NotifPriority.normal,
+      ));
+      expect(sink.shown, isEmpty);
+    });
+
+    test('a critical event overrides quiet hours (default) and still fires once',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        'notif_quiet_enabled': true,
+        'notif_quiet_start': 0,
+        'notif_quiet_end': 1440,
+      });
+      final sink = _FakeSink();
+      center.presentSink = sink.call;
+
+      final e = _ev('2026-07-23:illness', priority: NotifPriority.critical);
+      await center.emit(e);
+      await center.emit(e);
+      expect(sink.shown.length, 1);
+    });
+  });
+
+  group('FiredKeyStore bounding', () {
+    test('hasFired reflects recordFired', () async {
+      SharedPreferences.setMockInitialValues({});
+      const store = FiredKeyStore();
+      expect(await store.hasFired('a'), isFalse);
+      await store.recordFired('a');
+      expect(await store.hasFired('a'), isTrue);
+    });
+
+    test('a repeated record neither duplicates nor refreshes recency', () async {
+      SharedPreferences.setMockInitialValues({});
+      const store = FiredKeyStore();
+      await store.recordFired('a');
+      await store.recordFired('b');
+      await store.recordFired('a'); // hit — must be a no-op
+      final p = await SharedPreferences.getInstance();
+      // 'a' stays in its original (oldest) slot; no duplicate appended.
+      expect(p.getStringList('notif_fired_keys'), ['a', 'b']);
+    });
+
+    test('caps at maxKeys, evicting oldest first', () async {
+      SharedPreferences.setMockInitialValues({});
+      const store = FiredKeyStore();
+      for (var i = 0; i < FiredKeyStore.maxKeys + 5; i++) {
+        await store.recordFired('k$i');
+      }
+      final p = await SharedPreferences.getInstance();
+      final keys = p.getStringList('notif_fired_keys')!;
+      expect(keys.length, FiredKeyStore.maxKeys);
+      // Oldest five evicted; newest retained.
+      expect(await store.hasFired('k0'), isFalse);
+      expect(await store.hasFired('k4'), isFalse);
+      expect(await store.hasFired('k5'), isTrue);
+      expect(await store.hasFired('k${FiredKeyStore.maxKeys + 4}'), isTrue);
+    });
+  });
+}

--- a/test/notification_dedupe_test.dart
+++ b/test/notification_dedupe_test.dart
@@ -165,6 +165,42 @@ void main() {
     });
   });
 
+  group('stress-screen high-stress alert (now routed through emit)', () {
+    // The exact event stress_screen.dart builds: health category, default
+    // (normal) priority, no route. It used to call presentEvent directly,
+    // bypassing both the gate and the dedupe guard — now it goes through emit.
+    NotificationEvent highStress() => NotificationEvent(
+          dedupeKey: '2026-07-23:high_stress',
+          category: NotifCategory.health,
+          title: 'High Stress Detected',
+          body: 'Your stress score is 82. Consider taking a moment to breathe.',
+          date: '2026-07-23',
+        );
+
+    test('dedupes on repeat (was previously re-alerting per screen visit)',
+        () async {
+      final sink = _FakeSink();
+      center.presentSink = sink.call;
+      await center.emit(highStress());
+      await center.emit(highStress());
+      await center.emit(highStress());
+      expect(sink.shown.length, 1);
+    });
+
+    test('now respects quiet hours (normal priority, no longer bypassing)',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        'notif_quiet_enabled': true,
+        'notif_quiet_start': 0,
+        'notif_quiet_end': 1440,
+      });
+      final sink = _FakeSink();
+      center.presentSink = sink.call;
+      await center.emit(highStress());
+      expect(sink.shown, isEmpty);
+    });
+  });
+
   group('FiredKeyStore bounding', () {
     test('hasFired reflects recordFired', () async {
       SharedPreferences.setMockInitialValues({});

--- a/test/notification_dedupe_test.dart
+++ b/test/notification_dedupe_test.dart
@@ -5,6 +5,8 @@
 // the existing category/quiet-hours gating is untouched. We inject a fake
 // present sink (counts calls, no device) and a mocked SharedPreferences.
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -24,6 +26,24 @@ class _FakeSink {
     shown.add(e);
     return true;
   }
+}
+
+/// A sink that parks inside the present call until [release] is called, so a
+/// test can hold one emit mid-critical-section and prove a second overlapping
+/// emit is serialised behind it. [calls] counts entries into present.
+class _GatedSink {
+  int calls = 0;
+  final List<String> keys = [];
+  final Completer<void> _gate = Completer<void>();
+
+  Future<bool> call(NotificationEvent e, {bool allowPermissionPrompt = true}) async {
+    calls++;
+    keys.add(e.dedupeKey);
+    await _gate.future;
+    return true;
+  }
+
+  void release() => _gate.complete();
 }
 
 NotificationEvent _ev(
@@ -162,6 +182,47 @@ void main() {
       await center.emit(e);
       await center.emit(e);
       expect(sink.shown.length, 1);
+    });
+  });
+
+  group('concurrent emit serialisation', () {
+    test('two overlapping emits of the SAME key present exactly once',
+        () async {
+      final sink = _GatedSink();
+      center.presentSink = sink.call;
+
+      final e = _ev('2026-07-23:irregular');
+      final f1 = center.emit(e);
+      final f2 = center.emit(e);
+      // Drain microtasks: the lock lets only the first emit reach the sink;
+      // the second is parked on the lock, not racing the fired-key check.
+      await Future<void>.delayed(Duration.zero);
+      expect(sink.calls, 1);
+      sink.release();
+      await Future.wait([f1, f2]);
+
+      // Second emit saw the now-recorded key and never presented.
+      expect(sink.calls, 1);
+    });
+
+    test('two overlapping emits of DIFFERENT keys both record (no clobber)',
+        () async {
+      final sink = _GatedSink();
+      center.presentSink = sink.call;
+
+      final f1 = center.emit(_ev('2026-07-23:a'));
+      final f2 = center.emit(_ev('2026-07-23:b'));
+      await Future<void>.delayed(Duration.zero);
+      sink.release();
+      await Future.wait([f1, f2]);
+
+      expect(sink.calls, 2);
+      // Serialised read-modify-write: neither key clobbered the other.
+      final p = await SharedPreferences.getInstance();
+      expect(
+        p.getStringList('notif_fired_keys'),
+        containsAll(['2026-07-23:a', '2026-07-23:b']),
+      );
     });
   });
 


### PR DESCRIPTION
## The bug (#136)

A user gets the "Irregular heart rhythm" notification repeatedly/constantly.

Insight and health notifications are emitted with a `dedupeKey` like `'$date:irregular'`, and the call sites promise the event "fires at most once/day" — but nothing enforced it:

- `NotificationCenter.emit` gated only on `NotificationPrefs.shouldFireOs` (category-enabled + quiet-hours). It never consulted `dedupeKey`.
- The `osId` derived from the key makes a re-post **replace** the shade entry, but it still **re-alerts** (sound/buzz), and there was no persistent "already fired this key" record anywhere.
- Derivation re-runs on every BLE sync, so `emit('irregular', …)` re-fired all day while today's `irregular_rhythm_flag` was set. The same latent bug hit the illness / anomaly / temperature / readiness / HR-shift alerts (all via the local `emit` closure in `derivation_engine.dart`), plus recovery-ready, step-goal and auto-workout.

## The fix

Enforce the dedupe with a **persistent, bounded fired-key guard**:

- New `FiredKeyStore` (`lib/notify/fired_keys.dart`), backed by `shared_preferences` like the rest of the app.
- `NotificationCenter.emit` now: gate → **skip if the `dedupeKey` already fired** → present → **record the key only after a real present**. A permission-denied no-op therefore doesn't consume the key.
- `NotificationService.presentEvent` now returns `bool` (true = actually shown) so `emit` can record on success only.
- The store is a capped FIFO of the most-recent 200 keys (oldest evicted). Since a day only mints a handful of distinct keys, a same-day key can never be evicted and re-fire, and a new day's `'2026-07-24:irregular'` is a fresh key that fires once — so the guard **resets itself per day** with no manual reset. A repeated hit is a pure no-op (doesn't re-fire, doesn't refresh recency).

This also stops the other insight alerts (illness, anomaly, temperature, readiness, resting-HR shift, recovery-ready, step-goal, auto-workout) from repeating on re-derive.

### Also folded in: the stress-screen high-stress alert

`stress_screen.dart` called `NotificationService.presentEvent` **directly** for its "High Stress Detected" alert (`'$date:high_stress'`), bypassing **both** the prefs gate and the new dedupe guard — so it could re-alert on repeat screen visits and ignore quiet hours. It now routes through `NotificationCenter.emit` like every other insight, inheriting the same gating + fire-once behaviour. Event fields are unchanged (health category, normal priority); the call stays fire-and-forget.

## What is deliberately left alone

- **Device battery/charging alerts** go through `NotificationService.showDevice` with their own edge-triggered arm/re-arm hysteresis — they never route through `emit`, so they're unaffected.
- **Scheduled reminders** (water / wind-down / weekly recap / journal / AI briefings) are `zonedSchedule`d, not `emit`ed — untouched.
- Every `emit` caller was audited: all carry one-shot-per-key `dedupeKey`s (date-prefixed insights, per-firing `alarm_fired:$firedAt`, per-2h-bucket move nudge, and the ≥48h-cooldown `sync_stale` whose date prefix always differs between fires). None rely on same-key repetition, so none regress.

## Tests

`test/notification_dedupe_test.dart` (injects `SharedPreferences.setMockInitialValues` + a fake present sink, no device):

- same `dedupeKey` emitted repeatedly → OS present happens exactly once
- a different (next-day) key → fires
- the record survives via SharedPreferences (restart-safe)
- a permission-denied present does **not** consume the key
- category-disabled and quiet-hours gating still respected (critical still overrides quiet, and still only once)
- the stress-screen `high_stress` event shape dedupes and now respects quiet hours
- `FiredKeyStore` caps at 200, evicts oldest, and a repeated record neither duplicates nor refreshes recency

The stress-screen change itself is verified by inspection (routing `presentEvent` → `emit`); the event-level test above exercises the exact event shape through `emit`. A full widget test would need to mock the repository + the local-notifications plugin, which isn't worth the brittleness here.

## Verification note

No Flutter/Dart SDK or device was available in my environment, so this is verified by inspection + the new unit tests. **On-device confirmation of the end-to-end fix is still wanted.**

Closes #136


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent “fire once” notification deduplication with bounded history, preventing repeat displays across app restarts.
  * Routed high-stress alerts through the centralized notification flow so they benefit from the same dedupe and quiet-hours rules.

* **Bug Fixes**
  * Deduplication keys are now stored only after the notification is actually shown, not on permission denial or presentation failure.
  * Prevented race conditions so overlapping sends with the same key result in a single OS presentation (while different keys are handled independently).

* **Tests**
  * Added coverage for dedupe persistence, permission-failure behavior, gating/quiet-hours, and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Also fixes the repeated "Low readiness today" alert (same root cause).
Closes #138
