### PR TITLE
feat(lookback): browse past days on the Your day screen

### DIFF
--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -2359,20 +2359,24 @@ class LocalDb {
     return [for (final r in rows) _withDate(r)];
   }
 
-  /// Every day label ('YYYY-MM-DD') the user has ANY data for — the UNION of
-  /// derived `day_result` rows and raw `decoded_onehz` seconds (bucketed to the
-  /// local calendar day, matching the day model) — newest first. Bounds the
-  /// lookback screen's day navigation. A day with a `day_result` but pruned
-  /// minute-detail still appears (the screen shows its summary); only a day
-  /// with neither derived row nor raw substrate is absent (→ empty state).
+  /// Every day label ('YYYY-MM-DD') the lookback screen can actually RENDER —
+  /// exactly the days [dayResult]/`_bundleForDate` would return a real bundle
+  /// for, newest first. That is: the LATEST-`algo_version` `day_result` row per
+  /// day that is NOT a derivation skip-marker. A day whose minute-detail was
+  /// pruned still qualifies (its curves live in the persisted bundle payload,
+  /// so it renders a summary); but a raw-only day (`decoded_onehz` with no
+  /// derived row) and a skip-marker day both render EMPTY, so neither must
+  /// bound navigation. Skips are excluded via the `skipped` column, which
+  /// `_markDaySkipped` sets alongside the `{skipped:true}` payload.
   static Future<List<String>> availableDayIds() async {
     final db = await instance;
+    // Latest version per day (matches [dayResult]), then drop skip-markers.
     final rows = await db.rawQuery(
-      'SELECT day_id FROM day_result '
-      'UNION '
-      "SELECT strftime('%Y-%m-%d', rec_ts, 'unixepoch', 'localtime') AS day_id "
-      '  FROM decoded_onehz WHERE rec_ts > 0 '
-      'ORDER BY day_id DESC',
+      'SELECT r.day_id FROM day_result r '
+      'JOIN (SELECT day_id, MAX(algo_version) AS v FROM day_result GROUP BY day_id) m '
+      '  ON r.day_id = m.day_id AND r.algo_version = m.v '
+      'WHERE r.skipped = 0 '
+      'ORDER BY r.day_id DESC',
     );
     return [
       for (final r in rows)

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -2359,6 +2359,28 @@ class LocalDb {
     return [for (final r in rows) _withDate(r)];
   }
 
+  /// Every day label ('YYYY-MM-DD') the user has ANY data for — the UNION of
+  /// derived `day_result` rows and raw `decoded_onehz` seconds (bucketed to the
+  /// local calendar day, matching the day model) — newest first. Bounds the
+  /// lookback screen's day navigation. A day with a `day_result` but pruned
+  /// minute-detail still appears (the screen shows its summary); only a day
+  /// with neither derived row nor raw substrate is absent (→ empty state).
+  static Future<List<String>> availableDayIds() async {
+    final db = await instance;
+    final rows = await db.rawQuery(
+      'SELECT day_id FROM day_result '
+      'UNION '
+      "SELECT strftime('%Y-%m-%d', rec_ts, 'unixepoch', 'localtime') AS day_id "
+      '  FROM decoded_onehz WHERE rec_ts > 0 '
+      'ORDER BY day_id DESC',
+    );
+    return [
+      for (final r in rows)
+        if (r['day_id'] is String && (r['day_id'] as String).isNotEmpty)
+          r['day_id'] as String,
+    ];
+  }
+
   /// The set of day_id labels that already have a REAL, COMPLETE result at
   /// [algoVersion]. Used by the raw-pruning guard to decide what's safe to
   /// prune - a day that only ever got a skip-marker (its derivation threw)

--- a/lib/data/local_repository.dart
+++ b/lib/data/local_repository.dart
@@ -83,6 +83,13 @@ abstract class LocalRepository {
   Future<Map<String, dynamic>> getDayHrv(String date) =>
       throw UnimplementedError('re-layer: getDayHrv');
 
+  /// Every day ('YYYY-MM-DD') that has ANY recorded data — derived summary or
+  /// raw substrate — newest first. Bounds the lookback screen's day navigation
+  /// (the earliest reachable day + the date-picker's first date). Empty when
+  /// nothing has been recorded yet.
+  Future<List<String>> availableDays() =>
+      throw UnimplementedError('re-layer: availableDays');
+
   // ── trends + records + charts ────────────────────────────────────────────────
   Future<Map<String, dynamic>> getTrend(String metric,
           {String scale = 'week', String? anchor}) =>

--- a/lib/data/local_repository.dart
+++ b/lib/data/local_repository.dart
@@ -83,10 +83,11 @@ abstract class LocalRepository {
   Future<Map<String, dynamic>> getDayHrv(String date) =>
       throw UnimplementedError('re-layer: getDayHrv');
 
-  /// Every day ('YYYY-MM-DD') that has ANY recorded data — derived summary or
-  /// raw substrate — newest first. Bounds the lookback screen's day navigation
-  /// (the earliest reachable day + the date-picker's first date). Empty when
-  /// nothing has been recorded yet.
+  /// Every day ('YYYY-MM-DD') the lookback screen can actually RENDER — the days
+  /// with a genuine derived bundle (`getDayTimeline` returns real data for), not
+  /// raw-only or skip-marker days that would render empty — newest first. Bounds
+  /// the lookback screen's day navigation (the reachable prev/next days + the
+  /// date-picker's selectable days). Empty when nothing has been derived yet.
   Future<List<String>> availableDays() =>
       throw UnimplementedError('re-layer: availableDays');
 

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -511,6 +511,9 @@ class LocalRepositoryImpl extends LocalRepository {
   }
 
   @override
+  Future<List<String>> availableDays() => LocalDb.availableDayIds();
+
+  @override
   Future<Map<String, dynamic>> getDaySleep(String date) => _daySleep(date);
 
   @override

--- a/lib/ui/journey/day_nav.dart
+++ b/lib/ui/journey/day_nav.dart
@@ -59,6 +59,17 @@ class DayNav {
     return best;
   }
 
+  /// Whether the date picker may select [ymd] — true only for a day in
+  /// [navigable] (a recorded/renderable day, or today). Backs the picker's
+  /// `selectableDayPredicate` so an empty gap between recorded days can't be
+  /// chosen, only stepped over. [navigable] is the set from [navigableDays].
+  static bool isSelectable(String ymd, Iterable<String> navigable) {
+    for (final d in navigable) {
+      if (d == ymd) return true;
+    }
+    return false;
+  }
+
   /// The earliest navigable day — the date picker's `firstDate` bound. Null
   /// when [navigable] is empty. Order-independent.
   static String? earliest(Iterable<String> navigable) {

--- a/lib/ui/journey/day_nav.dart
+++ b/lib/ui/journey/day_nav.dart
@@ -1,0 +1,71 @@
+// Pure day-navigation maths for the lookback ("Your day") screen — no Flutter,
+// no DateTime, no intl. Days are 'YYYY-MM-DD' labels and, because they are
+// always zero-padded ISO, lexicographic string order IS chronological order —
+// so we compare and sort them as plain strings.
+//
+// Kept separate from [JourneyScreen] so the stepping/bounds rules (never past
+// today, stop at the earliest recorded day, skip empty gaps) are unit-testable
+// without a widget, a repo, or a database.
+
+class DayNav {
+  DayNav._();
+
+  /// The days the user may land on: every day that has data ([available]),
+  /// plus [today] and (when given) [current] — both always reachable. [today]
+  /// is the entry point even before it has filled, and [current] must never be
+  /// stranded outside its own bounds. Anything AFTER [today] is dropped so
+  /// navigation can never step into the future. Returned sorted ASCending
+  /// (oldest → newest) and de-duplicated.
+  static List<String> navigableDays(
+    Iterable<String> available,
+    String today, {
+    String? current,
+  }) {
+    final set = <String>{today};
+    if (current != null && current.isNotEmpty && current.compareTo(today) <= 0) {
+      set.add(current);
+    }
+    for (final d in available) {
+      if (d.isNotEmpty && d.compareTo(today) <= 0) set.add(d);
+    }
+    final list = set.toList()..sort();
+    return list;
+  }
+
+  /// The next day AFTER [current] the user may view — the SMALLEST navigable
+  /// day strictly later than [current] (so empty gaps between recorded days
+  /// are skipped). Null when [current] is already at/after the latest
+  /// navigable day (→ the "next" control is disabled, never entering the
+  /// future). Order-independent in [navigable].
+  static String? next(String current, Iterable<String> navigable) {
+    String? best;
+    for (final d in navigable) {
+      if (d.compareTo(current) <= 0) continue;
+      if (best == null || d.compareTo(best) < 0) best = d;
+    }
+    return best;
+  }
+
+  /// The previous day BEFORE [current] — the LARGEST navigable day strictly
+  /// earlier than [current] (gaps skipped). Null when [current] is already the
+  /// earliest navigable day (→ the "prev" control is disabled).
+  /// Order-independent in [navigable].
+  static String? prev(String current, Iterable<String> navigable) {
+    String? best;
+    for (final d in navigable) {
+      if (d.compareTo(current) >= 0) continue;
+      if (best == null || d.compareTo(best) > 0) best = d;
+    }
+    return best;
+  }
+
+  /// The earliest navigable day — the date picker's `firstDate` bound. Null
+  /// when [navigable] is empty. Order-independent.
+  static String? earliest(Iterable<String> navigable) {
+    String? best;
+    for (final d in navigable) {
+      if (best == null || d.compareTo(best) < 0) best = d;
+    }
+    return best;
+  }
+}

--- a/lib/ui/journey/journey_screen.dart
+++ b/lib/ui/journey/journey_screen.dart
@@ -8,14 +8,18 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../data/day_label.dart';
 import '../../data/local_repository.dart';
 import '../../state/app_state.dart';
 import '../design/design.dart';
 import '../timeline/timeline_screen.dart' show TimelineContent;
 import '../workouts/workout_types.dart';
+import 'day_nav.dart';
 
 class JourneyScreen extends StatefulWidget {
-  final String date; // 'YYYY-MM-DD'
+  /// The day to open on, 'YYYY-MM-DD'. The screen then lets the user step across
+  /// PAST days (issue #112) — this is only the ENTRY date, not a fixed one.
+  final String date;
   const JourneyScreen({super.key, required this.date});
   @override
   State<JourneyScreen> createState() => _JourneyScreenState();
@@ -28,10 +32,23 @@ class _JourneyScreenState extends State<JourneyScreen> {
   String? _error;
   Map<String, dynamic> _data = const {};
 
+  /// The day currently being viewed ('YYYY-MM-DD'). Starts at [widget.date] and
+  /// moves as the user navigates prev/next or picks a date; every change
+  /// re-runs [_load] for that day. All existing per-date behaviour (retention
+  /// gating, partial-today fallback, empty/error states) keys off THIS value.
+  late String _currentDate;
+
+  /// Days with any recorded data (newest first) — bounds the prev control and
+  /// the date picker. Empty until [_loadDays] returns (nav then falls back to
+  /// today-only bounds, which is safe).
+  List<String> _availableDays = const [];
+
   @override
   void initState() {
     super.initState();
+    _currentDate = widget.date;
     _load();
+    _loadDays();
   }
 
   Future<void> _load() async {
@@ -48,7 +65,7 @@ class _JourneyScreenState extends State<JourneyScreen> {
       _error = null;
     });
     try {
-      final res = await api.getDayTimeline(widget.date);
+      final res = await api.getDayTimeline(_currentDate);
       if (!mounted) return;
       setState(() {
         _data = res;
@@ -65,19 +82,78 @@ class _JourneyScreenState extends State<JourneyScreen> {
     }
   }
 
+  /// Fetch the recorded-day range once (non-fatal on failure).
+  Future<void> _loadDays() async {
+    final api = context.read<AppState>().repo;
+    if (api == null) return;
+    try {
+      final days = await api.availableDays();
+      if (!mounted) return;
+      setState(() => _availableDays = days);
+    } catch (_) {
+      // Navigation simply falls back to today-only bounds.
+    }
+  }
+
+  /// Navigate to [date] and reload (no-op if already there).
+  void _go(String date) {
+    if (date == _currentDate) return;
+    setState(() => _currentDate = date);
+    _load();
+  }
+
   /// The DISPLAYED day: the timeline's bundle date (a partial "today" may fall
   /// back to the latest complete day — the header must follow the data
-  /// actually shown, not the requested date). Falls back to widget.date.
+  /// actually shown, not the requested date). Falls back to [_currentDate].
   String get _displayDate {
     final d = _data['date'];
-    return (d is String && d.isNotEmpty) ? d : widget.date;
+    return (d is String && d.isNotEmpty) ? d : _currentDate;
   }
+
+  String get _today => todayLabel();
+
+  /// The set of days the user may land on, sorted ascending — recorded days
+  /// plus today and wherever we currently are, capped at today.
+  List<String> get _navigable =>
+      DayNav.navigableDays(_availableDays, _today, current: _currentDate);
+
+  // ── date parsing / picker ──────────────────────────────────────────────────
+
+  static DateTime? _parseYmd(String ymd) {
+    final p = ymd.split('-');
+    if (p.length != 3) return null;
+    final y = int.tryParse(p[0]), m = int.tryParse(p[1]), d = int.tryParse(p[2]);
+    if (y == null || m == null || d == null) return null;
+    return DateTime(y, m, d);
+  }
+
+  /// Tap the date → jump to any recorded day, bounded to [earliest, today].
+  Future<void> _openPicker() async {
+    final today = _parseYmd(_today);
+    if (today == null) return;
+    final earliestStr = DayNav.earliest(_navigable);
+    final first = (earliestStr == null ? null : _parseYmd(earliestStr)) ?? today;
+    var initial = _parseYmd(_displayDate) ?? today;
+    if (initial.isBefore(first)) initial = first;
+    if (initial.isAfter(today)) initial = today;
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: first,
+      lastDate: today,
+      helpText: 'Jump to a day',
+    );
+    if (picked == null || !mounted) return;
+    _go(dayLabelOf(picked));
+  }
+
+  // ── build ───────────────────────────────────────────────────────────────────
 
   @override
   Widget build(BuildContext context) {
     return AppScaffold(
       title: 'Your day',
-      subtitle: JourneyContent.prettyDate(_displayDate),
+      header: _dayNavBar(),
       children: [
         if (_phase == _Phase.loading) ...[
           Skeleton.chart(height: 260),
@@ -104,8 +180,92 @@ class _JourneyScreenState extends State<JourneyScreen> {
             onAction: _load,
           )
         else
-          JourneyContent(data: _data, requestedDate: widget.date),
+          JourneyContent(data: _data, requestedDate: _currentDate),
       ],
+    );
+  }
+
+  /// Prev / next chevrons flanking the (tappable) displayed date. Next is
+  /// disabled at today (never into the future); prev is disabled at the
+  /// earliest recorded day. Empty gaps between recorded days are skipped.
+  Widget _dayNavBar() {
+    final navigable = _navigable;
+    final prevDay = DayNav.prev(_currentDate, navigable);
+    final nextDay = DayNav.next(_currentDate, navigable);
+    final isToday = _displayDate == _today;
+    return Row(
+      children: [
+        _NavChevron(
+          icon: OsIcon.arrowLeft,
+          semanticLabel: 'Previous day',
+          onTap: prevDay == null ? null : () => _go(prevDay),
+        ),
+        Expanded(
+          child: Pressable(
+            pressedScale: 0.97,
+            onTap: _openPicker,
+            child: Semantics(
+              button: true,
+              label: 'Choose a day',
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: Sp.x2),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const OsAppIcon(OsIcon.calendar, size: 20),
+                    const SizedBox(width: Sp.x2),
+                    Flexible(
+                      child: Text(
+                        JourneyContent.prettyDate(_displayDate),
+                        style: AppText.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    if (isToday) ...[
+                      const SizedBox(width: Sp.x2),
+                      const Tag('today'),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+        _NavChevron(
+          icon: OsIcon.arrowRight,
+          semanticLabel: 'Next day',
+          onTap: nextDay == null ? null : () => _go(nextDay),
+        ),
+      ],
+    );
+  }
+}
+
+/// A circular prev/next control that greys out (and stops responding) when
+/// there's no day to move to in that direction.
+class _NavChevron extends StatelessWidget {
+  final OsIcon icon;
+  final String semanticLabel;
+  final VoidCallback? onTap;
+  const _NavChevron({
+    required this.icon,
+    required this.semanticLabel,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled = onTap != null;
+    return Semantics(
+      button: true,
+      enabled: enabled,
+      label: semanticLabel,
+      child: Opacity(
+        opacity: enabled ? 1.0 : 0.3,
+        child: RoundIconButton(icon, onTap: onTap),
+      ),
     );
   }
 }

--- a/lib/ui/journey/journey_screen.dart
+++ b/lib/ui/journey/journey_screen.dart
@@ -127,21 +127,30 @@ class _JourneyScreenState extends State<JourneyScreen> {
     return DateTime(y, m, d);
   }
 
-  /// Tap the date → jump to any recorded day, bounded to [earliest, today].
+  /// Tap the date → jump to any RECORDED day, bounded to [earliest, today].
+  /// Only recorded (renderable) days are choosable — empty gaps are greyed out
+  /// in the calendar so a tap can never land on a blank screen.
   Future<void> _openPicker() async {
     final today = _parseYmd(_today);
     if (today == null) return;
-    final earliestStr = DayNav.earliest(_navigable);
+    final navigable = _navigable;
+    final earliestStr = DayNav.earliest(navigable);
     final first = (earliestStr == null ? null : _parseYmd(earliestStr)) ?? today;
+    // The initial selection must itself be selectable, or showDatePicker
+    // asserts — fall back to today (always renderable via the partial-today
+    // fallback) when the displayed day somehow isn't in the set.
     var initial = _parseYmd(_displayDate) ?? today;
     if (initial.isBefore(first)) initial = first;
     if (initial.isAfter(today)) initial = today;
+    if (!DayNav.isSelectable(dayLabelOf(initial), navigable)) initial = today;
     final picked = await showDatePicker(
       context: context,
       initialDate: initial,
       firstDate: first,
       lastDate: today,
       helpText: 'Jump to a day',
+      selectableDayPredicate: (d) =>
+          DayNav.isSelectable(dayLabelOf(d), navigable),
     );
     if (picked == null || !mounted) return;
     _go(dayLabelOf(picked));

--- a/test/day_nav_test.dart
+++ b/test/day_nav_test.dart
@@ -1,0 +1,126 @@
+// Pure unit tests for the lookback day-navigation maths (issue #112): the
+// prev/next/earliest bounds over a set of recorded days. No Flutter, no repo,
+// no DB — [DayNav] is intentionally a pure string helper so these rules (never
+// past today, stop at the earliest day, skip empty gaps) are exhaustively
+// testable.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ui/journey/day_nav.dart';
+
+void main() {
+  group('DayNav.navigableDays', () {
+    test('always includes today and drops anything after it', () {
+      final nav = DayNav.navigableDays(
+        ['2026-07-25', '2026-07-19', '2026-07-30'], // 07-30 is in the future
+        '2026-07-24',
+      );
+      expect(nav, ['2026-07-19', '2026-07-24']);
+      // The future 07-30 and 07-25 (also > today) are excluded; today is added.
+      expect(nav.contains('2026-07-30'), isFalse);
+      expect(nav.contains('2026-07-25'), isFalse);
+      expect(nav.contains('2026-07-24'), isTrue);
+    });
+
+    test('is sorted ascending and de-duplicated', () {
+      final nav = DayNav.navigableDays(
+        ['2026-07-20', '2026-07-18', '2026-07-20'],
+        '2026-07-22',
+      );
+      expect(nav, ['2026-07-18', '2026-07-20', '2026-07-22']);
+    });
+
+    test('keeps the current day reachable even if not in the recorded set', () {
+      // A viewed day that has no data row must still be a valid bound.
+      final nav = DayNav.navigableDays(
+        const ['2026-07-20'],
+        '2026-07-24',
+        current: '2026-07-15',
+      );
+      expect(nav, ['2026-07-15', '2026-07-20', '2026-07-24']);
+    });
+
+    test('a future current is NOT admitted (cannot strand into tomorrow)', () {
+      final nav = DayNav.navigableDays(
+        const [],
+        '2026-07-24',
+        current: '2026-07-25',
+      );
+      expect(nav, ['2026-07-24']);
+    });
+
+    test('empty available yields today-only', () {
+      expect(DayNav.navigableDays(const [], '2026-07-24'), ['2026-07-24']);
+    });
+  });
+
+  group('DayNav.next / prev', () {
+    final days = ['2026-07-10', '2026-07-12', '2026-07-20', '2026-07-24'];
+
+    test('next steps to the immediately later recorded day (skips gaps)', () {
+      expect(DayNav.next('2026-07-12', days), '2026-07-20'); // skips 13..19
+      expect(DayNav.next('2026-07-10', days), '2026-07-12');
+    });
+
+    test('next is null at the latest day (never into the future)', () {
+      expect(DayNav.next('2026-07-24', days), isNull);
+    });
+
+    test('prev steps to the immediately earlier recorded day (skips gaps)', () {
+      expect(DayNav.prev('2026-07-20', days), '2026-07-12');
+      expect(DayNav.prev('2026-07-24', days), '2026-07-20');
+    });
+
+    test('prev is null at the earliest day', () {
+      expect(DayNav.prev('2026-07-10', days), isNull);
+    });
+
+    test('next/prev from a day between recorded days lands on neighbours', () {
+      // Current 07-15 is not itself in the set (e.g. an empty gap the user
+      // reached via the picker): next → 07-20, prev → 07-12.
+      expect(DayNav.next('2026-07-15', days), '2026-07-20');
+      expect(DayNav.prev('2026-07-15', days), '2026-07-12');
+    });
+
+    test('order of the input does not matter', () {
+      final shuffled = ['2026-07-24', '2026-07-10', '2026-07-20', '2026-07-12'];
+      expect(DayNav.next('2026-07-12', shuffled), '2026-07-20');
+      expect(DayNav.prev('2026-07-20', shuffled), '2026-07-12');
+    });
+  });
+
+  group('DayNav.earliest', () {
+    test('returns the minimum day', () {
+      expect(
+        DayNav.earliest(['2026-07-20', '2026-07-10', '2026-07-24']),
+        '2026-07-10',
+      );
+    });
+
+    test('null on empty', () {
+      expect(DayNav.earliest(const []), isNull);
+    });
+  });
+
+  group('end-to-end stepping walks the whole recorded range without escaping',
+      () {
+    test('walk back to earliest, forward to today, never past either bound', () {
+      final nav = DayNav.navigableDays(
+        ['2026-07-18', '2026-07-21'],
+        '2026-07-24',
+      ); // → [18, 21, 24]
+      // Start at today, step back to the earliest.
+      var cur = '2026-07-24';
+      cur = DayNav.prev(cur, nav)!; // 21
+      expect(cur, '2026-07-21');
+      cur = DayNav.prev(cur, nav)!; // 18
+      expect(cur, '2026-07-18');
+      expect(DayNav.prev(cur, nav), isNull); // stop at earliest
+      // Step forward back to today.
+      cur = DayNav.next(cur, nav)!; // 21
+      expect(cur, '2026-07-21');
+      cur = DayNav.next(cur, nav)!; // 24
+      expect(cur, '2026-07-24');
+      expect(DayNav.next(cur, nav), isNull); // stop at today
+    });
+  });
+}

--- a/test/day_nav_test.dart
+++ b/test/day_nav_test.dart
@@ -123,4 +123,37 @@ void main() {
       expect(DayNav.next(cur, nav), isNull); // stop at today
     });
   });
+
+  group('DayNav.isSelectable (date-picker predicate)', () {
+    // The navigable set the picker is backed by: recorded days + today.
+    final nav = DayNav.navigableDays(
+      ['2026-07-18', '2026-07-21'],
+      '2026-07-24',
+    ); // → ['2026-07-18', '2026-07-21', '2026-07-24']
+
+    test('allows recorded days and today', () {
+      expect(DayNav.isSelectable('2026-07-18', nav), isTrue);
+      expect(DayNav.isSelectable('2026-07-21', nav), isTrue);
+      expect(DayNav.isSelectable('2026-07-24', nav), isTrue); // today
+    });
+
+    test('rejects empty gap days between recorded days', () {
+      expect(DayNav.isSelectable('2026-07-19', nav), isFalse);
+      expect(DayNav.isSelectable('2026-07-20', nav), isFalse);
+      expect(DayNav.isSelectable('2026-07-22', nav), isFalse);
+    });
+
+    test('rejects days outside the recorded range', () {
+      expect(DayNav.isSelectable('2026-07-01', nav), isFalse); // before earliest
+      expect(DayNav.isSelectable('2026-07-25', nav), isFalse); // future
+    });
+
+    test('every selectable day is one navigation can also step onto', () {
+      // The picker and the chevrons share the same set — no day is choosable
+      // that prev/next could not also reach (and vice-versa).
+      for (final d in nav) {
+        expect(DayNav.isSelectable(d, nav), isTrue);
+      }
+    });
+  });
 }

--- a/test/journey_available_days_test.dart
+++ b/test/journey_available_days_test.dart
@@ -1,8 +1,9 @@
 // availableDays() over the REAL LocalDb (in-memory sqlite via
-// sqflite_common_ffi): the recorded-day range that bounds the lookback screen's
-// day navigation (issue #112). Covers the UNION of derived `day_result` rows
-// and raw `decoded_onehz` seconds, newest-first ordering, and the repository
-// wrapper that the screen actually calls.
+// sqflite_common_ffi): the RENDERABLE-day range that bounds the lookback
+// screen's day navigation (issue #112). availableDayIds must return EXACTLY the
+// days `getDayTimeline`/`_bundleForDate` would render non-empty — the latest
+// derived `day_result` per day that is NOT a skip-marker — and must EXCLUDE
+// raw-only `decoded_onehz` days and skip-markers (both render empty).
 
 import 'dart:convert';
 
@@ -29,9 +30,10 @@ void main() {
     await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
   });
 
-  Future<void> seedDayResult(String dayId) => LocalDb.putDayResult(
+  Future<void> seedDerived(String dayId, {int algoVersion = 15}) =>
+      LocalDb.putDayResult(
         dayId: dayId,
-        algoVersion: 15,
+        algoVersion: algoVersion,
         payloadJson: jsonEncode({
           'scalars': {'rhr': 52.0},
         }),
@@ -39,65 +41,32 @@ void main() {
         finalized: false,
       );
 
-  test('availableDayIds unions derived days + raw-only days, newest first',
-      () async {
-    // Three derived days (literal day_id labels, timezone-independent) …
-    await seedDayResult('2099-01-05');
-    await seedDayResult('2099-01-03');
-    await seedDayResult('2099-01-01');
+  // A derivation skip-marker, exactly as `_markDaySkipped` writes it: the
+  // `skipped` column set alongside the `{skipped:true}` payload.
+  Future<void> seedSkip(String dayId, {int algoVersion = 15}) =>
+      LocalDb.putDayResult(
+        dayId: dayId,
+        algoVersion: algoVersion,
+        payloadJson: jsonEncode({'skipped': true, 'reason': 'test'}),
+        windowJson: '{}',
+        finalized: false,
+        skipped: true,
+      );
 
-    // … plus a RAW-ONLY day (decoded_onehz, no day_result). Seed a frame at
-    // local noon so its calendar-day label is unambiguous in every timezone,
-    // and derive the expected label the same way the app buckets raw seconds.
-    final rawDt = DateTime(2099, 1, 4, 12, 0);
-    final rawTs = rawDt.millisecondsSinceEpoch ~/ 1000;
-    final rawDay = dayLabelOf(rawDt); // '2099-01-04'
-    await LocalDb.insertRecord(
+  Future<void> seedRawSecond(DateTime localNoon, int counter) {
+    final ts = localNoon.millisecondsSinceEpoch ~/ 1000;
+    return LocalDb.insertRecord(
       RawRecord(
-        counter: 990004,
+        counter: counter,
         packetType: 47,
         hex: 'deadbeef',
-        capturedAt: rawTs * 1000,
-        recTs: rawTs,
-      ),
-      Sample(
-        tsEpoch: rawTs,
-        counter: 990004,
-        hr: 60,
-        rrIntervalsMs: const [1000],
-        ax: 0,
-        ay: 0,
-        az: 1,
-        spo2RedRaw: 1,
-        spo2IrRaw: 1,
-        skinTempRaw: 1,
-      ),
-    );
-
-    final days = await LocalDb.availableDayIds();
-
-    // Exactly the four seeded days, newest → oldest, with the raw-only day
-    // slotted in by date (not appended) — proof the UNION + ORDER BY hold.
-    expect(days, ['2099-01-05', rawDay, '2099-01-03', '2099-01-01']);
-    expect(rawDay, '2099-01-04');
-  });
-
-  test('a day with BOTH a derived row and raw seconds appears once', () async {
-    // Add raw seconds for an already-derived day → UNION must de-duplicate it.
-    final dt = DateTime(2099, 1, 3, 12, 0);
-    final ts = dt.millisecondsSinceEpoch ~/ 1000;
-    await LocalDb.insertRecord(
-      RawRecord(
-        counter: 990003,
-        packetType: 47,
-        hex: 'cafe',
         capturedAt: ts * 1000,
         recTs: ts,
       ),
       Sample(
         tsEpoch: ts,
-        counter: 990003,
-        hr: 61,
+        counter: counter,
+        hr: 60,
         ax: 0,
         ay: 0,
         az: 1,
@@ -106,26 +75,71 @@ void main() {
         skinTempRaw: 1,
       ),
     );
+  }
 
+  test('returns only genuine derived days; excludes raw-only + skip-markers',
+      () async {
+    await seedDerived('2099-01-05');
+    await seedDerived('2099-01-03');
+    await seedDerived('2099-01-01');
+
+    // A skip-marker day — renders empty, must NOT bound navigation.
+    await seedSkip('2099-01-06');
+
+    // A RAW-ONLY day (decoded_onehz, no derived row) — also renders empty.
+    // Local noon so its calendar-day label is unambiguous in every timezone.
+    await seedRawSecond(DateTime(2099, 1, 4, 12), 990004);
+    final rawDay = dayLabelOf(DateTime(2099, 1, 4, 12));
+    expect(rawDay, '2099-01-04');
+
+    final days = await LocalDb.availableDayIds();
+
+    // Exactly the three genuine derived days, newest → oldest.
+    expect(days, ['2099-01-05', '2099-01-03', '2099-01-01']);
+    expect(days.contains('2099-01-06'), isFalse, reason: 'skip-marker excluded');
+    expect(days.contains(rawDay), isFalse, reason: 'raw-only day excluded');
+  });
+
+  test('a derived day that also has raw seconds appears exactly once', () async {
+    // '2099-01-03' already has a derived row; adding raw seconds must not
+    // duplicate it (and must not resurrect anything via a raw path).
+    await seedRawSecond(DateTime(2099, 1, 3, 12), 990003);
     final days = await LocalDb.availableDayIds();
     expect(days.where((d) => d == '2099-01-03').length, 1);
   });
 
-  test('LocalRepositoryImpl.availableDays surfaces the same range', () async {
-    final repo = LocalRepositoryImpl(getProfileMap: () => const {});
-    final days = await repo.availableDays();
-    expect(days.first, '2099-01-05'); // newest
-    expect(days.last, '2099-01-01'); // oldest
-    expect(days, containsAll(['2099-01-04', '2099-01-03', '2099-01-01']));
+  test('the LATEST algo_version decides skip vs render', () async {
+    // Superseded-by-skip: real v15 then skip v16 → latest is skip → EXCLUDED.
+    await seedDerived('2099-02-10', algoVersion: 15);
+    await seedSkip('2099-02-10', algoVersion: 16);
+
+    // Recovered-from-skip: skip v15 then real v16 → latest is real → INCLUDED.
+    await seedSkip('2099-02-11', algoVersion: 15);
+    await seedDerived('2099-02-11', algoVersion: 16);
+
+    final days = await LocalDb.availableDayIds();
+    expect(days.contains('2099-02-10'), isFalse);
+    expect(days.contains('2099-02-11'), isTrue);
   });
 
-  test('empty DB (no data) yields an empty range', () async {
-    // A fresh, separate DB so nothing seeded above leaks in.
+  test('LocalRepositoryImpl.availableDays surfaces the same renderable range',
+      () async {
+    final repo = LocalRepositoryImpl(getProfileMap: () => const {});
+    final days = await repo.availableDays();
+    expect(days.first, '2099-02-11'); // newest genuine derived day
+    expect(days.contains('2099-01-04'), isFalse); // raw-only
+    expect(days.contains('2099-01-06'), isFalse); // skip-marker
+    expect(days, containsAll(['2099-01-05', '2099-01-03', '2099-01-01']));
+  });
+
+  test('empty DB (no derived days) yields an empty range', () async {
     await LocalDb.close();
     final dir = await databaseFactory.getDatabasesPath();
     LocalDb.dbName = 'openstrap_available_days_empty_test.db';
     await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
 
+    // Raw seconds alone (no derived day_result) must NOT make a day available.
+    await seedRawSecond(DateTime(2099, 3, 1, 12), 991001);
     final days = await LocalDb.availableDayIds();
     expect(days, isEmpty);
 

--- a/test/journey_available_days_test.dart
+++ b/test/journey_available_days_test.dart
@@ -1,0 +1,136 @@
+// availableDays() over the REAL LocalDb (in-memory sqlite via
+// sqflite_common_ffi): the recorded-day range that bounds the lookback screen's
+// day navigation (issue #112). Covers the UNION of derived `day_result` rows
+// and raw `decoded_onehz` seconds, newest-first ordering, and the repository
+// wrapper that the screen actually calls.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:openstrap_edge/data/db.dart';
+import 'package:openstrap_edge/data/day_label.dart';
+import 'package:openstrap_edge/data/local_repository_impl.dart';
+import 'package:openstrap_edge/data/models.dart';
+
+void main() {
+  setUpAll(() async {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+    LocalDb.dbName = 'openstrap_available_days_test.db';
+    final dir = await databaseFactory.getDatabasesPath();
+    await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+  });
+
+  tearDownAll(() async {
+    await LocalDb.close();
+    final dir = await databaseFactory.getDatabasesPath();
+    await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+  });
+
+  Future<void> seedDayResult(String dayId) => LocalDb.putDayResult(
+        dayId: dayId,
+        algoVersion: 15,
+        payloadJson: jsonEncode({
+          'scalars': {'rhr': 52.0},
+        }),
+        windowJson: '{}',
+        finalized: false,
+      );
+
+  test('availableDayIds unions derived days + raw-only days, newest first',
+      () async {
+    // Three derived days (literal day_id labels, timezone-independent) …
+    await seedDayResult('2099-01-05');
+    await seedDayResult('2099-01-03');
+    await seedDayResult('2099-01-01');
+
+    // … plus a RAW-ONLY day (decoded_onehz, no day_result). Seed a frame at
+    // local noon so its calendar-day label is unambiguous in every timezone,
+    // and derive the expected label the same way the app buckets raw seconds.
+    final rawDt = DateTime(2099, 1, 4, 12, 0);
+    final rawTs = rawDt.millisecondsSinceEpoch ~/ 1000;
+    final rawDay = dayLabelOf(rawDt); // '2099-01-04'
+    await LocalDb.insertRecord(
+      RawRecord(
+        counter: 990004,
+        packetType: 47,
+        hex: 'deadbeef',
+        capturedAt: rawTs * 1000,
+        recTs: rawTs,
+      ),
+      Sample(
+        tsEpoch: rawTs,
+        counter: 990004,
+        hr: 60,
+        rrIntervalsMs: const [1000],
+        ax: 0,
+        ay: 0,
+        az: 1,
+        spo2RedRaw: 1,
+        spo2IrRaw: 1,
+        skinTempRaw: 1,
+      ),
+    );
+
+    final days = await LocalDb.availableDayIds();
+
+    // Exactly the four seeded days, newest → oldest, with the raw-only day
+    // slotted in by date (not appended) — proof the UNION + ORDER BY hold.
+    expect(days, ['2099-01-05', rawDay, '2099-01-03', '2099-01-01']);
+    expect(rawDay, '2099-01-04');
+  });
+
+  test('a day with BOTH a derived row and raw seconds appears once', () async {
+    // Add raw seconds for an already-derived day → UNION must de-duplicate it.
+    final dt = DateTime(2099, 1, 3, 12, 0);
+    final ts = dt.millisecondsSinceEpoch ~/ 1000;
+    await LocalDb.insertRecord(
+      RawRecord(
+        counter: 990003,
+        packetType: 47,
+        hex: 'cafe',
+        capturedAt: ts * 1000,
+        recTs: ts,
+      ),
+      Sample(
+        tsEpoch: ts,
+        counter: 990003,
+        hr: 61,
+        ax: 0,
+        ay: 0,
+        az: 1,
+        spo2RedRaw: 1,
+        spo2IrRaw: 1,
+        skinTempRaw: 1,
+      ),
+    );
+
+    final days = await LocalDb.availableDayIds();
+    expect(days.where((d) => d == '2099-01-03').length, 1);
+  });
+
+  test('LocalRepositoryImpl.availableDays surfaces the same range', () async {
+    final repo = LocalRepositoryImpl(getProfileMap: () => const {});
+    final days = await repo.availableDays();
+    expect(days.first, '2099-01-05'); // newest
+    expect(days.last, '2099-01-01'); // oldest
+    expect(days, containsAll(['2099-01-04', '2099-01-03', '2099-01-01']));
+  });
+
+  test('empty DB (no data) yields an empty range', () async {
+    // A fresh, separate DB so nothing seeded above leaks in.
+    await LocalDb.close();
+    final dir = await databaseFactory.getDatabasesPath();
+    LocalDb.dbName = 'openstrap_available_days_empty_test.db';
+    await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+
+    final days = await LocalDb.availableDayIds();
+    expect(days, isEmpty);
+
+    await LocalDb.close();
+    await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+    LocalDb.dbName = 'openstrap_available_days_test.db';
+  });
+}


### PR DESCRIPTION
## What

The lookback / **Your day** screen only ever rendered *today*. This adds day navigation so users can browse **past days'** lookback — nap times, HR / HRV / respiration / skin-temp and movement trends — one day at a time, the way the Sleep section already lets you.

Almost all the plumbing already existed: `JourneyScreen` already rendered any date passed to it, already handled the retention boundary (minute detail only for recent days; older days show derived summaries) and the partial-"today" fallback, and every day-detail repo method is date-parameterised. So this is essentially a **day-navigation UI addition** on top of behaviour the screen already supports.

## Navigation UX

The screen header gains a day-nav bar (in the scaffold's `header` slot, below the title):

- **Prev / next chevrons** flanking the displayed date. **Next is disabled at today** (navigation never enters the future); **prev is disabled at the earliest recorded day**. Empty gaps between recorded days are skipped — stepping lands on the next day that actually has data.
- The **date is tappable** → `showDatePicker`, bounded to `[earliestAvailable, today]`, to jump straight to a day.
- Disabled chevrons grey out (opacity + no tap) and carry semantics labels; the whole bar reuses existing design-system parts (`RoundIconButton`, `Pressable`, `OsAppIcon`, `Tag`) rather than inventing a new style.

`JourneyScreen` now holds a mutable current-date (initialised from the entry date, which stays the entry point). Every navigation re-runs the existing `_load()` for the new date, so refresh, empty-state and error handling are unchanged.

## Retention boundary respected

No data or retention behaviour changed — navigation only moves across dates the screen already handles. Retention gating and the partial-today fallback still key off the **viewed** date, so **older days show derived summaries, not minute curves**, and truly-empty days show the empty state.

## Data

Adds `LocalRepository.availableDays()` → `LocalDb.availableDayIds()`: the `UNION` of `day_result` day_ids and `decoded_onehz` day labels (bucketed to the local calendar day), newest first. It bounds the prev/earliest control and the date picker. A day with a `day_result` but pruned minute-detail still appears (its summary shows); only a day with neither derived row nor raw substrate is absent.

## Files

- `lib/ui/journey/journey_screen.dart` — mutable current-date state, day-nav header, date picker, `_go`/`_loadDays`.
- `lib/ui/journey/day_nav.dart` — **new** pure `DayNav` helper (navigable-set / next / prev / earliest maths).
- `lib/data/local_repository.dart` — `availableDays()` on the contract.
- `lib/data/local_repository_impl.dart` — implements it.
- `lib/data/db.dart` — `availableDayIds()` query.
- `test/day_nav_test.dart` — pure stepping/bounds tests (never past today, stop at earliest, skip gaps).
- `test/journey_available_days_test.dart` — `availableDays()` over the real `sqflite_ffi` `LocalDb` (union, ordering, de-dup, empty).

## Testing

Unit tests cover the new repo method and the pure stepping/bounds logic. The widget wiring (header nav bar, picker, per-date reload) is **inspection-verified only** — full widget tests would need repo + plugin mocking and are brittle for this screen.

> [!NOTE]
> **Runtime is unverified** — no Flutter/Dart SDK or device was available in this environment, so this was verified by inspection and unit tests, not run on a device.

Closes #112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added day navigation for journey timelines using previous and next controls.
  - Added a date picker constrained to days with locally recorded data and today.
  - Added a “Today” indicator when viewing the current day.
  - Journey data now reloads when selecting a different date.
  - Available days include dates with either processed or locally recorded data, shown newest first.

- **Bug Fixes**
  - Prevented navigation beyond the earliest recorded day or into future dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->