### PR TITLE
feat(today): gate lookback card on collected-data span

### DIFF
--- a/lib/ui/today/today_screen.dart
+++ b/lib/ui/today/today_screen.dart
@@ -46,6 +46,12 @@ class _TodayScreenState extends State<TodayScreen>
   ChartSeries _hr = const ChartSeries([]);
   bool _storyDismissed = false;
 
+  /// Span of collected data (earliest decoded record → now), in hours, or null
+  /// when nothing has been decoded yet. Gates the Lookback card so it only
+  /// appears once there's a meaningful day to look back on rather than on first
+  /// run with minutes of data (see [kLookbackMinDataHours] / [shouldShowLookback]).
+  double? _dataSpanHours;
+
   // Cache for the onboarding collection-progress FutureBuilder below — without
   // this, `LocalDb.firstAndLastRecordTs()` called inline in `future:` builds a
   // brand-new Future on every rebuild of this branch (any of the unrelated
@@ -131,6 +137,19 @@ class _TodayScreenState extends State<TodayScreen>
           b['has'] == true ? ((b['value'] as num?)?.toDouble()) : null,
       ];
       if (mounted) setState(() => _stepsWeek = week);
+    } catch (_) {}
+    try {
+      // Data-span signal for the Lookback gate: how long we've been collecting,
+      // from the earliest decoded record to now. Best-effort — a failure just
+      // leaves the card hidden until the next successful load.
+      final (first, _) = await LocalDb.firstAndLastRecordTs();
+      final span = first == null
+          ? null
+          : DateTime.now()
+                  .difference(DateTime.fromMillisecondsSinceEpoch(first * 1000))
+                  .inMinutes /
+              60.0;
+      if (mounted) setState(() => _dataSpanHours = span);
     } catch (_) {}
     return today;
   }
@@ -338,10 +357,15 @@ class _TodayScreenState extends State<TodayScreen>
         ),
         const SizedBox(height: Sp.x3),
       ],
-      KeyedSubtree(
-        key: const ValueKey('today-lookback'),
-        child: _lookbackCard().dsEnter(index: 6),
-      ),
+      // Lookback only appears once there's a meaningful span of collected data
+      // (~a full day). On first run — minutes of data — the "Your day" view is
+      // empty and misleading (#140), so hide the card entirely rather than
+      // render a bare "No data yet today" placeholder.
+      if (shouldShowLookback(_dataSpanHours))
+        KeyedSubtree(
+          key: const ValueKey('today-lookback'),
+          child: _lookbackCard().dsEnter(index: 6),
+        ),
     ];
   }
 
@@ -1063,6 +1087,19 @@ class TodayVitals extends StatelessWidget {
     ).dsEnter(index: 7);
   }
 }
+
+/// Minimum span of collected data — earliest decoded record → now, in hours —
+/// before the Today "Lookback / Your day" card is worth surfacing. Below this
+/// the day view is near-empty and misleading on first run (#140, from #102), so
+/// the card stays hidden entirely rather than render a bare "No data yet".
+/// Tunable: localhoop's lower bound for a meaningful day is ~18h.
+const double kLookbackMinDataHours = 18;
+
+/// Whether Today's Lookback card should appear, given [dataSpanHours] — the span
+/// from the earliest collected record to now. Null (no data yet) → hidden.
+@visibleForTesting
+bool shouldShowLookback(double? dataSpanHours) =>
+    dataSpanHours != null && dataSpanHours >= kLookbackMinDataHours;
 
 /// Pure mapper for the Today week-of-rings: Mon→Sun raw step counts → exactly
 /// seven goal-relative fills (0..1, null = no data / future day) plus today's

--- a/lib/ui/today/today_screen.dart
+++ b/lib/ui/today/today_screen.dart
@@ -46,11 +46,12 @@ class _TodayScreenState extends State<TodayScreen>
   ChartSeries _hr = const ChartSeries([]);
   bool _storyDismissed = false;
 
-  /// Span of collected data (earliest decoded record → now), in hours, or null
-  /// when nothing has been decoded yet. Gates the Lookback card so it only
-  /// appears once there's a meaningful day to look back on rather than on first
-  /// run with minutes of data (see [kLookbackMinDataHours] / [shouldShowLookback]).
-  double? _dataSpanHours;
+  /// Earliest decoded record timestamp (unix seconds), or null when nothing has
+  /// been decoded yet. The Lookback card is gated on the span from here to *now*
+  /// — computed live in the build path (see [shouldShowLookback] /
+  /// [kLookbackMinDataHours]), not stored precomputed — so the card appears as
+  /// soon as enough time has elapsed, not only on the next loader refresh.
+  int? _earliestRecordSec;
 
   // Cache for the onboarding collection-progress FutureBuilder below — without
   // this, `LocalDb.firstAndLastRecordTs()` called inline in `future:` builds a
@@ -139,17 +140,13 @@ class _TodayScreenState extends State<TodayScreen>
       if (mounted) setState(() => _stepsWeek = week);
     } catch (_) {}
     try {
-      // Data-span signal for the Lookback gate: how long we've been collecting,
-      // from the earliest decoded record to now. Best-effort — a failure just
-      // leaves the card hidden until the next successful load.
+      // Data-span signal for the Lookback gate: the earliest decoded record.
+      // We store the anchor, not a precomputed span, so the gate re-derives
+      // `now - earliest` on every build and the card can appear purely by wall
+      // clock crossing the threshold. Best-effort — a failure just leaves the
+      // card hidden until the next successful load.
       final (first, _) = await LocalDb.firstAndLastRecordTs();
-      final span = first == null
-          ? null
-          : DateTime.now()
-                  .difference(DateTime.fromMillisecondsSinceEpoch(first * 1000))
-                  .inMinutes /
-              60.0;
-      if (mounted) setState(() => _dataSpanHours = span);
+      if (mounted) setState(() => _earliestRecordSec = first);
     } catch (_) {}
     return today;
   }
@@ -361,7 +358,7 @@ class _TodayScreenState extends State<TodayScreen>
       // (~a full day). On first run — minutes of data — the "Your day" view is
       // empty and misleading (#140), so hide the card entirely rather than
       // render a bare "No data yet today" placeholder.
-      if (shouldShowLookback(_dataSpanHours))
+      if (shouldShowLookback(_earliestRecordSec, now: DateTime.now()))
         KeyedSubtree(
           key: const ValueKey('today-lookback'),
           child: _lookbackCard().dsEnter(index: 6),
@@ -1095,11 +1092,23 @@ class TodayVitals extends StatelessWidget {
 /// Tunable: localhoop's lower bound for a meaningful day is ~18h.
 const double kLookbackMinDataHours = 18;
 
-/// Whether Today's Lookback card should appear, given [dataSpanHours] — the span
-/// from the earliest collected record to now. Null (no data yet) → hidden.
+/// Whether Today's Lookback card should appear, given the earliest collected
+/// record [earliestRecordSec] (unix seconds; null = no data yet → hidden) and
+/// the current time [now]. Deriving the span from a live `now` rather than a
+/// value cached at load time means the card appears as soon as the collected
+/// span crosses [kLookbackMinDataHours] on the next rebuild — even if no fresh
+/// data arrived to trigger a loader pass.
 @visibleForTesting
-bool shouldShowLookback(double? dataSpanHours) =>
-    dataSpanHours != null && dataSpanHours >= kLookbackMinDataHours;
+bool shouldShowLookback(int? earliestRecordSec, {required DateTime now}) {
+  if (earliestRecordSec == null) return false;
+  final spanHours = now
+          .difference(
+            DateTime.fromMillisecondsSinceEpoch(earliestRecordSec * 1000),
+          )
+          .inMinutes /
+      60.0;
+  return spanHours >= kLookbackMinDataHours;
+}
 
 /// Pure mapper for the Today week-of-rings: Mon→Sun raw step counts → exactly
 /// seven goal-relative fills (0..1, null = no data / future day) plus today's

--- a/test/lookback_gate_test.dart
+++ b/test/lookback_gate_test.dart
@@ -1,0 +1,37 @@
+// Gate-logic tests for Today's Lookback card (#140): it should only appear once
+// there's a meaningful span of collected data (~a full day), never on first run
+// with minutes of data where the "Your day" view is empty and misleading.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:openstrap_edge/ui/today/today_screen.dart'
+    show kLookbackMinDataHours, shouldShowLookback;
+
+void main() {
+  group('shouldShowLookback (Today lookback data-span gate)', () {
+    test('hidden when no data has been collected yet', () {
+      expect(shouldShowLookback(null), isFalse);
+    });
+
+    test('hidden with only minutes of data (first run)', () {
+      expect(shouldShowLookback(0), isFalse);
+      expect(shouldShowLookback(0.25), isFalse); // 15 minutes
+      expect(shouldShowLookback(6), isFalse);
+    });
+
+    test('hidden just below the threshold', () {
+      expect(shouldShowLookback(kLookbackMinDataHours - 0.1), isFalse);
+    });
+
+    test('shown at and above the threshold', () {
+      expect(shouldShowLookback(kLookbackMinDataHours), isTrue);
+      expect(shouldShowLookback(24), isTrue);
+      expect(shouldShowLookback(72), isTrue);
+    });
+
+    test('threshold sits in the documented ~18–24h band', () {
+      expect(kLookbackMinDataHours, greaterThanOrEqualTo(18));
+      expect(kLookbackMinDataHours, lessThanOrEqualTo(24));
+    });
+  });
+}

--- a/test/lookback_gate_test.dart
+++ b/test/lookback_gate_test.dart
@@ -1,6 +1,8 @@
 // Gate-logic tests for Today's Lookback card (#140): it should only appear once
 // there's a meaningful span of collected data (~a full day), never on first run
-// with minutes of data where the "Your day" view is empty and misleading.
+// with minutes of data where the "Your day" view is empty and misleading. The
+// span is derived from the earliest record against a live `now`, so the card can
+// cross the threshold purely by elapsed wall-clock time (no fresh data needed).
 
 import 'package:flutter_test/flutter_test.dart';
 
@@ -9,24 +11,56 @@ import 'package:openstrap_edge/ui/today/today_screen.dart'
 
 void main() {
   group('shouldShowLookback (Today lookback data-span gate)', () {
+    final now = DateTime(2026, 7, 24, 12, 0, 0);
+    int secAgo(Duration d) => now.subtract(d).millisecondsSinceEpoch ~/ 1000;
+
     test('hidden when no data has been collected yet', () {
-      expect(shouldShowLookback(null), isFalse);
+      expect(shouldShowLookback(null, now: now), isFalse);
     });
 
     test('hidden with only minutes of data (first run)', () {
-      expect(shouldShowLookback(0), isFalse);
-      expect(shouldShowLookback(0.25), isFalse); // 15 minutes
-      expect(shouldShowLookback(6), isFalse);
+      expect(shouldShowLookback(secAgo(const Duration(minutes: 15)), now: now),
+          isFalse);
+      expect(shouldShowLookback(secAgo(const Duration(hours: 6)), now: now),
+          isFalse);
     });
 
     test('hidden just below the threshold', () {
-      expect(shouldShowLookback(kLookbackMinDataHours - 0.1), isFalse);
+      expect(
+        shouldShowLookback(
+          secAgo(Duration(minutes: (kLookbackMinDataHours * 60).round() - 30)),
+          now: now,
+        ),
+        isFalse,
+      );
     });
 
     test('shown at and above the threshold', () {
-      expect(shouldShowLookback(kLookbackMinDataHours), isTrue);
-      expect(shouldShowLookback(24), isTrue);
-      expect(shouldShowLookback(72), isTrue);
+      expect(
+        shouldShowLookback(
+          secAgo(Duration(minutes: (kLookbackMinDataHours * 60).round())),
+          now: now,
+        ),
+        isTrue,
+      );
+      expect(shouldShowLookback(secAgo(const Duration(hours: 24)), now: now),
+          isTrue);
+    });
+
+    test('crosses purely by elapsed wall-clock time (same anchor, later now)',
+        () {
+      // A fixed earliest record — 18h01m before the later `now`, but only 17h59m
+      // before the earlier one. No new data; the gate flips solely on the clock.
+      final earliest =
+          DateTime(2026, 7, 24, 0, 0, 0).millisecondsSinceEpoch ~/ 1000;
+      expect(
+        shouldShowLookback(earliest, now: DateTime(2026, 7, 24, 17, 59, 0)),
+        isFalse,
+      );
+      expect(
+        shouldShowLookback(earliest, now: DateTime(2026, 7, 24, 18, 1, 0)),
+        isTrue,
+      );
     });
 
     test('threshold sits in the documented ~18–24h band', () {


### PR DESCRIPTION
## What

The Lookback / "Your day" card on the Today screen appeared immediately, even with only minutes of collected data, so on first run it was empty and misleading.

This gates the card's appearance on having a meaningful span of collected data (~a full day). Below the threshold the card is hidden cleanly — no empty "No data yet today" placeholder.

## How

- **Data-span signal**: the span from the earliest decoded record (`MIN(rec_ts)` via the existing `LocalDb.firstAndLastRecordTs()`) to now, loaded best-effort in `fetch()` and held in `_dataSpanHours`.
- **Threshold**: a documented, tunable `const kLookbackMinDataHours = 18` (localhoop's lower bound for a meaningful day; the ~18–24h band).
- **Gate**: a pure, testable helper `shouldShowLookback(double? dataSpanHours)` wraps the card's `collection-if` in `_content()`. Null span (no data yet) → hidden.

Scope is deliberately just the card's appearance on the Today screen — this does not touch `journey_screen.dart` (day-navigation inside the JourneyScreen is a separate concern).

## Tests

Added `test/lookback_gate_test.dart` covering the gate helper: null/minutes-of-data → hidden, just-below threshold → hidden, at/above threshold → shown, and that the threshold sits in the documented ~18–24h band.

No Flutter/Dart SDK was available in this environment, so the change is inspection-verified; the pure-helper tests are provided for CI to run.

Closes #140
Reported in #102.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The “Lookback / Your day” card now appears only after enough activity data has been collected.
  * The card remains hidden when no data, limited first-run data, or insufficient history is available.

* **Bug Fixes**
  * Prevented the Lookback card from appearing prematurely with incomplete daily data.

* **Tests**
  * Added coverage for empty, insufficient, threshold, and sufficient data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->