### PR TITLE
fix(notify): make the fire-once dedupe guard cross-isolate safe

### DIFF
--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -142,6 +142,7 @@ class LocalDb {
         await _createWorkoutSuggestions(db);
         await _createSleepOverride(db);
         await _createWorkoutRoute(db);
+        await _createNotifFired(db);
         await _ensureCoachViews(db);
       },
       onUpgrade: (db, oldV, newV) async {
@@ -345,11 +346,21 @@ class LocalDb {
           // right.
           await _ensureDayResultPartialColumn(db);
         }
+        if (oldV < 26) {
+          // Cross-isolate fire-once for notifications. The dedupe guard used to
+          // live entirely in SharedPreferences, where a check and a record are
+          // two separate operations — so the foreground and WorkManager derive
+          // isolates could both read "not fired" and both alert (issue #136's
+          // tail). This table makes the claim a single atomic INSERT OR IGNORE.
+          // Purely additive; the legacy prefs keys are migrated lazily on first
+          // use by FiredKeyStore, so nothing is lost on upgrade.
+          await _createNotifFired(db);
+        }
       },
       onOpen: (db) async {
         await _repairOpenSchema(db);
       },
-      version: 25,
+      version: 26,
     );
   }
 
@@ -398,6 +409,7 @@ class LocalDb {
     await _ensureWorkoutRouteSpeed(db);
     await _ensureDayResultSkippedColumn(db);
     await _ensureDayResultPartialColumn(db);
+    await _createNotifFired(db);
     // Views LAST — they depend on metric_series / day_result / baselines / sessions
     // / notifications all existing. DROP+CREATE so a shape change takes effect.
     await _ensureCoachViews(db);
@@ -497,6 +509,114 @@ class LocalDb {
   //   source: 'manual'    — user typed the times
   //           'confirmed' — user accepted the fallback's proposed window
   // Times are epoch SECONDS (phone clock; raw rec_ts is SET_CLOCK'd to match).
+  /// The cross-isolate fire-once claim ledger for notification dedupeKeys.
+  ///
+  /// SharedPreferences CANNOT enforce fire-once across isolates, however fresh
+  /// its reads: a check and a record are two independent operations, so the
+  /// foreground derive isolate and the WorkManager background derive isolate
+  /// can both read "not fired" before either writes, and both alert. SQLite
+  /// can: `INSERT OR IGNORE` against a PRIMARY KEY is ONE atomic statement, and
+  /// writers are serialised (a single native handle per process, and SQLite's
+  /// own write lock across handles), so for a given key exactly one caller ever
+  /// observes `changes() == 1`. That caller owns the fire; everyone else backs
+  /// off. See [claimNotifFired] and lib/notify/fired_keys.dart.
+  static Future<void> _createNotifFired(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS notif_fired (
+        key TEXT PRIMARY KEY,
+        fired_at INTEGER NOT NULL
+      )
+    ''');
+  }
+
+  /// Atomically claim [key] for a one-time OS notification fire.
+  ///
+  /// Returns true iff THIS caller won the claim (the row did not exist and we
+  /// inserted it). A concurrent claimant — in this isolate or the other
+  /// derivation isolate — gets false and MUST NOT present.
+  ///
+  /// Throws if the claim can't be decided, deliberately: the caller falls back
+  /// to the best-effort store rather than treating an unusable DB as "already
+  /// fired", which would silently swallow every notification on the device.
+  static Future<bool> claimNotifFired(String key, {int? firedAtMs}) async {
+    final now = firedAtMs ?? DateTime.now().millisecondsSinceEpoch;
+    final won = await _guardedWrite<bool>((db) async {
+      return db.transaction<bool>((txn) async {
+        await txn.rawInsert(
+          'INSERT OR IGNORE INTO notif_fired(key, fired_at) VALUES(?, ?)',
+          [key, now],
+        );
+        // changes() reports rows touched by the statement just executed on this
+        // connection; inside the transaction that is unambiguously our INSERT.
+        final n = Sqflite.firstIntValue(await txn.rawQuery('SELECT changes()'));
+        return n == 1;
+      });
+    });
+    if (won == null) throw StateError('notif_fired: claim undecided');
+    return won;
+  }
+
+  /// Give back a claim taken by [claimNotifFired] — used when the present did
+  /// NOT actually happen (permission denied, OS error), so a later attempt can
+  /// still fire. Best-effort: never throws into the notification path.
+  static Future<void> releaseNotifFired(String key) async {
+    await _guardedWrite<int>(
+      (db) => db.delete('notif_fired', where: 'key = ?', whereArgs: [key]),
+      bestEffort: true,
+    );
+  }
+
+  /// Whether [key] has already been claimed (read-only; does not claim).
+  static Future<bool> notifFiredExists(String key) async {
+    final db = await instance;
+    final rows = await db.query(
+      'notif_fired',
+      columns: ['key'],
+      where: 'key = ?',
+      whereArgs: [key],
+      limit: 1,
+    );
+    return rows.isNotEmpty;
+  }
+
+  /// Seed claims for [keys] without taking ownership — used once to carry the
+  /// legacy SharedPreferences fired-key list over, so keys that already fired
+  /// under the old store don't re-fire on the upgrade.
+  static Future<void> seedNotifFired(
+    Iterable<String> keys, {
+    int? firedAtMs,
+  }) async {
+    if (keys.isEmpty) return;
+    final now = firedAtMs ?? DateTime.now().millisecondsSinceEpoch;
+    await _guardedWrite<void>((db) async {
+      final batch = db.batch();
+      for (final k in keys) {
+        batch.rawInsert(
+          'INSERT OR IGNORE INTO notif_fired(key, fired_at) VALUES(?, ?)',
+          [k, now],
+        );
+      }
+      await batch.commit(noResult: true);
+    }, bestEffort: true);
+  }
+
+  /// Drop dated claims whose leading "YYYY-MM-DD" is before [cutoffDate].
+  ///
+  /// Undated keys (e.g. `alarm_fired:<epoch>`) are left alone: they have no day
+  /// to expire against, and they're rare enough to be self-limiting. Matches
+  /// the retention semantics of the SharedPreferences fallback exactly.
+  static Future<void> pruneNotifFired(String cutoffDate) async {
+    await _guardedWrite<int>(
+      (db) => db.rawDelete(
+        "DELETE FROM notif_fired "
+        "WHERE substr(key, 1, 10) GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]' "
+        "AND substr(key, 1, 10) < ?",
+        [cutoffDate],
+      ),
+      bestEffort: true,
+    );
+  }
+
   static Future<void> _createSleepOverride(Database db) async {
     await db.execute('''
       CREATE TABLE IF NOT EXISTS sleep_override (
@@ -3038,6 +3158,7 @@ class LocalDb {
       'wake_day_features',
       'live_coverage',
       'workout_route',
+      'notif_fired',
     ];
 
     final missingTables = <String>[];

--- a/lib/notify/fired_keys.dart
+++ b/lib/notify/fired_keys.dart
@@ -115,13 +115,19 @@ class FiredKeyStore {
     // We own the fire. Everything below is bookkeeping and must never revoke it.
     try {
       if (p != null) {
-        // The DB row is fresh, but a fallback claim taken while the DB was down
-        // lives only in the prefs mirror. Honour it: hand the claim back so a
-        // key that already fired in degraded mode can't fire a second time.
-        if (p.getBool('$_prefix$dedupeKey') ?? false) {
-          await release(dedupeKey);
-          return false;
-        }
+        // RECONCILE, don't undo. The DB row is fresh, but a fallback claim taken
+        // while the DB was down lives only in the prefs mirror — so a mirror
+        // that already reads true means this key HAS fired and the row we just
+        // inserted is simply the truth arriving late. Keep it and back off.
+        //
+        // Emphatically NOT release(): that clears the mirror too, and the mirror
+        // is the only evidence of the degraded-mode fire. Erasing it leaves both
+        // stores reading "not fired", so the NEXT pass would win cleanly and
+        // re-alert — reopening this PR's bug in the one path (DB recovered after
+        // an outage) these comments call out as expected. Undoing the insert
+        // instead of keeping it has the same flaw one pass later, and leaves the
+        // claim table permanently ignorant of a fire it should own.
+        if (p.getBool('$_prefix$dedupeKey') ?? false) return false;
         await p.setBool('$_prefix$dedupeKey', true);
       }
       await LocalDb.pruneNotifFired(_cutoffLabel());

--- a/lib/notify/fired_keys.dart
+++ b/lib/notify/fired_keys.dart
@@ -8,93 +8,214 @@
 // flag) would fire over and over (issue #136). This store makes emit() honour the
 // promise: a key that has already fired is skipped until a *new* key comes along.
 //
-// CROSS-ISOLATE. Derivation runs in TWO isolates: the long-lived
-// foreground pass (kept alive for BLE) and the WorkManager background pass
+// CROSS-ISOLATE. Derivation runs in TWO isolates: the long-lived foreground pass
+// (kept alive for BLE) and the WorkManager background pass
 // (background_derivation.dart) — both call emit()/this store, ~every drain and
 // ~every 15 min. The NotificationCenter lock only orders emits WITHIN one
-// isolate; it can't coordinate across them. The original store defeated its own
-// guard two ways here, so a same-day key re-fired all day:
+// isolate; it can't coordinate across them. Three distinct things went wrong
+// there, and a same-day key re-fired all day:
+//
 //   1. Stale read cache. The legacy SharedPreferences instance loads a snapshot
 //      once and never re-reads disk. The long-lived foreground isolate loaded
 //      prefs before today's key existed, so after the background isolate recorded
 //      it, hasFired() still read the stale snapshot as "not fired" → re-alert.
-//      FIX: reload() before every read so a write from the other isolate is seen.
 //   2. Lost-update clobber. Keys lived in ONE shared list mutated via
 //      read-modify-write (getStringList → add → setStringList). With no
 //      cross-process lock, whichever isolate wrote last rewrote the WHOLE list
 //      from its own (stale) copy, dropping the other's keys — including a
-//      just-recorded one, which then re-fired. FIX: one independent bool flag per
-//      key. Native SharedPreferences merges single-key writes, so two isolates
-//      recording different keys can't clobber each other, and recording the same
-//      key twice is idempotent.
+//      just-recorded one, which then re-fired.
+//   3. Check-then-record is not atomic. Even with a fresh read and independent
+//      per-key flags, "has it fired?" and "record that it fired" are two separate
+//      operations. Both isolates can read false before either writes, and both
+//      present. Fresher reads shrink that window; they cannot close it.
 //
-// Reset is automatic: keys are date-prefixed, so tomorrow's "2026-07-24:low_read"
-// is a fresh key that fires once. Growth is bounded by _prune(): date-prefixed
-// flags older than [retentionDays] are dropped (the dedupe only needs today, so a
-// fortnight is ample). Keys without a leading date (e.g. "alarm_fired:<epoch>")
-// are rare and self-limiting, so they're left alone.
+// (1) and (2) are properties of the storage medium; (3) is a property of the
+// PROTOCOL, so the fix is a protocol change: [claim] replaces check-then-record
+// with a single atomic operation, backed by SQLite. `INSERT OR IGNORE` against a
+// PRIMARY KEY is one statement and writers are serialised, so for a given key
+// exactly one caller in the whole process ever wins. That caller — and only it —
+// presents. See LocalDb.claimNotifFired.
+//
+// DEGRADED MODE. If the DB is unusable (not yet open, torn down mid-background
+// pass, or absent in a plain unit test), claim falls back to the
+// SharedPreferences per-key flags: reload-before-read plus one independent bool
+// per key, which still fixes (1) and (2) and leaves only the narrow (3) window.
+// The fallback is deliberately NOT "assume already fired" — a broken DB must
+// never silently swallow every notification on the device. Every successful
+// claim also writes the prefs mirror, so the two stores can't disagree about a
+// key that fired while the DB was down.
+//
+// Reset is automatic: keys are date-prefixed, so tomorrow's "2026-07-27:low_read"
+// is a fresh key that fires once. Growth is bounded by the prune pass: dated
+// claims older than [retentionDays] are dropped (the dedupe only needs today, so
+// a fortnight is ample). Keys without a leading date (e.g. "alarm_fired:<epoch>")
+// have no day to expire against and are rare, so they're left alone.
 
 import 'package:shared_preferences/shared_preferences.dart';
+
+import '../data/day_label.dart';
+import '../data/db.dart';
 
 class FiredKeyStore {
   const FiredKeyStore();
 
-  /// Per-key flag namespace. Each fired dedupeKey is its own bool at
-  /// "$_prefix$dedupeKey" — never a shared list (see the clobber note above).
+  /// Per-key flag namespace for the degraded-mode mirror. Each fired dedupeKey
+  /// is its own bool at "$_prefix$dedupeKey" — never a shared list (see the
+  /// clobber note above).
   static const String _prefix = 'notif_fired:';
 
-  /// How long a date-prefixed fired flag is retained before [_prune] drops it.
+  /// The pre-#145 shared list. Read once to carry already-fired keys over, then
+  /// deleted. Without this, every key that had already fired on the day of the
+  /// upgrade would fire a second time under the new scheme.
+  static const String legacyListKey = 'notif_fired_keys';
+
+  /// How long a dated fired flag is retained before the prune pass drops it.
   /// The guard only needs the current day; a fortnight is a generous margin.
   static const int retentionDays = 14;
 
-  /// Whether [dedupeKey] has already fired an OS notification.
+  /// Atomically claim [dedupeKey] for a one-time fire.
   ///
-  /// Reloads from the platform first: this isolate's in-memory snapshot can be
-  /// stale relative to a record from the OTHER derivation isolate, and reading
-  /// stale is exactly what let an already-fired key re-alert across isolates.
+  /// Returns true iff THIS caller owns the fire and should present. Any other
+  /// claimant — a concurrent emit in this isolate, or the other derivation
+  /// isolate — gets false. A caller that wins the claim but then fails to
+  /// present MUST [release] it, or that key never fires again.
+  Future<bool> claim(String dedupeKey) async {
+    final p = await _prefs();
+    if (p != null) {
+      await _reload(p);
+      await _migrateLegacyList(p);
+    }
+    // Scoped tightly to the claim DECISION. Nothing after it may re-enter the
+    // degraded branch: once the atomic claim is won, a throw in the bookkeeping
+    // below must not be mistaken for "no DB", which would leave the key claimed
+    // in the table while we report a fallback claim — firing it twice.
+    bool? won;
+    try {
+      won = await LocalDb.claimNotifFired(dedupeKey);
+    } catch (_) {
+      won = null; // DEGRADED — no atomic claim available.
+    }
+
+    if (won == null) {
+      // Fall back to the per-key flags: still fresh cross-isolate reads and
+      // clobber-free writes, just without atomicity. Deliberately NOT "assume
+      // fired" — an unusable DB must never mute every notification on the
+      // device.
+      if (p == null) return true; // no store at all — never suppress the alert
+      try {
+        if (p.getBool('$_prefix$dedupeKey') ?? false) return false;
+        await p.setBool('$_prefix$dedupeKey', true);
+        await _prunePrefs(p);
+      } catch (_) {/* best-effort — better a repeat alert than a silent one */}
+      return true;
+    }
+
+    if (!won) return false;
+
+    // We own the fire. Everything below is bookkeeping and must never revoke it.
+    try {
+      if (p != null) {
+        // The DB row is fresh, but a fallback claim taken while the DB was down
+        // lives only in the prefs mirror. Honour it: hand the claim back so a
+        // key that already fired in degraded mode can't fire a second time.
+        if (p.getBool('$_prefix$dedupeKey') ?? false) {
+          await release(dedupeKey);
+          return false;
+        }
+        await p.setBool('$_prefix$dedupeKey', true);
+      }
+      await LocalDb.pruneNotifFired(_cutoffLabel());
+    } catch (_) {/* bookkeeping is best-effort — the claim stands */}
+    return true;
+  }
+
+  /// Give back a claim taken by [claim] when the present did NOT happen
+  /// (permission denied, OS error, a throw). Best-effort; never throws.
+  Future<void> release(String dedupeKey) async {
+    try {
+      await LocalDb.releaseNotifFired(dedupeKey);
+    } catch (_) {/* degraded mode has no DB row to give back */}
+    try {
+      final p = await _prefs();
+      await p?.remove('$_prefix$dedupeKey');
+    } catch (_) {/* mirror is best-effort */}
+  }
+
+  /// Whether [dedupeKey] has already fired an OS notification. Read-only — it
+  /// does NOT claim, so it must never be used to gate a present (that's [claim];
+  /// a check followed by a separate record is exactly the race this store
+  /// exists to kill). For diagnostics, tests, and non-presenting callers.
   Future<bool> hasFired(String dedupeKey) async {
-    final p = await SharedPreferences.getInstance();
+    try {
+      if (await LocalDb.notifFiredExists(dedupeKey)) return true;
+    } catch (_) {/* fall through to the mirror */}
+    final p = await _prefs();
+    if (p == null) return false;
+    // Reload: this isolate's snapshot can be stale relative to a write from the
+    // OTHER derivation isolate, and reading stale is what let an already-fired
+    // key re-alert across isolates.
     await _reload(p);
     return p.getBool('$_prefix$dedupeKey') ?? false;
   }
 
-  /// Record [dedupeKey] as fired — one independent flag, so a concurrent record
-  /// of a different key from the other isolate can't clobber it. Recording the
-  /// same key again is a harmless idempotent no-op. Prunes stale flags after.
-  Future<void> recordFired(String dedupeKey) async {
-    final p = await SharedPreferences.getInstance();
-    // Reload first so both the write and the prune below act on the latest
-    // cross-isolate state (and so _prune enumerates the other isolate's keys).
-    await _reload(p);
-    await p.setBool('$_prefix$dedupeKey', true);
-    await _prune(p);
+  /// Record [dedupeKey] as fired without caring who won. Idempotent. Prefer
+  /// [claim] anywhere the result gates a present.
+  Future<void> recordFired(String dedupeKey) async => claim(dedupeKey);
+
+  /// The oldest day label a dated claim may carry and still be retained.
+  static String _cutoffLabel() =>
+      dayLabelOf(DateTime.now().subtract(const Duration(days: retentionDays)));
+
+  static Future<SharedPreferences?> _prefs() async {
+    try {
+      return await SharedPreferences.getInstance();
+    } catch (_) {
+      return null; // no platform prefs (headless test) — DB path still works
+    }
   }
 
-  Future<void> _reload(SharedPreferences p) async {
+  static Future<void> _reload(SharedPreferences p) async {
     try {
       await p.reload();
     } catch (_) {/* reload is best-effort freshness, never fatal */}
   }
 
-  /// Drop date-prefixed flags older than [retentionDays]. Best-effort and cheap:
-  /// it only runs after a real fire (rare), and a slightly stale key view just
-  /// prunes a little late. Keys without a leading YYYY-MM-DD are left untouched.
-  Future<void> _prune(SharedPreferences p) async {
+  /// Carry the pre-#145 shared list over to the per-key flags and the claim
+  /// table exactly once, then delete it. Idempotent: the list's absence IS the
+  /// "already migrated" marker, so this costs one cached getStringList per call.
+  static Future<void> _migrateLegacyList(SharedPreferences p) async {
     try {
-      final cutoff = DateTime.now().subtract(const Duration(days: retentionDays));
+      final legacy = p.getStringList(legacyListKey);
+      if (legacy == null) return;
+      for (final k in legacy) {
+        await p.setBool('$_prefix$k', true);
+      }
+      try {
+        await LocalDb.seedNotifFired(legacy);
+      } catch (_) {/* degraded — the prefs mirror above still carries them */}
+      await p.remove(legacyListKey);
+    } catch (_) {/* migration is best-effort; worst case is one repeat alert */}
+  }
+
+  /// Drop dated mirror flags older than [retentionDays]. Best-effort and cheap:
+  /// it only runs after a real fire (rare), and a slightly stale view just
+  /// prunes a little late. Keys without a leading YYYY-MM-DD are left untouched.
+  static Future<void> _prunePrefs(SharedPreferences p) async {
+    try {
+      final cutoff = _cutoffLabel();
       for (final k in p.getKeys()) {
         if (!k.startsWith(_prefix)) continue;
-        final d = _leadingDate(k.substring(_prefix.length));
-        if (d != null && d.isBefore(cutoff)) await p.remove(k);
+        final d = leadingDate(k.substring(_prefix.length));
+        if (d != null && d.compareTo(cutoff) < 0) await p.remove(k);
       }
     } catch (_) {/* bounding is best-effort — never break a record on it */}
   }
 
-  /// Parse a leading "YYYY-MM-DD" from a dedupeKey, or null if it isn't dated.
-  static DateTime? _leadingDate(String dedupeKey) {
+  /// The leading "YYYY-MM-DD" of a dedupeKey, or null if it isn't dated.
+  static String? leadingDate(String dedupeKey) {
     if (dedupeKey.length < 10) return null;
     final head = dedupeKey.substring(0, 10);
     if (!RegExp(r'^\d{4}-\d{2}-\d{2}$').hasMatch(head)) return null;
-    return DateTime.tryParse(head);
+    return head;
   }
 }

--- a/lib/notify/fired_keys.dart
+++ b/lib/notify/fired_keys.dart
@@ -1,51 +1,100 @@
-// fired_keys.dart — the persistent "already fired this key" record.
+// fired_keys.dart — the persistent, cross-isolate "already fired this key" record.
 //
 // A NotificationEvent's dedupeKey (by convention "$date:$kind") promises the
 // event fires at most once. The OS notification id alone does NOT enforce this:
 // re-showing the same id only REPLACES the prior post in the shade — it still
 // re-alerts (sound/buzz). Since derivation re-runs on every BLE sync, an insight
-// whose condition holds all day (e.g. today's irregular-rhythm flag) would fire
-// over and over (issue #136). This store makes emit() honour the promise: a key
-// that has already fired is skipped until a *new* key comes along.
+// whose condition holds all day (e.g. today's low-readiness or irregular-rhythm
+// flag) would fire over and over (issue #136). This store makes emit() honour the
+// promise: a key that has already fired is skipped until a *new* key comes along.
 //
-// Reset is automatic: keys are date-prefixed, so tomorrow's "2026-07-24:irregular"
-// is a fresh key that fires once. No manual clearing is needed. The store is a
-// bounded FIFO of the most-recent [maxKeys] fired keys — format-agnostic and
-// safe: since a single day only ever mints a handful of distinct keys, the cap
-// is far larger than any one day's worth, so a same-day key can never be evicted
-// and re-fire.
+// CROSS-ISOLATE. Derivation runs in TWO isolates: the long-lived
+// foreground pass (kept alive for BLE) and the WorkManager background pass
+// (background_derivation.dart) — both call emit()/this store, ~every drain and
+// ~every 15 min. The NotificationCenter lock only orders emits WITHIN one
+// isolate; it can't coordinate across them. The original store defeated its own
+// guard two ways here, so a same-day key re-fired all day:
+//   1. Stale read cache. The legacy SharedPreferences instance loads a snapshot
+//      once and never re-reads disk. The long-lived foreground isolate loaded
+//      prefs before today's key existed, so after the background isolate recorded
+//      it, hasFired() still read the stale snapshot as "not fired" → re-alert.
+//      FIX: reload() before every read so a write from the other isolate is seen.
+//   2. Lost-update clobber. Keys lived in ONE shared list mutated via
+//      read-modify-write (getStringList → add → setStringList). With no
+//      cross-process lock, whichever isolate wrote last rewrote the WHOLE list
+//      from its own (stale) copy, dropping the other's keys — including a
+//      just-recorded one, which then re-fired. FIX: one independent bool flag per
+//      key. Native SharedPreferences merges single-key writes, so two isolates
+//      recording different keys can't clobber each other, and recording the same
+//      key twice is idempotent.
+//
+// Reset is automatic: keys are date-prefixed, so tomorrow's "2026-07-24:low_read"
+// is a fresh key that fires once. Growth is bounded by _prune(): date-prefixed
+// flags older than [retentionDays] are dropped (the dedupe only needs today, so a
+// fortnight is ample). Keys without a leading date (e.g. "alarm_fired:<epoch>")
+// are rare and self-limiting, so they're left alone.
 
 import 'package:shared_preferences/shared_preferences.dart';
 
 class FiredKeyStore {
   const FiredKeyStore();
 
-  static const String _prefsKey = 'notif_fired_keys';
+  /// Per-key flag namespace. Each fired dedupeKey is its own bool at
+  /// "$_prefix$dedupeKey" — never a shared list (see the clobber note above).
+  static const String _prefix = 'notif_fired:';
 
-  /// How many most-recent fired keys to retain. Generous: a day mints only a
-  /// handful of distinct insight keys, so this spans many days — a same-day key
-  /// is never evicted (which would let it re-fire).
-  static const int maxKeys = 200;
+  /// How long a date-prefixed fired flag is retained before [_prune] drops it.
+  /// The guard only needs the current day; a fortnight is a generous margin.
+  static const int retentionDays = 14;
 
   /// Whether [dedupeKey] has already fired an OS notification.
+  ///
+  /// Reloads from the platform first: this isolate's in-memory snapshot can be
+  /// stale relative to a record from the OTHER derivation isolate, and reading
+  /// stale is exactly what let an already-fired key re-alert across isolates.
   Future<bool> hasFired(String dedupeKey) async {
     final p = await SharedPreferences.getInstance();
-    final keys = p.getStringList(_prefsKey);
-    return keys != null && keys.contains(dedupeKey);
+    await _reload(p);
+    return p.getBool('$_prefix$dedupeKey') ?? false;
   }
 
-  /// Record [dedupeKey] as fired. Bounded FIFO: the newest key is appended and
-  /// the oldest evicted once past [maxKeys]. A key already present is left
-  /// untouched — a repeated hit must NOT re-fire and must NOT refresh its
-  /// recency (otherwise a hot duplicate could keep a stale key pinned forever).
+  /// Record [dedupeKey] as fired — one independent flag, so a concurrent record
+  /// of a different key from the other isolate can't clobber it. Recording the
+  /// same key again is a harmless idempotent no-op. Prunes stale flags after.
   Future<void> recordFired(String dedupeKey) async {
     final p = await SharedPreferences.getInstance();
-    final keys = List<String>.of(p.getStringList(_prefsKey) ?? const <String>[]);
-    if (keys.contains(dedupeKey)) return;
-    keys.add(dedupeKey);
-    if (keys.length > maxKeys) {
-      keys.removeRange(0, keys.length - maxKeys);
-    }
-    await p.setStringList(_prefsKey, keys);
+    // Reload first so both the write and the prune below act on the latest
+    // cross-isolate state (and so _prune enumerates the other isolate's keys).
+    await _reload(p);
+    await p.setBool('$_prefix$dedupeKey', true);
+    await _prune(p);
+  }
+
+  Future<void> _reload(SharedPreferences p) async {
+    try {
+      await p.reload();
+    } catch (_) {/* reload is best-effort freshness, never fatal */}
+  }
+
+  /// Drop date-prefixed flags older than [retentionDays]. Best-effort and cheap:
+  /// it only runs after a real fire (rare), and a slightly stale key view just
+  /// prunes a little late. Keys without a leading YYYY-MM-DD are left untouched.
+  Future<void> _prune(SharedPreferences p) async {
+    try {
+      final cutoff = DateTime.now().subtract(const Duration(days: retentionDays));
+      for (final k in p.getKeys()) {
+        if (!k.startsWith(_prefix)) continue;
+        final d = _leadingDate(k.substring(_prefix.length));
+        if (d != null && d.isBefore(cutoff)) await p.remove(k);
+      }
+    } catch (_) {/* bounding is best-effort — never break a record on it */}
+  }
+
+  /// Parse a leading "YYYY-MM-DD" from a dedupeKey, or null if it isn't dated.
+  static DateTime? _leadingDate(String dedupeKey) {
+    if (dedupeKey.length < 10) return null;
+    final head = dedupeKey.substring(0, 10);
+    if (!RegExp(r'^\d{4}-\d{2}-\d{2}$').hasMatch(head)) return null;
+    return DateTime.tryParse(head);
   }
 }

--- a/lib/notify/notification_center.dart
+++ b/lib/notify/notification_center.dart
@@ -26,13 +26,15 @@ class NotificationCenter {
   /// The persistent "already fired this dedupeKey" guard. See [FiredKeyStore].
   final FiredKeyStore _fired = const FiredKeyStore();
 
-  /// Tail of a chained-Future lock that serialises the check-present-record
-  /// critical section in [emit]. Without it two overlapping emits of the SAME
-  /// key could both pass [FiredKeyStore.hasFired] before either records, and both
-  /// present. More likely now the UI-thread stress alert can race the background
-  /// derive loop. This lock only orders emits WITHIN this isolate — cross-isolate
-  /// fire-once (the foreground vs WorkManager derivation passes) is enforced by
-  /// FiredKeyStore itself (reload-before-read + independent per-key flags).
+  /// Tail of a chained-Future lock that serialises the claim-present-release
+  /// critical section in [emit]. It keeps two overlapping emits in THIS isolate
+  /// from interleaving their presents — more likely now the UI-thread stress
+  /// alert can race the background derive loop.
+  ///
+  /// It is not what enforces fire-once. This lock can only order emits WITHIN
+  /// this isolate; derivation also runs in the WorkManager isolate, which it
+  /// cannot see. Fire-once across both is enforced by the atomic
+  /// [FiredKeyStore.claim] below — one SQLite INSERT OR IGNORE, one winner.
   Future<void> _lock = Future<void>.value();
 
   /// Run [action] after any in-flight critical section completes, exclusively.
@@ -77,21 +79,30 @@ class NotificationCenter {
       // Enforce the dedupeKey's "fires at most once" contract (issue #136).
       // The OS id only REPLACES a prior post of the same key — it still
       // re-alerts — and derivation re-runs on every BLE sync, so an insight
-      // whose condition holds all day would otherwise buzz over and over.
-      // Skip a key that has already fired; record it only after a real present
-      // (a permission-denied no-op must not consume the key). The guard resets
-      // itself per new day via the date-prefixed keys.
+      // whose condition holds all day would otherwise buzz over and over. The
+      // guard resets itself per new day via the date-prefixed keys.
       //
-      // Serialised: hasFired → present → recordFired runs one emit at a time,
-      // so overlapping emits can't both present the same key nor clobber the
-      // fired-key list (recordFired re-reads the latest list inside the lock).
+      // CLAIM, don't check. A check-then-record pair is not atomic: the two
+      // derivation isolates can both read "not fired" before either records and
+      // both alert. [FiredKeyStore.claim] decides ownership in ONE atomic
+      // operation, so exactly one caller — in either isolate — ever proceeds.
+      //
+      // A claim we don't spend is given straight back: a permission-denied
+      // no-op or a throwing present must NOT consume the key, or that insight
+      // stays silent for the rest of the day. Release on every non-present path
+      // (hence the finally), which restores the pre-existing
+      // "record only after a real present" semantics.
       await _synchronized(() async {
-        if (await _fired.hasFired(e.dedupeKey)) return;
-        final shown = await presentSink(
-          e,
-          allowPermissionPrompt: allowPermissionPrompt,
-        );
-        if (shown) await _fired.recordFired(e.dedupeKey);
+        if (!await _fired.claim(e.dedupeKey)) return;
+        var shown = false;
+        try {
+          shown = await presentSink(
+            e,
+            allowPermissionPrompt: allowPermissionPrompt,
+          );
+        } finally {
+          if (!shown) await _fired.release(e.dedupeKey);
+        }
       });
     } catch (_) {/* OS present best-effort */}
   }

--- a/lib/notify/notification_center.dart
+++ b/lib/notify/notification_center.dart
@@ -27,12 +27,12 @@ class NotificationCenter {
   final FiredKeyStore _fired = const FiredKeyStore();
 
   /// Tail of a chained-Future lock that serialises the check-present-record
-  /// critical section in [emit]. Without it two overlapping emits could both
-  /// pass [FiredKeyStore.hasFired] before either records (→ both present), and
-  /// their read-modify-write of the fired-key list could clobber each other
-  /// (losing a key). More likely now the UI-thread stress alert can race the
-  /// background derive loop. Dart is single-isolate, so this in-memory lock
-  /// fully orders the awaits within emit.
+  /// critical section in [emit]. Without it two overlapping emits of the SAME
+  /// key could both pass [FiredKeyStore.hasFired] before either records, and both
+  /// present. More likely now the UI-thread stress alert can race the background
+  /// derive loop. This lock only orders emits WITHIN this isolate — cross-isolate
+  /// fire-once (the foreground vs WorkManager derivation passes) is enforced by
+  /// FiredKeyStore itself (reload-before-read + independent per-key flags).
   Future<void> _lock = Future<void>.value();
 
   /// Run [action] after any in-flight critical section completes, exclusively.

--- a/test/notification_claim_atomic_test.dart
+++ b/test/notification_claim_atomic_test.dart
@@ -1,0 +1,211 @@
+// Atomic cross-isolate fire-once for notification dedupeKeys (issue #136 tail).
+//
+// The sibling suite (notification_dedupe_test.dart) runs with no sqlite factory
+// and covers the degraded SharedPreferences fallback. THIS suite runs the real
+// LocalDb via sqflite_common_ffi, so it exercises the path that actually ships:
+// FiredKeyStore.claim → LocalDb.claimNotifFired → one atomic INSERT OR IGNORE.
+//
+// Why this can be tested in-process at all: the race being fixed is two
+// derivation isolates racing between "has it fired?" and "record that it fired".
+// A unit test can't spawn the WorkManager isolate, but it doesn't need to — both
+// isolates reach the SAME sqlite database, and the claim's correctness is a
+// property of the statement, not of who calls it. Calling claim() concurrently
+// WITHOUT NotificationCenter's in-isolate lock reproduces exactly the
+// interleaving the other isolate would produce: two claimants, no ordering
+// between them. Under the old check-then-record protocol both would win.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:openstrap_edge/data/day_label.dart';
+import 'package:openstrap_edge/data/db.dart';
+import 'package:openstrap_edge/notify/fired_keys.dart';
+import 'package:openstrap_edge/notify/notification_center.dart';
+import 'package:openstrap_edge/notify/notification_event.dart';
+
+NotificationEvent _ev(String dedupeKey) => NotificationEvent(
+      dedupeKey: dedupeKey,
+      category: NotifCategory.health,
+      title: 't',
+      body: 'b',
+      date: dedupeKey.split(':').first,
+      // critical so quiet hours can never mask a failure to dedupe.
+      priority: NotifPriority.critical,
+    );
+
+/// A local YYYY-MM-DD offset from today — same convention the store's retention
+/// cutoff uses (day labels are LOCAL everywhere; see data/day_label.dart).
+String _dayOffset(int days) => dayLabelOf(DateTime.now().add(Duration(days: days)));
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+    LocalDb.dbName = 'openstrap_notif_claim_test.db';
+  });
+
+  setUp(() async {
+    // A fresh DB per test: the claim table is the unit under test, so leaked
+    // rows between tests would mask a real failure to claim.
+    await LocalDb.close();
+    final dir = await databaseFactory.getDatabasesPath();
+    await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  tearDownAll(() async => LocalDb.close());
+
+  group('atomic claim', () {
+    test('exactly one of two concurrent claimants for the same key wins',
+        () async {
+      const store = FiredKeyStore();
+      const key = '2026-07-25:readiness';
+
+      // No in-isolate lock here — this is the cross-isolate shape.
+      final results = await Future.wait([
+        store.claim(key),
+        store.claim(key),
+        store.claim(key),
+      ]);
+
+      expect(results.where((won) => won).length, 1,
+          reason: 'a second claimant presenting is the duplicate alert');
+      expect(await store.hasFired(key), isTrue);
+    });
+
+    test('a claim released (present failed) is claimable again', () async {
+      const store = FiredKeyStore();
+      const key = '2026-07-25:low_read';
+
+      expect(await store.claim(key), isTrue);
+      await store.release(key);
+      // The whole point: a permission-denied no-op must not consume the day's
+      // only chance to fire this insight.
+      expect(await store.hasFired(key), isFalse);
+      expect(await store.claim(key), isTrue);
+      expect(await store.claim(key), isFalse);
+    });
+
+    test('distinct keys never contend', () async {
+      const store = FiredKeyStore();
+      final results = await Future.wait([
+        store.claim('${_dayOffset(0)}:a'),
+        store.claim('${_dayOffset(0)}:b'),
+        store.claim('${_dayOffset(0)}:c'),
+      ]);
+      expect(results, everyElement(isTrue));
+    });
+
+    test('the claim survives a store instance being thrown away (restart)',
+        () async {
+      const key = '2026-07-25:sync_stale';
+      expect(await const FiredKeyStore().claim(key), isTrue);
+      await LocalDb.close(); // simulate a process teardown between passes
+      expect(await const FiredKeyStore().claim(key), isFalse);
+    });
+  });
+
+  group('emit integration', () {
+    late NotificationCenter center;
+
+    setUp(() {
+      center = NotificationCenter.instance;
+    });
+
+    test('a denied present leaves the key free to fire later', () async {
+      final shown = <String>[];
+      var grant = false;
+      center.presentSink = (e, {bool allowPermissionPrompt = true}) async {
+        if (!grant) return false;
+        shown.add(e.dedupeKey);
+        return true;
+      };
+
+      await center.emit(_ev('2026-07-25:temp'));
+      expect(shown, isEmpty);
+
+      grant = true;
+      await center.emit(_ev('2026-07-25:temp'));
+      expect(shown, ['2026-07-25:temp']);
+
+      // ...and now it's spent.
+      await center.emit(_ev('2026-07-25:temp'));
+      expect(shown, ['2026-07-25:temp']);
+    });
+
+    test('a throwing present does not consume the key', () async {
+      final shown = <String>[];
+      var boom = true;
+      center.presentSink = (e, {bool allowPermissionPrompt = true}) async {
+        if (boom) throw StateError('OS layer blew up');
+        shown.add(e.dedupeKey);
+        return true;
+      };
+
+      await center.emit(_ev('2026-07-25:auto_workout')); // swallowed by emit
+      boom = false;
+      await center.emit(_ev('2026-07-25:auto_workout'));
+      expect(shown, ['2026-07-25:auto_workout']);
+    });
+  });
+
+  group('legacy migration', () {
+    test('keys that already fired under the old shared list do not re-fire',
+        () async {
+      // Pre-#145 on-disk shape: one shared list of fired keys.
+      const already = '2026-07-25:low_read';
+      SharedPreferences.setMockInitialValues({
+        FiredKeyStore.legacyListKey: <String>[already, '2026-07-25:step_goal'],
+      });
+
+      const store = FiredKeyStore();
+      expect(await store.claim(already), isFalse,
+          reason: 'upgrading must not re-alert the day\'s already-fired keys');
+      expect(await store.claim('2026-07-25:step_goal'), isFalse);
+      // A key that never fired is still free.
+      expect(await store.claim('2026-07-25:recovery_ready'), isTrue);
+
+      // The legacy list is consumed, not left behind as a dead pref.
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.reload();
+      expect(prefs.getStringList(FiredKeyStore.legacyListKey), isNull);
+    });
+
+    test('migration is idempotent across repeated claims', () async {
+      SharedPreferences.setMockInitialValues({
+        FiredKeyStore.legacyListKey: <String>['2026-07-25:x'],
+      });
+      const store = FiredKeyStore();
+      expect(await store.claim('2026-07-25:x'), isFalse);
+      expect(await store.claim('2026-07-25:x'), isFalse);
+      expect(await store.claim('2026-07-25:y'), isTrue);
+    });
+  });
+
+  group('retention', () {
+    test('dated claims older than the window are pruned; recent ones survive',
+        () async {
+      const store = FiredKeyStore();
+      final stale = '${_dayOffset(-(FiredKeyStore.retentionDays + 5))}:low_read';
+      final fresh = '${_dayOffset(-1)}:low_read';
+      await LocalDb.seedNotifFired([stale, fresh]);
+
+      // Any successful claim triggers a prune pass.
+      expect(await store.claim('${_dayOffset(0)}:trigger'), isTrue);
+
+      expect(await LocalDb.notifFiredExists(stale), isFalse);
+      expect(await LocalDb.notifFiredExists(fresh), isTrue);
+    });
+
+    test('undated claims (alarm_fired:<epoch>) are never pruned', () async {
+      const store = FiredKeyStore();
+      await LocalDb.seedNotifFired(['alarm_fired:12345']);
+      expect(await store.claim('${_dayOffset(0)}:trigger'), isTrue);
+      expect(await LocalDb.notifFiredExists('alarm_fired:12345'), isTrue);
+    });
+  });
+}

--- a/test/notification_claim_atomic_test.dart
+++ b/test/notification_claim_atomic_test.dart
@@ -100,6 +100,29 @@ void main() {
       expect(results, everyElement(isTrue));
     });
 
+    test('a key that fired in degraded mode never fires again once the DB is '
+        'back — however many passes run', () async {
+      const store = FiredKeyStore();
+      const key = '2026-07-25:low_read';
+
+      // The exact on-disk state left by a fallback claim taken while the DB was
+      // unusable: the prefs mirror remembers the fire, the claim table doesn't.
+      SharedPreferences.setMockInitialValues({'notif_fired:$key': true});
+
+      // Every subsequent pass (each background derive is one) must lose. The
+      // first reconciling pass is the easy case; the ones after it are where a
+      // reconciliation that ERASED the mirror would hand the key back out and
+      // re-alert.
+      for (var pass = 0; pass < 3; pass++) {
+        expect(await store.claim(key), isFalse, reason: 'pass $pass re-fired');
+      }
+
+      // Reconciled forward: the claim table now records the fire too, so the
+      // mirror is no longer the only thing standing between us and a repeat.
+      expect(await LocalDb.notifFiredExists(key), isTrue);
+      expect(await store.hasFired(key), isTrue);
+    });
+
     test('the claim survives a store instance being thrown away (restart)',
         () async {
       const key = '2026-07-25:sync_stale';

--- a/test/notification_dedupe_test.dart
+++ b/test/notification_dedupe_test.dart
@@ -4,11 +4,20 @@
 // persisted across restarts, while a fresh (e.g. next-day) key still fires and
 // the existing category/quiet-hours gating is untouched. We inject a fake
 // present sink (counts calls, no device) and a mocked SharedPreferences.
+//
+// NOTE — this suite runs with NO sqlite factory registered, so FiredKeyStore's
+// atomic SQLite claim is unavailable and every test here exercises its DEGRADED
+// SharedPreferences fallback. That's deliberate: the fallback is what runs when
+// the DB is torn down mid-background-pass, and it must still dedupe. The atomic
+// claim itself (and the legacy-list migration) is covered against a real DB in
+// notification_claim_atomic_test.dart.
 
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:openstrap_edge/data/day_label.dart';
 
 import 'package:openstrap_edge/notify/fired_keys.dart';
 import 'package:openstrap_edge/notify/notification_center.dart';
@@ -271,10 +280,12 @@ void main() {
     });
   });
 
-  group('FiredKeyStore per-key + retention', () {
-    // A YYYY-MM-DD offset from today, for retention-window assertions.
+  group('FiredKeyStore per-key + retention (degraded mode)', () {
+    // A local YYYY-MM-DD offset from today, for retention-window assertions.
+    // dayLabelOf, not raw toIso8601String: day labels are LOCAL everywhere, and
+    // the store's own cutoff is computed the same way.
     String dayOffset(int days) =>
-        DateTime.now().add(Duration(days: days)).toIso8601String().substring(0, 10);
+        dayLabelOf(DateTime.now().add(Duration(days: days)));
 
     test('hasFired reflects recordFired', () async {
       SharedPreferences.setMockInitialValues({});

--- a/test/notification_dedupe_test.dart
+++ b/test/notification_dedupe_test.dart
@@ -228,12 +228,10 @@ void main() {
       await Future.wait([f1, f2]);
 
       expect(sink.calls, 2);
-      // Serialised read-modify-write: neither key clobbered the other.
-      final p = await SharedPreferences.getInstance();
-      expect(
-        p.getStringList('notif_fired_keys'),
-        containsAll(['2026-07-23:a', '2026-07-23:b']),
-      );
+      // Independent per-key flags: neither key clobbered the other.
+      const store = FiredKeyStore();
+      expect(await store.hasFired('2026-07-23:a'), isTrue);
+      expect(await store.hasFired('2026-07-23:b'), isTrue);
     });
   });
 
@@ -273,7 +271,11 @@ void main() {
     });
   });
 
-  group('FiredKeyStore bounding', () {
+  group('FiredKeyStore per-key + retention', () {
+    // A YYYY-MM-DD offset from today, for retention-window assertions.
+    String dayOffset(int days) =>
+        DateTime.now().add(Duration(days: days)).toIso8601String().substring(0, 10);
+
     test('hasFired reflects recordFired', () async {
       SharedPreferences.setMockInitialValues({});
       const store = FiredKeyStore();
@@ -282,31 +284,42 @@ void main() {
       expect(await store.hasFired('a'), isTrue);
     });
 
-    test('a repeated record neither duplicates nor refreshes recency', () async {
+    test('independent per-key flags — a record never clobbers another key',
+        () async {
       SharedPreferences.setMockInitialValues({});
       const store = FiredKeyStore();
-      await store.recordFired('a');
-      await store.recordFired('b');
-      await store.recordFired('a'); // hit — must be a no-op
-      final p = await SharedPreferences.getInstance();
-      // 'a' stays in its original (oldest) slot; no duplicate appended.
-      expect(p.getStringList('notif_fired_keys'), ['a', 'b']);
+      await store.recordFired('${dayOffset(0)}:a');
+      await store.recordFired('${dayOffset(0)}:b');
+      await store.recordFired('${dayOffset(0)}:a'); // repeat — idempotent no-op
+      expect(await store.hasFired('${dayOffset(0)}:a'), isTrue);
+      expect(await store.hasFired('${dayOffset(0)}:b'), isTrue);
     });
 
-    test('caps at maxKeys, evicting oldest first', () async {
-      SharedPreferences.setMockInitialValues({});
+    test('prune drops date-prefixed flags older than the retention window',
+        () async {
+      // Seed a clearly-stale dated flag directly (bypassing recordFired, whose
+      // own prune would eat it immediately), plus a within-window one.
+      final stale = '${dayOffset(-(FiredKeyStore.retentionDays + 5))}:low_read';
+      final fresh = '${dayOffset(-1)}:low_read';
+      SharedPreferences.setMockInitialValues({
+        'notif_fired:$stale': true,
+        'notif_fired:$fresh': true,
+      });
       const store = FiredKeyStore();
-      for (var i = 0; i < FiredKeyStore.maxKeys + 5; i++) {
-        await store.recordFired('k$i');
-      }
-      final p = await SharedPreferences.getInstance();
-      final keys = p.getStringList('notif_fired_keys')!;
-      expect(keys.length, FiredKeyStore.maxKeys);
-      // Oldest five evicted; newest retained.
-      expect(await store.hasFired('k0'), isFalse);
-      expect(await store.hasFired('k4'), isFalse);
-      expect(await store.hasFired('k5'), isTrue);
-      expect(await store.hasFired('k${FiredKeyStore.maxKeys + 4}'), isTrue);
+      // Any record triggers a prune pass.
+      await store.recordFired('${dayOffset(0)}:trigger');
+      expect(await store.hasFired(stale), isFalse); // pruned
+      expect(await store.hasFired(fresh), isTrue); // retained
+    });
+
+    test('prune leaves undated keys (e.g. alarm_fired:<epoch>) untouched',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        'notif_fired:alarm_fired:12345': true,
+      });
+      const store = FiredKeyStore();
+      await store.recordFired('${dayOffset(0)}:trigger');
+      expect(await store.hasFired('alarm_fired:12345'), isTrue);
     });
   });
 }


### PR DESCRIPTION
## Problem

A same-day insight notification — reproduced with **"Low readiness today"** — re-fires repeatedly and re-alerts every time it's dismissed. The `dedupeKey` (`\$date:readiness`) is stable, so the fire-once guard added in #137 (issue #136) is being **defeated across isolates**, not bypassed by a changing key.

Derivation runs in **two isolates**, both of which call `NotificationCenter.emit()` → `FiredKeyStore`:

1. **Foreground** — `AppState._afterDrain` kicks a light derive on every BLE drain, and the foreground service keeps this isolate alive for days while backgrounded.
2. **WorkManager background** — `derivationDispatcher` runs `engine.run(heavy: true)` (→ `_runNotifications`) every ~15 min, even app-closed.

`NotificationCenter`'s `_synchronized` lock only orders emits **within one isolate**. The store defeated its own guard two ways across them:

- **Stale read cache** — legacy `SharedPreferences` loads a snapshot once and never re-reads disk. The long-lived foreground isolate loaded prefs before today's key existed, so after the background isolate recorded it, `hasFired()` still read the stale snapshot as "not fired" → re-alert.
- **Lost-update clobber** — keys lived in one shared list mutated via read-modify-write (`getStringList` → add → `setStringList`). With no cross-process lock, whichever isolate wrote last rewrote the whole list from its own stale copy, dropping the other's keys — including a just-recorded one, which then re-fired.

The existing tests are single-isolate against one in-memory mock, so they stayed green while this shipped.

## Fix

`FiredKeyStore` is now cross-isolate safe:

- **`reload()` before every read** so a record from the other isolate is seen.
- **One independent `bool` flag per key** (`notif_fired:\$dedupeKey`) instead of a shared list. Native SharedPreferences merges single-key writes, so concurrent records of different keys can't clobber each other and a repeat record is idempotent.
- **Bounded growth via `_prune()`** — date-prefixed flags older than a 14-day window are dropped (replacing the old FIFO cap). Undated keys (e.g. `alarm_fired:<epoch>`) are rare and left alone.

The in-isolate emit lock is unchanged; its comment is corrected to scope it to a single isolate.

## Tests

`test/notification_dedupe_test.dart` is updated to the per-key model and adds coverage for retention pruning and undated-key retention. Behavioural dedupe/gating/concurrency tests are unchanged in intent.

> Note: a unit test can't span isolates (one in-process mock store), so this can't be regression-tested end-to-end in the suite — the fix removes the two mechanisms (stale-cache read, shared-list clobber) that the multi-isolate race depended on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made notification “fire once” deduplication atomic across isolates to prevent duplicate deliveries.
  * Prevented one notification’s dedupe record from affecting others.
  * Improved dedupe handling so permission denial or presentation failures don’t permanently consume the key.
  * Added automatic cleanup of old date-tagged dedupe entries (while keeping undated ones).
  * Migrates previous fired-notification history so already-fired notifications aren’t re-delivered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->