### PR TITLE
remove Awake and Consistency tiles from the sleep screen bento

### DIFF
--- a/lib/ui/sleep/sleep_detail_screen.dart
+++ b/lib/ui/sleep/sleep_detail_screen.dart
@@ -649,7 +649,6 @@ class SleepNightContent extends StatelessWidget {
     final eff = _efficiency;
     final debt = _debtMin;
     final noDebt = debt == null || debt.round() <= 0;
-    final reg = _regularity;
 
     void info(String title, String body, [String? method]) =>
         showInfoSheet(context, title: title, body: body, methodNote: method);
@@ -731,6 +730,12 @@ class SleepNightContent extends StatelessWidget {
           ),
         ),
       ],
+      // "Awake" (WASO) and "Consistency" (SRI) tiles removed from this bento
+      // per request — WASO stays available inline in the Efficiency tile's
+      // long-press detail (`_awakeMin` is still used there), and Consistency
+      // still has its own row further down in the metrics list (`_regularity`,
+      // gated the same honest way) — this only drops the duplicate summary
+      // tiles up here, neither getter/section was touched.
       right: [
         BentoTile(
           onLongPress: () => info(
@@ -742,43 +747,6 @@ class SleepNightContent extends StatelessWidget {
               const TileHeader('Woke'),
               const SizedBox(height: Sp.x2),
               BigStat(value: wake == null ? null : _clock(wake)),
-            ],
-          ),
-        ),
-        BentoTile(
-          accent: DomainAccent.stress,
-          onLongPress: () => info(
-              'Awake (WASO)',
-              'Time awake after first falling asleep — brief wake-ups are '
-                  'normal; long stretches drag efficiency down.'),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const TileHeader('Awake'),
-              const SizedBox(height: Sp.x2),
-              BigStat(value: _awakeMin == null ? null : _hm(_awakeMin)),
-            ],
-          ),
-        ),
-        BentoTile(
-          accent: DomainAccent.recovery,
-          onLongPress: () => info(
-            'Sleep consistency',
-            'How steady your bed and wake times have been. Higher is steadier.',
-            'Sleep Regularity Index over recent nights — needs several nights to unlock',
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const TileHeader('Consistency'),
-              const SizedBox(height: Sp.x2),
-              BigStat(
-                value: reg == null ? null : '${reg.round()}',
-                unit: reg == null ? null : '/100',
-                caption: reg == null ? 'need a few more nights' : null,
-              ),
             ],
           ),
         ),

--- a/test/workout_sleep_redesign_test.dart
+++ b/test/workout_sleep_redesign_test.dart
@@ -249,7 +249,13 @@ void main() {
         expect(find.text('94%'), findsOneWidget);
         expect(find.text('EFFICIENCY'), findsOneWidget);
         expect(find.text('SLEEP DEBT'), findsOneWidget);
-        expect(find.text('CONSISTENCY'), findsOneWidget);
+        // "Awake" and "Consistency" summary tiles were deliberately removed
+        // from this bento (Consistency still has its own honest-gated row
+        // further down the screen; Awake/WASO still surfaces inline in the
+        // Efficiency tile's long-press detail) — assert they're GONE rather
+        // than leaving a stale assumption they still render here.
+        expect(find.text('AWAKE'), findsNothing);
+        expect(find.text('CONSISTENCY'), findsNothing);
         expect(t.takeException(), isNull);
       }
     });


### PR DESCRIPTION
took out both BentoTile entries from the right column of the sleep summary bento.

left the underlying data/getters alone since they're both still used elsewhere on the same screen:
- `_awakeMin` is still used in the Efficiency tile's long-press detail text
- Consistency still has its own honest-gated row further down the screen (shows "Need a few more nights" when there isn't enough history yet)

just removed the duplicate summary tiles up top, plus the now-unused `reg` local in `_summaryBento`.

had to update one test (`workout_sleep_redesign_test.dart`) that was asserting CONSISTENCY showed up in this bento — flipped it to assert both AWAKE and CONSISTENCY are gone from there instead, so it pins the new behavior instead of going stale.

611/611 green, analyze clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Simplified the sleep summary layout by removing the separate “Awake” and “Consistency” tiles.
  * Awake time remains available in the Efficiency details.
  * Consistency information is still available in the detailed metrics list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->