### PR TITLE
put sleep debt and efficiency side by side on the sleep screen

### DIFF
--- a/lib/ui/sleep/sleep_detail_screen.dart
+++ b/lib/ui/sleep/sleep_detail_screen.dart
@@ -708,6 +708,32 @@ class SleepNightContent extends StatelessWidget {
             ],
           ),
         ),
+      ],
+      // "Awake" (WASO) and "Consistency" (SRI) tiles removed from this bento
+      // per request — WASO stays available inline in the Efficiency tile's
+      // long-press detail (`_awakeMin` is still used there), and Consistency
+      // still has its own row further down in the metrics list (`_regularity`,
+      // gated the same honest way) — this only drops the duplicate summary
+      // tiles up here, neither getter/section was touched.
+      //
+      // Sleep debt moved here (was left-column row 3, stacked under
+      // Efficiency) so it sits in the same row as Efficiency side by side,
+      // per request — left/right are independent stacks in this two-column
+      // bento, so same list-index = same row.
+      right: [
+        BentoTile(
+          onLongPress: () => info(
+              'Woke', 'When you woke for the day — the end of the window.'),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const TileHeader('Woke'),
+              const SizedBox(height: Sp.x2),
+              BigStat(value: wake == null ? null : _clock(wake)),
+            ],
+          ),
+        ),
         BentoTile(
           tone: noDebt ? BentoTone.paper : BentoTone.soft,
           accent: DomainAccent.sleep,
@@ -726,27 +752,6 @@ class SleepNightContent extends StatelessWidget {
                     : (noDebt ? 'all caught up' : 'carried over'),
                 captionAccent: !noDebt,
               ),
-            ],
-          ),
-        ),
-      ],
-      // "Awake" (WASO) and "Consistency" (SRI) tiles removed from this bento
-      // per request — WASO stays available inline in the Efficiency tile's
-      // long-press detail (`_awakeMin` is still used there), and Consistency
-      // still has its own row further down in the metrics list (`_regularity`,
-      // gated the same honest way) — this only drops the duplicate summary
-      // tiles up here, neither getter/section was touched.
-      right: [
-        BentoTile(
-          onLongPress: () => info(
-              'Woke', 'When you woke for the day — the end of the window.'),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const TileHeader('Woke'),
-              const SizedBox(height: Sp.x2),
-              BigStat(value: wake == null ? null : _clock(wake)),
             ],
           ),
         ),


### PR DESCRIPTION
just a reorder — moved the "Sleep debt" tile out of the left column (where it was stacked under Efficiency) into the right column, right after "Woke" (which has been sitting there alone since the Awake/Consistency tiles came off it in #152).

this bento is a two-column independent stack, so same list position = same row. row 1 is still To bed / Woke, row 2 is now Efficiency / Sleep debt side by side instead of Sleep debt being stacked underneath.

no data/getters touched, just where the tile sits. tested locally before this went up — 611/611 green, analyze clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Removed duplicate “Awake” and “Consistency” summary tiles from the sleep overview.
  * Added the “Sleep debt” tile to the overview for easier access.
  * “Awake” details remain available through the Efficiency tile, while “Consistency” continues to appear in the metrics and trends sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->