### PR TITLE
docs: add an "As featured in" strip to the README and landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ An app that makes a WHOOP 4.0 useful without a WHOOP subscription. Connects to t
 
 <img width="1774" height="887" alt="image" src="https://github.com/user-attachments/assets/66653a25-ac97-4f8c-8be1-6c9fceeaf08b" />
 
+## As featured in
+
+> **"The goal of the so-called OpenStrap project is not to re-create the WHOOP app.
+> Rather, the algorithms and processing methods are developed from scratch, based on
+> public research… The health data collected from the watch never leaves the phone."**
+>
+> — [**Hackaday**, 15 July 2026](https://hackaday.com/2026/07/15/making-a-locked-down-wearable-work-without-a-subscription/)
+
+> **"When a membership lapses, the hardware is basically useless. You own it, you still
+> can't use it — it just goes dark, because the app stops talking to it. So you've got a
+> perfectly good sensor turning into a paperweight."**
+>
+> — [**Adafruit**, 15 July 2026](https://blog.adafruit.com/2026/07/15/openstrap-edge-makes-a-whoop-4-0-band-useful-without-a-subscription/)
+
 ## Install
 
 | | |

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,6 +51,36 @@
       </p>
     </section>
 
+    <section class="press" aria-label="Press coverage">
+      <p class="eyebrow">As featured in</p>
+      <div class="press-grid">
+        <figure>
+          <blockquote>
+            The goal of the so-called OpenStrap project is not to re-create the WHOOP
+            app. Rather, the algorithms and processing methods are developed from
+            scratch, based on public research&hellip; The health data collected from the
+            watch never leaves the phone.
+          </blockquote>
+          <figcaption>
+            <a href="https://hackaday.com/2026/07/15/making-a-locked-down-wearable-work-without-a-subscription/">Hackaday</a>
+            <span>15 July 2026</span>
+          </figcaption>
+        </figure>
+        <figure>
+          <blockquote>
+            When a membership lapses, the hardware is basically useless. You own it, you
+            still can&rsquo;t use it &mdash; it just goes dark, because the app stops
+            talking to it. So you&rsquo;ve got a perfectly good sensor turning into a
+            paperweight.
+          </blockquote>
+          <figcaption>
+            <a href="https://blog.adafruit.com/2026/07/15/openstrap-edge-makes-a-whoop-4-0-band-useful-without-a-subscription/">Adafruit</a>
+            <span>15 July 2026</span>
+          </figcaption>
+        </figure>
+      </div>
+    </section>
+
     <section class="shots">
       <figure>
         <img src="https://raw.githubusercontent.com/OpenStrap/edge/main/screenshots/today.png" alt="The Today screen, showing a readiness ring and the day's headline metrics" loading="lazy">

--- a/docs/style.css
+++ b/docs/style.css
@@ -459,3 +459,78 @@ strong {
   word-break: break-all;
   white-space: normal;
 }
+
+/* ── Press strip ──────────────────────────────────────────────────────────
+   Sits directly under the hero: third-party corroboration is worth more than
+   another paragraph of our own claims, so it goes above the screenshots. */
+.press {
+  margin: 44px 0 8px;
+  padding-top: 24px;
+  border-top: 1px solid var(--border);
+}
+
+.press .eyebrow {
+  display: block;
+  margin-bottom: 14px;
+}
+
+.press-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 18px;
+}
+
+.press figure {
+  margin: 0;
+  padding: 18px 20px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.press blockquote {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--fg);
+  text-wrap: pretty;
+}
+
+/* Quote mark as a hanging accent rather than a decorative glyph blob. */
+.press blockquote::before {
+  content: "\201C";
+  color: var(--accent);
+  font-size: 28px;
+  line-height: 0;
+  vertical-align: -0.15em;
+  margin-right: 2px;
+}
+
+.press figcaption {
+  margin-top: auto;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-size: 13px;
+}
+
+.press figcaption a {
+  font-weight: 650;
+  color: var(--fg);
+  text-decoration: none;
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: 1px;
+}
+
+.press figcaption a:hover { color: var(--accent); }
+
+.press figcaption span {
+  color: var(--fg-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11.5px;
+}
+
+.press > .fineprint { margin: 14px 0 0; }


### PR DESCRIPTION
### **User description**
Hackaday and Adafruit both covered this on 15 July. Until now that credibility only did work for the handful of people we email — on the site it works on every visitor.

## The two quotes

Chosen because they say things we can't credibly say about ourselves:

> **"The goal of the so-called OpenStrap project is not to re-create the WHOOP app. Rather, the algorithms and processing methods are developed from scratch, based on public research… The health data collected from the watch never leaves the phone."**
> — Hackaday

A third party stating *both* the non-clone position and the local-first claim. Worth more than any number of times we assert either — and directly relevant given WHOOP is currently litigating a trade-dress "it's a clone of our app" theory against Bevel.

> **"When a membership lapses, the hardware is basically useless. You own it, you still can't use it — it just goes dark, because the app stops talking to it. So you've got a perfectly good sensor turning into a paperweight."**
> — Adafruit

Clearest one-paragraph statement of the problem anyone has written, ours included.

## Placement

Directly under the hero, **above** the screenshots. Corroboration lands harder before the product tour than after it. Styled with the existing tokens; verified in light and dark.

## What's deliberately not here

**Android Authority.** Their piece *"Open source app could finally free WHOOP users from expensive subscriptions"* (Stephen Schenck, 2 June) is about **Goose**, not this project — I fetched the full text and OpenStrap isn't mentioned once.

I had it recorded as our coverage, and it was in this branch before Abdul caught it. Worth stating plainly because it nearly went into a pitch email aimed at Android Authority themselves, which is about the worst possible way to open a cold pitch.

**Two outlets have covered OpenStrap.** That's the whole list, it's a good list, and padding it with a third is the kind of claim that collapses the moment someone clicks through.

Docs and CSS only — no Dart touched.


___

### **PR Type**
Documentation


___

### **Description**
- Add "As featured in" press strip to README and landing page

- Feature quotes from Hackaday and Adafruit (15 July 2026)

- New CSS section styles the press grid with cards and accent quote marks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hackaday quote\n(non-clone + local-first)"] -- "blockquote card" --> C["press-grid section\n(docs/index.html)"]
  B["Adafruit quote\n(subscription lock-in)"] -- "blockquote card" --> C
  C -- "above screenshots" --> D["Landing page hero"]
  E["README.md"] -- "markdown blockquotes" --> F["GitHub repo front page"]
  G["docs/style.css\n(.press, .press-grid, figcaption)"] -- "styles" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add press quote section to README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Adds an "As featured in" section with two blockquote citations<br> <li> Quotes Hackaday (non-clone + local-first claim) and Adafruit <br>(subscription lock-in problem)<br> <li> Links to the respective articles dated 15 July 2026</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/157/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Add press coverage section to landing page HTML</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/index.html

<ul><li>Inserts a new <code><section class="press"></code> block directly under the hero, <br>above screenshots<br> <li> Contains two <code><figure></code> cards with <code><blockquote></code> and <code><figcaption></code> for Hackaday and Adafruit<br> <li> Uses <code>aria-label="Press coverage"</code> for accessibility</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/157/files#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350ae">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>style.css</strong><dd><code>Add CSS styles for press strip cards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/style.css

<ul><li>Adds ~75 lines of CSS for the new <code>.press</code> strip and <code>.press-grid</code> <br>responsive layout<br> <li> Styles blockquote cards with border, border-radius, and surface <br>background using existing CSS variables<br> <li> Adds decorative opening quote mark via <code>::before</code> pseudo-element using <br><code>--accent</code> color<br> <li> Styles figcaption with outlet name link (underlined with accent) and <br>monospace date span</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/157/files#diff-4dde236d1a1b6f7a24be281ce9e8212368612d66a631fa592bfe18653f57c601">+75/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

