### PR TITLE
docs: correct stale stress-fallback comments in local_repository_impl

### DIFF
--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -341,9 +341,9 @@ class LocalRepositoryImpl extends LocalRepository {
           : const {'value': null},
       // Stress (Baevsky SI → 0–100 score block) + relative SpO₂ (desat index),
       // both emitted by the pipeline. The Today tiles + stress screen read these.
-      // Same readiness-inverse fallback as getDayStress: without it the Today
-      // stress tile rendered "—" whenever SI abstained while the stress screen
-      // showed a number (the "stress pill has no number" bug).
+      // No imputation: stressSummaryForToday returns the SI block verbatim (null
+      // when absent), so the Today tile shows "—" whenever the real SI abstained.
+      // The old `100 - readiness` fallback that fabricated a number was removed.
       if (sleepBundle != null)
         'stress': ?stressSummaryForToday(sleepBundle, _scalar(sleepBundle, 'readiness')),
       if (sleepBundle != null && sleepBundle['spo2'] is Map)
@@ -713,8 +713,9 @@ class LocalRepositoryImpl extends LocalRepository {
   @override
   Future<Map<String, dynamic>> getDayStress(String date) async {
     // Stress = the pipeline's Baevsky Stress Index block (resting autonomic
-    // tension; transparent RR-histogram metric → 0–100 score). Falls back to the
-    // readiness inverse only if SI is absent. Nocturnal arousal isn't computed,
+    // tension; transparent RR-histogram metric → 0–100 score). No fallback: the
+    // score stays null when the SI is absent, so the screen renders "—" (the old
+    // `100 - readiness` imputation was removed). Nocturnal arousal isn't computed,
     // so `sleep_stress` is intentionally absent (the screen handles it).
     final b = await _bundleForDate(date);
     if (b == null) return const {};


### PR DESCRIPTION
Two comments in `local_repository_impl.dart` still describe the removed `100 − readiness` stress fallback as if it were live, directly contradicting the code beneath them:

- **`getDayStress` (~:715)** said *"Falls back to the readiness inverse only if SI is absent"* — but the body has an explicit *"NO fallback here"* and returns `null` when the Baevsky SI is absent.
- **Today-tile assembly (~:344)** said *"Same readiness-inverse fallback as getDayStress"* — but it uses `stressSummaryForToday`, which returns the SI block verbatim (null when empty), i.e. no imputation.

Both now describe the actual no-fallback behaviour (abstain → "—", never impute from an unrelated metric), matching the `stressSummaryForToday` docstring and the removal already recorded in `derivation_engine.dart`.

**No behaviour change — comments only.**

Context: surfaced while investigating #148 (stress showing a confident number on near-zero data). That report predates the fabrication removal (`adb5117`, already in v0.9.20+51), so the reported bug is stale — but these stale comments would mislead the next reader into thinking the fallback still exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stress scores now remain unavailable when the underlying stress index is missing.
  * Today’s stress summary and daily details consistently display “—” instead of an estimated value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->