### PR TITLE
feat: warn before the strap dies overnight, and help find it when it's lost

### DIFF
--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -2781,6 +2781,30 @@ class BleEngine {
   Future<void> buzzPattern(int pattern) =>
       _send(Cmd.runHapticsPattern, [pattern, 0, 0, 0, 0]);
 
+  /// Signal strength of the live link, in dBm (negative; closer to zero is
+  /// stronger). Null whenever there is nothing to measure.
+  ///
+  /// Used by the find-my-band hunt. Note what this does NOT do: it never
+  /// scans. A hunt needs to BUZZ the band as well as track it, and buzzing
+  /// requires the connection — so a band we cannot reach is one we could not
+  /// help find anyway. Read straight off the connected device instead, which
+  /// also means the hunt costs nothing beyond one small GATT read per poll:
+  /// no radio mode change, no interference with an in-flight offload.
+  ///
+  /// Returns null rather than throwing on a mid-hunt disconnect; the caller
+  /// polls on a timer and a dropped sample must not blow up the screen. The
+  /// timeout matters because `readRssi` can hang on a link that is technically
+  /// still "connected" but is not passing traffic.
+  Future<int?> readRssi() async {
+    final s = _session;
+    if (s == null || !s.connected) return null;
+    try {
+      return await s.device.readRssi().timeout(const Duration(seconds: 3));
+    } catch (_) {
+      return null;
+    }
+  }
+
   /// Enable live foreground streams (makes the band emit live R10/R11 + optical).
   /// Optical stays WRIST-GATED (0x6B only). This sends the toggle commands but
   /// DOES NOT change the displayed state — we stay in the single `listening` phase;

--- a/lib/ble/proximity_policy.dart
+++ b/lib/ble/proximity_policy.dart
@@ -1,0 +1,262 @@
+// proximity_policy.dart — pure smoothing/labelling for the "find my band"
+// hunt. No BLE types, no timers: samples in, a stable label out.
+//
+// WHY A POLICY AND NOT AN INLINE READING
+// Raw BLE RSSI is brutally noisy. Consecutive reads of a stationary device
+// routinely swing 10 dB from multipath alone, and a hand or a duvet between the
+// phone and the band costs another 10–20 dB. Painting that straight onto a
+// screen gives a number that jitters wildly while you stand still and barely
+// moves when you actually walk toward it — the exact opposite of what a hunt
+// needs. Two things fix it and both belong in one testable place:
+//
+//   1. EWMA smoothing, so a single bad read cannot move the label.
+//   2. HYSTERESIS on the zone boundaries, so hovering at a threshold does not
+//      flicker between "Nearby" and "Close" several times a second.
+//
+// WHAT RSSI IS NOT
+// It is not distance, and this file will not pretend otherwise. There is no
+// path-loss-to-metres conversion here on purpose: that conversion needs a
+// calibrated TX power and a free-space assumption, and a band down the side of
+// a mattress violates the assumption completely. Showing "1.4 m" would be a
+// fabricated number in a codebase whose whole contract is not fabricating them.
+// Coarse zones plus an honest warmer/colder trend is what the signal can
+// actually support, so that is what it reports.
+
+/// How close the band looks, coarsely. Ordered strongest → weakest.
+enum ProximityZone {
+  /// Within arm's reach — under a pillow, in the bedding, on the desk.
+  immediate,
+
+  /// Same room, a few paces away.
+  near,
+
+  /// Reachable but attenuated — another room, or buried in something.
+  far,
+
+  /// Connected, but the signal is too weak to guide a hunt.
+  veryFar,
+
+  /// Not enough samples yet.
+  unknown,
+}
+
+/// Which way the signal is moving as you walk.
+enum ProximityTrend { warmer, colder, steady, unknown }
+
+/// One evaluated reading.
+class ProximityReading {
+  const ProximityReading({
+    required this.zone,
+    required this.trend,
+    required this.samples,
+    this.smoothedRssi,
+    this.rawRssi,
+  });
+
+  final ProximityZone zone;
+  final ProximityTrend trend;
+
+  /// How many samples have been folded in since the last reset.
+  final int samples;
+
+  /// EWMA of the raw values, in dBm. Null until the first sample.
+  final double? smoothedRssi;
+
+  /// The most recent raw value, in dBm. Shown only as a diagnostic.
+  final int? rawRssi;
+
+  /// 0..1 for a signal-strength bar. Maps the useful RSSI band (-95..-45 dBm)
+  /// onto the unit interval; deliberately NOT presented as distance.
+  double? get strength {
+    final s = smoothedRssi;
+    if (s == null) return null;
+    const worst = -95.0;
+    const best = -45.0;
+    final t = (s - worst) / (best - worst);
+    return t < 0 ? 0.0 : (t > 1 ? 1.0 : t);
+  }
+}
+
+/// Stateful across samples, but pure: no clock, no I/O, no BLE dependency.
+class ProximityTracker {
+  ProximityTracker({
+    this.alpha = 0.35,
+    this.hysteresisDb = 3.0,
+    this.trendDeadbandDb = 2.0,
+    this.trendLookback = 4,
+  });
+
+  /// EWMA weight for each new sample. 0.35 settles in roughly five reads —
+  /// responsive enough to feel live at ~1.5 Hz polling, damped enough that one
+  /// multipath dropout does not jump the label.
+  final double alpha;
+
+  /// A zone boundary must be crossed by this much before the label changes.
+  /// Without it, a signal sitting exactly on a threshold flickers continuously.
+  final double hysteresisDb;
+
+  /// Movement smaller than this is called steady rather than warmer/colder.
+  final double trendDeadbandDb;
+
+  /// How many samples back the trend compares against. Too short and the trend
+  /// is noise; too long and it lags behind you as you walk.
+  final int trendLookback;
+
+  double? _ewma;
+  int? _lastRaw;
+  int _samples = 0;
+  ProximityZone _zone = ProximityZone.unknown;
+  final List<double> _history = [];
+
+  /// Last three RAW samples, for the median prefilter below.
+  final List<int> _rawWindow = [];
+
+  /// Zone lower bounds in dBm, strongest first. Values are the conventional
+  /// BLE proximity bands; they are coarse by design.
+  static const _bounds = <(ProximityZone, double)>[
+    (ProximityZone.immediate, -60.0),
+    (ProximityZone.near, -75.0),
+    (ProximityZone.far, -88.0),
+  ];
+
+  /// Fold in one RSSI reading (dBm, negative).
+  ProximityReading add(int rssi) {
+    _lastRaw = rssi;
+    _samples++;
+
+    // MEDIAN-OF-3 PREFILTER, ahead of the EWMA. An EWMA alone cannot survive
+    // impulse noise: at alpha 0.35 a single -100 dBm dropout (a hand over the
+    // band, a multipath null — both common while hunting) drags the average
+    // 15 dB in one step, which is enough to repaint the zone and send the user
+    // walking the wrong way. A median of the last three RAW samples removes a
+    // lone outlier completely while letting any change that persists for two
+    // samples through, which is exactly the distinction we want. Below three
+    // samples it passes through, so the very first reads still respond
+    // immediately instead of sitting inert.
+    _rawWindow.add(rssi);
+    if (_rawWindow.length > 3) _rawWindow.removeAt(0);
+    final filtered = _rawWindow.length < 3
+        ? rssi.toDouble()
+        : (List<int>.from(_rawWindow)..sort())[1].toDouble();
+
+    final prev = _ewma;
+    _ewma = prev == null ? filtered : prev + alpha * (filtered - prev);
+
+    _history.add(_ewma!);
+    if (_history.length > trendLookback + 1) _history.removeAt(0);
+
+    _zone = _zoneFor(_ewma!, _zone);
+    return ProximityReading(
+      zone: _samples >= _minSamplesForZone ? _zone : ProximityZone.unknown,
+      trend: _trend(),
+      samples: _samples,
+      smoothedRssi: _ewma,
+      rawRssi: _lastRaw,
+    );
+  }
+
+  /// Current state without folding in a new sample.
+  ProximityReading get current => ProximityReading(
+        zone: _samples >= _minSamplesForZone ? _zone : ProximityZone.unknown,
+        trend: _trend(),
+        samples: _samples,
+        smoothedRssi: _ewma,
+        rawRssi: _lastRaw,
+      );
+
+  /// Forget everything — call when the hunt restarts or the link drops, so a
+  /// stale EWMA from the last session cannot seed the new one.
+  void reset() {
+    _ewma = null;
+    _lastRaw = null;
+    _samples = 0;
+    _zone = ProximityZone.unknown;
+    _history.clear();
+    _rawWindow.clear();
+  }
+
+  /// One sample is not a zone: the first read is as likely to be a multipath
+  /// null as the truth.
+  static const int _minSamplesForZone = 3;
+
+  /// Hysteresis in both directions: to move to a STRONGER zone the value must
+  /// clear that zone's floor by [hysteresisDb]; to fall to a weaker one it must
+  /// drop below the current zone's floor by the same margin. Between those it
+  /// holds whatever it already showed.
+  ProximityZone _zoneFor(double v, ProximityZone currentZone) {
+    final bare = _bareZone(v);
+    if (currentZone == ProximityZone.unknown) return bare;
+    final bareIdx = _index(bare);
+    final curIdx = _index(currentZone);
+    if (bareIdx == curIdx) return currentZone;
+
+    if (bareIdx < curIdx) {
+      // Candidate is a stronger zone — require clearing its floor by the margin.
+      final floor = _floorOf(bare);
+      return floor == null || v >= floor + hysteresisDb ? bare : currentZone;
+    }
+    // Candidate is weaker — require dropping below the CURRENT floor by margin.
+    final curFloor = _floorOf(currentZone);
+    return curFloor == null || v <= curFloor - hysteresisDb ? bare : currentZone;
+  }
+
+  static ProximityZone _bareZone(double v) {
+    for (final (zone, floor) in _bounds) {
+      if (v >= floor) return zone;
+    }
+    return ProximityZone.veryFar;
+  }
+
+  static double? _floorOf(ProximityZone z) {
+    for (final (zone, floor) in _bounds) {
+      if (zone == z) return floor;
+    }
+    return null; // veryFar / unknown have no floor
+  }
+
+  static int _index(ProximityZone z) => switch (z) {
+        ProximityZone.immediate => 0,
+        ProximityZone.near => 1,
+        ProximityZone.far => 2,
+        ProximityZone.veryFar => 3,
+        ProximityZone.unknown => 4,
+      };
+
+  ProximityTrend _trend() {
+    if (_history.length <= trendLookback) return ProximityTrend.unknown;
+    final delta = _history.last - _history.first;
+    if (delta.abs() < trendDeadbandDb) return ProximityTrend.steady;
+    return delta > 0 ? ProximityTrend.warmer : ProximityTrend.colder;
+  }
+}
+
+/// Display strings, kept beside the model so wording and thresholds stay in
+/// step. Deliberately about signal, never about metres.
+extension ProximityZoneLabel on ProximityZone {
+  String get label => switch (this) {
+        ProximityZone.immediate => 'Right here',
+        ProximityZone.near => 'Close by',
+        ProximityZone.far => 'Somewhere around',
+        ProximityZone.veryFar => 'Faint signal',
+        ProximityZone.unknown => 'Listening…',
+      };
+
+  String get hint => switch (this) {
+        ProximityZone.immediate =>
+          'Within arm\'s reach — check the bedding, pockets and under cushions.',
+        ProximityZone.near => 'You\'re in the right area. Sweep slowly.',
+        ProximityZone.far => 'Try another part of the room, or the next one.',
+        ProximityZone.veryFar =>
+          'Barely in range. Walk around and watch for the signal to climb.',
+        ProximityZone.unknown => 'Getting a fix on the signal…',
+      };
+}
+
+extension ProximityTrendLabel on ProximityTrend {
+  String get label => switch (this) {
+        ProximityTrend.warmer => 'Warmer',
+        ProximityTrend.colder => 'Colder',
+        ProximityTrend.steady => 'Steady',
+        ProximityTrend.unknown => '',
+      };
+}

--- a/lib/notify/battery_forecast.dart
+++ b/lib/notify/battery_forecast.dart
@@ -289,17 +289,19 @@ class BatteryForecaster {
   /// DateTime. Minutes-from-midnight in, absolute instant out — kept here so
   /// the wrap-past-midnight arithmetic is unit-tested rather than inlined at
   /// the call site.
+  ///
+  /// Rolls to tomorrow via the DateTime CONSTRUCTOR, never `add(Duration(days:
+  /// 1))`. A Duration is absolute elapsed time, so across a DST boundary
+  /// "+24 h" lands an hour either side of the wall-clock time the user actually
+  /// set — which would then skew hours-to-wake and the projection built on it.
+  /// The constructor normalises a day overflow (day 32 → the 1st) while keeping
+  /// the wall-clock hour fixed, which is the property that matters here.
   static DateTime nextWakeTime(DateTime now, int wakeMinuteOfDay) {
-    final today = DateTime(
-      now.year,
-      now.month,
-      now.day,
-      wakeMinuteOfDay ~/ 60,
-      wakeMinuteOfDay % 60,
-    );
-    return today.isAfter(now)
-        ? today
-        : today.add(const Duration(days: 1));
+    final h = wakeMinuteOfDay ~/ 60;
+    final m = wakeMinuteOfDay % 60;
+    final today = DateTime(now.year, now.month, now.day, h, m);
+    if (today.isAfter(now)) return today;
+    return DateTime(now.year, now.month, now.day + 1, h, m);
   }
 
   /// True when [nowMinuteOfDay] sits in the run-up to bedtime.
@@ -327,6 +329,12 @@ class BatteryForecaster {
 
   /// Human-readable one-liner for the notification body. Kept next to the model
   /// so the numbers and the words can never drift apart.
+  /// The "before you wake" clause is CONDITIONAL on the forecast actually
+  /// saying so, rather than assumed. Today the only caller gates on
+  /// [willNotSurvive] first, so the claim happens to hold — but a function
+  /// whose text asserts an invariant it never checks is one refactor away from
+  /// lying, and a UI surface showing a survivable forecast is the obvious next
+  /// caller. Check it here instead of relying on where it is called from.
   static String describe(BatteryForecast f, {required DateTime wakeAt}) {
     final rate = f.drainPctPerHour;
     final pct = f.currentPct;
@@ -334,8 +342,10 @@ class BatteryForecaster {
     if (rate == null || pct == null || empty == null) return '';
     final h = empty.hour.toString().padLeft(2, '0');
     final m = empty.minute.toString().padLeft(2, '0');
-    return 'At ${rate.toStringAsFixed(1)}%/h it runs out around $h:$m — '
-        'before you wake. Charge it now to keep tonight\'s sleep.';
+    final head = 'At ${rate.toStringAsFixed(1)}%/h it runs out around $h:$m';
+    return empty.isBefore(wakeAt)
+        ? '$head — before you wake. Charge it now to keep tonight\'s sleep.'
+        : '$head, after your usual wake time.';
   }
 
   /// Whole hours remaining at the current rate, for compact UI. Null when the

--- a/lib/notify/battery_forecast.dart
+++ b/lib/notify/battery_forecast.dart
@@ -1,0 +1,348 @@
+// battery_forecast.dart — will the band still be alive when you wake up?
+//
+// WHY THIS EXISTS
+// A band that dies at 03:00 does not cost you a battery bar; it costs the whole
+// night. Sleep is the one block this app cannot reconstruct from anything else:
+// no nocturnal HRV, no sleep stages, no recovery score in the morning, and a
+// hole in the rolling baselines that quietly degrades every baseline-relative
+// metric for days afterwards. The band already reports battery every few
+// minutes and we already persist it (`band_battery`), so the information needed
+// to say "charge it now" at dinner time has been sitting on disk unused.
+//
+// WHAT THIS IS NOT
+// It is not a fuel gauge and it does not model the pack. It answers one narrow
+// question — at the rate you have ACTUALLY been discharging over the last few
+// hours, where do you land at wake time? — and it abstains loudly the moment
+// that question is not answerable. A wrong "you're fine" is worse than silence,
+// because silence still lets the user look at the battery number themselves.
+//
+// ESTIMATOR
+// Theil–Sen: the median of all pairwise slopes (Theil 1950; Sen 1968). Chosen
+// over least squares because the input is quantised percentage points sampled
+// at irregular intervals, so a single stuck or rounded reading drags an OLS fit
+// noticeably; the median of slopes ignores it. It also degrades honestly — with
+// too few points the median is simply not computed and we abstain.
+
+import 'dart:math' as math;
+
+/// One battery observation from `band_battery`.
+class BatterySample {
+  const BatterySample({
+    required this.tsSec,
+    required this.pct,
+    required this.charging,
+  });
+
+  /// Unix seconds (the table's `ts`).
+  final int tsSec;
+
+  /// Battery percentage 0–100 (the table's `battery_pct`).
+  final double pct;
+
+  /// True while on the charger (the table's `charging`).
+  final bool charging;
+}
+
+/// Why a forecast could not be made. Mirrors the analytics convention of a
+/// machine-readable note rather than a silent null.
+class ForecastNote {
+  static const charging = 'charging';
+  static const notDraining = 'not_draining';
+  static const rateImplausible = 'rate_implausible';
+
+  /// `need_history:have=H,need=N` — same shape as the analytics cold-start
+  /// note, so the two read alike in logs and diagnostics.
+  static String needHistory(int have, int need) => 'need_history:have=$have,need=$need';
+
+  /// `need_span:have=Hm,need=Nm` — enough samples, but over too short a window
+  /// to trust a slope through them.
+  static String needSpan(Duration have, Duration need) =>
+      'need_span:have=${have.inMinutes}m,need=${need.inMinutes}m';
+}
+
+/// The forecast. Every numeric field is null when unknown — never a guess.
+class BatteryForecast {
+  const BatteryForecast({
+    required this.samplesUsed,
+    required this.spanUsed,
+    this.drainPctPerHour,
+    this.currentPct,
+    this.predictedPctAtWake,
+    this.predictedEmptyAt,
+    this.note,
+  });
+
+  /// Abstention with a reason and no numbers.
+  const BatteryForecast.abstain(
+    String reason, {
+    this.samplesUsed = 0,
+    this.spanUsed = Duration.zero,
+  })  : drainPctPerHour = null,
+        currentPct = null,
+        predictedPctAtWake = null,
+        predictedEmptyAt = null,
+        note = reason;
+
+  /// Points in the discharge run the estimate was built from.
+  final int samplesUsed;
+
+  /// Wall-clock covered by that run.
+  final Duration spanUsed;
+
+  /// Percentage points lost per hour. Always > 0 when present.
+  final double? drainPctPerHour;
+
+  /// Most recent observed battery percentage.
+  final double? currentPct;
+
+  /// Where the current rate lands at the wake time passed in. May be negative —
+  /// that is meaningful ("it runs out well before then") and is deliberately not
+  /// clamped to zero, so callers can see the size of the shortfall.
+  final double? predictedPctAtWake;
+
+  /// When the current rate reaches 0%.
+  final DateTime? predictedEmptyAt;
+
+  /// Abstention reason, or null on a usable forecast.
+  final String? note;
+
+  bool get isUsable => drainPctPerHour != null;
+}
+
+/// Pure, I/O-free battery projection. No database, no clock of its own — the
+/// caller passes `now`, which is what makes every branch testable.
+class BatteryForecaster {
+  const BatteryForecaster({
+    this.minSamples = 4,
+    this.minSpan = const Duration(hours: 2),
+    this.maxSampleAge = const Duration(hours: 48),
+    this.maxPlausibleDrainPctPerHour = 25.0,
+    this.reservePct = 5.0,
+  });
+
+  /// Fewer points than this and the median slope is not meaningful.
+  final int minSamples;
+
+  /// A slope through samples spanning less than this is dominated by the 1%
+  /// quantisation of the reading itself.
+  final Duration minSpan;
+
+  /// Ignore anything older — a week-old discharge rate says nothing about
+  /// tonight's, and wear patterns change.
+  final Duration maxSampleAge;
+
+  /// Above this, treat the slope as an artefact (a pack reset, a bad sample,
+  /// a firmware quirk) rather than a real discharge rate.
+  final double maxPlausibleDrainPctPerHour;
+
+  /// Land above this and we call it survivable. Not zero: a band at 1% has
+  /// effectively already failed, and the estimate has real error bars.
+  final double reservePct;
+
+  /// Project the battery forward to [wakeAt].
+  ///
+  /// [samples] may be in any order and may span charge cycles; only the CURRENT
+  /// uninterrupted discharge run is used, because a rate measured across a
+  /// charge is not a rate at all.
+  BatteryForecast forecast({
+    required List<BatterySample> samples,
+    required DateTime now,
+    required DateTime wakeAt,
+  }) {
+    if (samples.isEmpty) {
+      return BatteryForecast.abstain(ForecastNote.needHistory(0, minSamples));
+    }
+
+    final nowSec = now.millisecondsSinceEpoch ~/ 1000;
+    final oldestAllowed = nowSec - maxSampleAge.inSeconds;
+
+    // Newest first, recent only.
+    final fresh = [
+      for (final s in samples)
+        if (s.tsSec >= oldestAllowed && s.tsSec <= nowSec) s,
+    ]..sort((a, b) => b.tsSec.compareTo(a.tsSec));
+
+    if (fresh.isEmpty) {
+      return BatteryForecast.abstain(ForecastNote.needHistory(0, minSamples));
+    }
+
+    // On the charger → the question is moot, and the slope would be positive.
+    if (fresh.first.charging) {
+      return BatteryForecast.abstain(ForecastNote.charging);
+    }
+
+    // Walk back through the current discharge run. It ends at the first sample
+    // that was charging, or where the battery was LOWER than the one after it
+    // (walking backwards, that means the level rose over time — a charge we
+    // never saw the `charging` flag for, e.g. a brief top-up between polls).
+    final run = <BatterySample>[fresh.first];
+    for (var i = 1; i < fresh.length; i++) {
+      final s = fresh[i];
+      if (s.charging) break;
+      // Compare against the MEDIAN of the last few accepted samples, not the
+      // single previous one. Walking backwards through a discharge the level
+      // should only rise, so a fall means a charge we never saw flagged — but
+      // one spuriously HIGH reading would otherwise make the next perfectly
+      // good sample look like that fall and truncate the run right there. The
+      // median ignores a lone bad point; a real charge moves all three.
+      if (s.pct < _medianOfTail(run) - _riseTolerancePct) break;
+      run.add(s);
+    }
+
+    if (run.length < minSamples) {
+      return BatteryForecast.abstain(
+        ForecastNote.needHistory(run.length, minSamples),
+        samplesUsed: run.length,
+      );
+    }
+
+    final span = Duration(seconds: run.first.tsSec - run.last.tsSec);
+    if (span < minSpan) {
+      return BatteryForecast.abstain(
+        ForecastNote.needSpan(span, minSpan),
+        samplesUsed: run.length,
+        spanUsed: span,
+      );
+    }
+
+    final rate = _theilSenDrainPctPerHour(run);
+    if (rate == null || rate <= 0) {
+      return BatteryForecast.abstain(
+        ForecastNote.notDraining,
+        samplesUsed: run.length,
+        spanUsed: span,
+      );
+    }
+    if (rate > maxPlausibleDrainPctPerHour) {
+      return BatteryForecast.abstain(
+        ForecastNote.rateImplausible,
+        samplesUsed: run.length,
+        spanUsed: span,
+      );
+    }
+
+    final currentPct = run.first.pct;
+    final hoursToWake = wakeAt.difference(now).inSeconds / 3600.0;
+    final predicted = currentPct - rate * hoursToWake;
+    final hoursToEmpty = currentPct / rate;
+
+    return BatteryForecast(
+      samplesUsed: run.length,
+      spanUsed: span,
+      drainPctPerHour: rate,
+      currentPct: currentPct,
+      predictedPctAtWake: predicted,
+      predictedEmptyAt:
+          now.add(Duration(seconds: (hoursToEmpty * 3600).round())),
+    );
+  }
+
+  /// True when this forecast says the band does not make it to wake with the
+  /// reserve intact. False for a usable forecast that survives — and false for
+  /// an abstention, because "we don't know" must never alarm.
+  bool willNotSurvive(BatteryForecast f) {
+    final p = f.predictedPctAtWake;
+    return p != null && p <= reservePct;
+  }
+
+  /// A battery reading only moves in whole percent, so a 1-point wobble between
+  /// consecutive polls is noise, not a charge event.
+  static const double _riseTolerancePct = 1.0;
+
+  /// Median of the last up-to-3 accepted samples in the run, used as the
+  /// reference level for charge detection.
+  static double _medianOfTail(List<BatterySample> run) {
+    final tail = run.length <= 3
+        ? [for (final s in run) s.pct]
+        : [for (final s in run.sublist(run.length - 3)) s.pct];
+    tail.sort();
+    final mid = tail.length ~/ 2;
+    return tail.length.isOdd ? tail[mid] : (tail[mid - 1] + tail[mid]) / 2.0;
+  }
+
+  /// Median of all pairwise slopes, in percentage points lost per hour.
+  /// Positive means discharging. Null when no pair is far enough apart in time
+  /// to give a finite slope.
+  static double? _theilSenDrainPctPerHour(List<BatterySample> run) {
+    final slopes = <double>[];
+    for (var i = 0; i < run.length; i++) {
+      for (var j = i + 1; j < run.length; j++) {
+        final dtHours = (run[i].tsSec - run[j].tsSec) / 3600.0;
+        if (dtHours.abs() < _minPairHours) continue;
+        // run[i] is newer than run[j]; discharging ⇒ pct fell ⇒ positive rate.
+        slopes.add((run[j].pct - run[i].pct) / dtHours);
+      }
+    }
+    if (slopes.isEmpty) return null;
+    slopes.sort();
+    final mid = slopes.length ~/ 2;
+    return slopes.length.isOdd
+        ? slopes[mid]
+        : (slopes[mid - 1] + slopes[mid]) / 2.0;
+  }
+
+  /// Pairs closer together than this produce a slope dominated by quantisation
+  /// (1% over 30 s reads as 120%/h), so they are excluded from the median.
+  static const double _minPairHours = 0.25;
+
+  /// The next occurrence of the user's wake time (quiet-hours end), as a local
+  /// DateTime. Minutes-from-midnight in, absolute instant out — kept here so
+  /// the wrap-past-midnight arithmetic is unit-tested rather than inlined at
+  /// the call site.
+  static DateTime nextWakeTime(DateTime now, int wakeMinuteOfDay) {
+    final today = DateTime(
+      now.year,
+      now.month,
+      now.day,
+      wakeMinuteOfDay ~/ 60,
+      wakeMinuteOfDay % 60,
+    );
+    return today.isAfter(now)
+        ? today
+        : today.add(const Duration(days: 1));
+  }
+
+  /// True when [nowMinuteOfDay] sits in the run-up to bedtime.
+  ///
+  /// The warning is only worth firing while it is still ACTIONABLE — you are
+  /// awake, near a charger, and have time to act. Telling someone at 02:00 that
+  /// their band died an hour ago is a notification that wakes them for nothing;
+  /// telling them at 09:00 that tonight might be tight is noise they will have
+  /// forgotten by evening. Both ends of the window matter, and the arithmetic
+  /// wraps midnight (a 01:00 bedtime means a 21:00–01:00 window), which is
+  /// exactly the kind of thing worth a test rather than an inline expression.
+  static bool inEveningWindow(
+    int nowMinuteOfDay,
+    int bedtimeMinuteOfDay, {
+    int leadMinutes = 240,
+  }) {
+    const day = 1440;
+    final start = (bedtimeMinuteOfDay - leadMinutes) % day;
+    final end = bedtimeMinuteOfDay % day;
+    if (start == end) return true; // a full-day lead — degenerate but defined
+    return start < end
+        ? (nowMinuteOfDay >= start && nowMinuteOfDay < end)
+        : (nowMinuteOfDay >= start || nowMinuteOfDay < end);
+  }
+
+  /// Human-readable one-liner for the notification body. Kept next to the model
+  /// so the numbers and the words can never drift apart.
+  static String describe(BatteryForecast f, {required DateTime wakeAt}) {
+    final rate = f.drainPctPerHour;
+    final pct = f.currentPct;
+    final empty = f.predictedEmptyAt;
+    if (rate == null || pct == null || empty == null) return '';
+    final h = empty.hour.toString().padLeft(2, '0');
+    final m = empty.minute.toString().padLeft(2, '0');
+    return 'At ${rate.toStringAsFixed(1)}%/h it runs out around $h:$m — '
+        'before you wake. Charge it now to keep tonight\'s sleep.';
+  }
+
+  /// Whole hours remaining at the current rate, for compact UI. Null when the
+  /// forecast abstained.
+  static int? hoursRemaining(BatteryForecast f, DateTime now) {
+    final empty = f.predictedEmptyAt;
+    if (empty == null) return null;
+    return math.max(0, empty.difference(now).inMinutes) ~/ 60;
+  }
+}

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -46,6 +46,7 @@ import '../gps/gps_source.dart';
 import '../gps/route_tracker.dart';
 import '../gps/screen_wake.dart';
 import '../data/local_repository_impl.dart';
+import '../notify/battery_forecast.dart';
 import '../notify/notification_center.dart';
 import '../notify/notification_event.dart';
 import '../notify/notification_prefs.dart';
@@ -179,6 +180,12 @@ class AppState extends ChangeNotifier {
   bool? _widgetBattCharging;
   String? _widgetBattName;
   int? _storedBatteryPct;
+
+  /// Last time the overnight battery forecast ran. `_onEngineState` fires on
+  /// every device-state update, and the forecast reads a few hundred rows, so
+  /// it is throttled rather than run per tick. The user-visible fire-once
+  /// guarantee comes from the dedupeKey, not from this.
+  DateTime? _lastBatteryForecastAt;
   bool? _storedBatteryCharging;
   bool? _storedBatteryWristOn;
   bool initialized = false;
@@ -1939,6 +1946,70 @@ class AppState extends ChangeNotifier {
     }
   }
 
+  /// "Charge it now or lose tonight" — the one battery warning that is about
+  /// DATA rather than about the battery.
+  ///
+  /// A band that dies at 03:00 costs the whole night: no nocturnal HRV, no
+  /// stages, no recovery score in the morning, and a hole in the rolling
+  /// baselines that quietly degrades baseline-relative metrics for days. The
+  /// band has been reporting battery every few minutes and we have been
+  /// persisting it all along, so the drain rate needed to see this coming was
+  /// already on disk.
+  ///
+  /// Deliberately conservative. It fires only in the evening run-up to bedtime
+  /// (while there is still time to act), only when the projection actually
+  /// lands under the reserve, and never on an abstention — an unknown rate must
+  /// stay silent, because the user can always read the battery number
+  /// themselves and a false "you're fine" is worse than no message at all.
+  Future<void> _maybeWarnOvernightBattery() async {
+    try {
+      final now = DateTime.now();
+      final last = _lastBatteryForecastAt;
+      if (last != null && now.difference(last) < const Duration(minutes: 15)) {
+        return;
+      }
+      _lastBatteryForecastAt = now;
+
+      final prefs = await NotificationPrefs.load();
+      final nowMin = now.hour * 60 + now.minute;
+      if (!BatteryForecaster.inEveningWindow(nowMin, prefs.quietStartMin)) {
+        return;
+      }
+
+      final rows = await LocalDb.recentBandBatterySamples(limit: 400);
+      final samples = <BatterySample>[
+        for (final r in rows)
+          if (r['battery_pct'] != null && r['ts'] != null)
+            BatterySample(
+              tsSec: (r['ts'] as num).toInt(),
+              pct: (r['battery_pct'] as num).toDouble(),
+              charging: (r['charging'] as num?)?.toInt() == 1,
+            ),
+      ];
+
+      const forecaster = BatteryForecaster();
+      final wakeAt = BatteryForecaster.nextWakeTime(now, prefs.quietEndMin);
+      final f = forecaster.forecast(samples: samples, now: now, wakeAt: wakeAt);
+      if (!forecaster.willNotSurvive(f)) return;
+
+      final day = todayLabel(now);
+      await NotificationCenter.instance.emit(
+        NotificationEvent(
+          dedupeKey: '$day:battery_overnight',
+          category: NotifCategory.device,
+          title: 'Charge your strap before bed',
+          body: BatteryForecaster.describe(f, wakeAt: wakeAt),
+          date: day,
+          route: '/profile',
+        ),
+      );
+    } catch (e) {
+      // A forecast is a nicety; it must never take down the state update that
+      // carries the actual band data.
+      _log('[battery-forecast] skipped: $e');
+    }
+  }
+
   void _onEngineState(DeviceState s) {
     // Battery-low / charging OS notifications (edge-triggered + de-duped inside).
     _deviceAlerts.onDeviceState(batteryPct: s.batteryPct, charging: s.charging);
@@ -1960,6 +2031,9 @@ class AppState extends ChangeNotifier {
         ),
       );
     }
+    // A fresh battery reading is exactly when the overnight forecast is worth
+    // re-running — and only then, so this costs nothing on idle ticks.
+    unawaited(_maybeWarnOvernightBattery());
     // Heal a stale/garbled persisted serial: once the band reports a clean serial
     // (HELLO body, fixed offset), persist it so the disconnected display stops
     // showing any old "?*" junk left by a previous build. HEAL ONLY — see
@@ -2337,6 +2411,23 @@ class AppState extends ChangeNotifier {
     if (!isConnected) throw Exception('Connect to your strap first');
     await engine.buzzPattern(pattern);
   }
+
+  /// Pulse the strap so it can be heard/felt during a find-my-strap hunt.
+  /// Unlike [testAlarmBuzz] this NEVER throws — the hunt screen fires it on a
+  /// timer and a momentary disconnect must not surface as an error dialog.
+  Future<void> buzzBand() async {
+    if (!isConnected) return;
+    try {
+      await engine.buzz();
+    } catch (_) {
+      // Best-effort by design: the next tick will try again.
+    }
+  }
+
+  /// Live signal strength of the band in dBm, or null when unmeasurable.
+  /// Deliberately raw — all smoothing and labelling belongs to
+  /// ProximityTracker, which is testable without a radio.
+  Future<int?> readBandRssi() => engine.readRssi();
 
   Future<void> disableAlarm() async {
     if (!isConnected) throw Exception('Connect to your strap first');

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1968,13 +1968,18 @@ class AppState extends ChangeNotifier {
       if (last != null && now.difference(last) < const Duration(minutes: 15)) {
         return;
       }
-      _lastBatteryForecastAt = now;
 
       final prefs = await NotificationPrefs.load();
       final nowMin = now.hour * 60 + now.minute;
       if (!BatteryForecaster.inEveningWindow(nowMin, prefs.quietStartMin)) {
         return;
       }
+      // Stamped only once the cheap checks have PASSED, so the throttle governs
+      // the expensive work (a few hundred rows off `band_battery`) rather than
+      // the clock check. Stamping earlier meant a tick that arrived just before
+      // the evening window opened would push the first real forecast back by up
+      // to another 15 minutes for no reason.
+      _lastBatteryForecastAt = now;
 
       final rows = await LocalDb.recentBandBatterySamples(limit: 400);
       final samples = <BatterySample>[

--- a/lib/ui/find/find_band_screen.dart
+++ b/lib/ui/find/find_band_screen.dart
@@ -1,0 +1,246 @@
+// find_band_screen.dart — the hunt. Buzz the band and follow the signal.
+//
+// The band is small, dark and silent, and it comes off in bed, in a gym bag, or
+// beside a charger. Every other device you own can be made to announce itself;
+// this one could too, and the two pieces needed have been sitting there all
+// along — a haptic motor we can fire on command, and an RSSI we never read.
+//
+// HONESTY, because this screen is one long temptation to fake precision:
+// RSSI is not distance. Converting it to metres needs a calibrated TX power and
+// a free-space assumption, and a band down the side of a mattress breaks the
+// assumption completely — the number would be confident and wrong, which is the
+// one thing this app does not do. So the screen shows a coarse zone, a
+// warmer/colder trend and a relative bar, and says plainly what it is.
+//
+// Presentation only: the smoothing, the zone thresholds and the hysteresis all
+// live in ProximityTracker, which is unit-tested without a radio.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../ble/proximity_policy.dart';
+import '../../state/app_state.dart';
+import '../design/design.dart';
+
+class FindBandScreen extends StatefulWidget {
+  const FindBandScreen({super.key});
+
+  @override
+  State<FindBandScreen> createState() => _FindBandScreenState();
+}
+
+class _FindBandScreenState extends State<FindBandScreen> {
+  /// ~1.4 Hz. Fast enough to feel live as you sweep a room, slow enough that
+  /// each GATT read comfortably completes before the next is due.
+  static const _pollInterval = Duration(milliseconds: 700);
+
+  /// Auto-buzz cadence. Long enough to locate the sound between pulses.
+  static const _buzzInterval = Duration(seconds: 3);
+
+  final _tracker = ProximityTracker();
+  Timer? _poll;
+  Timer? _buzzer;
+  ProximityReading _reading = const ProximityReading(
+    zone: ProximityZone.unknown,
+    trend: ProximityTrend.unknown,
+    samples: 0,
+  );
+  bool _autoBuzz = true;
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _start();
+  }
+
+  @override
+  void dispose() {
+    _poll?.cancel();
+    _buzzer?.cancel();
+    super.dispose();
+  }
+
+  void _start() {
+    _poll?.cancel();
+    _buzzer?.cancel();
+    _poll = Timer.periodic(_pollInterval, (_) => _tick());
+    if (_autoBuzz) {
+      _buzzer = Timer.periodic(_buzzInterval, (_) => _buzz());
+    }
+    _tick();
+    _buzz();
+  }
+
+  Future<void> _tick() async {
+    // A read can outlive its timer tick on a marginal link; skipping is better
+    // than queueing reads behind each other.
+    if (_busy || !mounted) return;
+    _busy = true;
+    try {
+      final app = context.read<AppState>();
+      final rssi = await app.readBandRssi();
+      if (!mounted) return;
+      if (rssi == null) {
+        // Link gone: drop the stale EWMA so a reconnect starts clean rather
+        // than blending the old room's signal into the new one.
+        _tracker.reset();
+        setState(() => _reading = _tracker.current);
+        return;
+      }
+      setState(() => _reading = _tracker.add(rssi));
+    } finally {
+      _busy = false;
+    }
+  }
+
+  Future<void> _buzz() async {
+    if (!mounted) return;
+    final app = context.read<AppState>();
+    if (!app.isConnected) return;
+    await app.buzzBand();
+  }
+
+  void _toggleAutoBuzz(bool v) {
+    setState(() => _autoBuzz = v);
+    _buzzer?.cancel();
+    if (v) {
+      _buzzer = Timer.periodic(_buzzInterval, (_) => _buzz());
+      _buzz();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final connected = context.select<AppState, bool>((a) => a.isConnected);
+    return FindBandView(
+      connected: connected,
+      reading: _reading,
+      autoBuzz: _autoBuzz,
+      onBuzzNow: _buzz,
+      onAutoBuzzChanged: _toggleAutoBuzz,
+      onBack: () => Navigator.of(context).maybePop(),
+    );
+  }
+}
+
+/// The pure board — plain values in, no AppState, so it can be widget-tested
+/// for every state including the ones that are hard to produce on real radio.
+class FindBandView extends StatelessWidget {
+  const FindBandView({
+    super.key,
+    required this.connected,
+    required this.reading,
+    this.autoBuzz = true,
+    this.onBuzzNow,
+    this.onAutoBuzzChanged,
+    this.onBack,
+  });
+
+  final bool connected;
+  final ProximityReading reading;
+  final bool autoBuzz;
+  final VoidCallback? onBuzzNow;
+  final ValueChanged<bool>? onAutoBuzzChanged;
+  final VoidCallback? onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    final t = Theme.of(context);
+    return AppScaffold(
+      title: 'Find my strap',
+      subtitle: connected ? 'Buzzing and tracking the signal' : 'Not connected',
+      onBack: onBack,
+      actions: [
+        InfoDot(
+          title: 'How this works',
+          body: 'Your strap buzzes while the phone measures how strong its '
+              'Bluetooth signal is. Stronger usually means closer.\n\n'
+              'This is signal strength, not distance — we deliberately don\'t '
+              'show metres. Walls, bedding and your own body all weaken the '
+              'signal, so a strap under a duvet two feet away can read weaker '
+              'than one across an empty room. Walk slowly and follow '
+              '"warmer".',
+        ),
+      ],
+      children: connected
+          ? _hunting(context, t)
+          : [const _Disconnected()],
+    );
+  }
+
+  List<Widget> _hunting(BuildContext context, ThemeData t) {
+    final strength = reading.strength;
+    return [
+      Center(
+        child: ArcGauge(
+          value: strength ?? double.nan,
+          size: 200,
+          valueText: reading.zone.label,
+          label: reading.trend.label.isEmpty ? null : reading.trend.label,
+        ),
+      ),
+      const SizedBox(height: 16),
+      SurfaceCard(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(reading.zone.hint, style: t.textTheme.bodyMedium),
+            if (reading.smoothedRssi != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                'Signal ${reading.smoothedRssi!.toStringAsFixed(0)} dBm',
+                style: t.textTheme.bodySmall,
+              ),
+            ],
+          ],
+        ),
+      ),
+      const SizedBox(height: 12),
+      SurfaceCard(
+        child: Column(
+          children: [
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              value: autoBuzz,
+              onChanged: onAutoBuzzChanged,
+              title: const Text('Keep buzzing'),
+              subtitle: const Text('A pulse every few seconds while you look'),
+            ),
+            const SizedBox(height: 4),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: onBuzzNow,
+                icon: const Icon(Icons.vibration),
+                label: const Text('Buzz now'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ];
+  }
+}
+
+class _Disconnected extends StatelessWidget {
+  const _Disconnected();
+
+  @override
+  Widget build(BuildContext context) {
+    // Said plainly rather than dressed up as a spinner: the hunt needs the
+    // link for BOTH halves — buzzing it and measuring it — so a strap we
+    // cannot reach is one this screen genuinely cannot help with. Better to
+    // explain that than to show a hopeful empty gauge forever.
+    return const StateCard(
+      icon: OsIcon.bluetooth,
+      title: 'Can\'t reach your strap',
+      message: 'Finding it needs a live connection — that\'s how we buzz it '
+          'and how we measure the signal.\n\nIf it\'s in range it should '
+          'reconnect on its own in a moment. If nothing happens it\'s probably '
+          'out of range, out of battery, or still connected to another phone.',
+    );
+  }
+}

--- a/lib/ui/profile/profile_screen.dart
+++ b/lib/ui/profile/profile_screen.dart
@@ -23,6 +23,7 @@ import '../../state/units_controller.dart';
 import '../../debug/debug_mode.dart';
 import '../../telemetry/health_uploader.dart' show kHealthDataContributionEnabled;
 import '../../theme/theme_switcher.dart';
+import '../find/find_band_screen.dart';
 import '../ai/ai_settings_screen.dart';
 import '../coach/ai_coach_screen.dart';
 import '../design/design.dart';
@@ -1356,6 +1357,22 @@ class _DeviceSheet extends StatelessWidget {
           value: live.strapName ?? 'OpenStrap',
           divider: true,
           onTap: connected ? () => _rename(context, live) : null,
+        ),
+        ListRow(
+          icon: OsIcon.bluetooth,
+          title: 'Find my strap',
+          value: connected ? 'Buzz and track' : 'Needs a connection',
+          divider: true,
+          onTap: connected
+              ? () {
+                  Navigator.of(context).pop();
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const FindBandScreen(),
+                    ),
+                  );
+                }
+              : null,
         ),
         ListRow(
           icon: OsIcon.alarm,

--- a/test/battery_forecast_test.dart
+++ b/test/battery_forecast_test.dart
@@ -209,6 +209,35 @@ void main() {
       expect(w, DateTime(2026, 7, 29, 7, 0));
       expect(w.isAfter(n), isTrue);
     });
+
+    test('the WALL-CLOCK hour is preserved when rolling to tomorrow', () {
+      // This is the property DST breaks. `add(Duration(days: 1))` is absolute
+      // elapsed time, so across a transition it lands at 06:00 or 08:00 rather
+      // than the 07:00 the user set — and hours-to-wake, and everything built
+      // on it, shifts by an hour. Asserting the wall clock rather than the
+      // instant is what makes the constructor-vs-Duration distinction visible.
+      // (In a UTC test environment there is no transition to cross, so this
+      // pins the intent; the guarantee itself lives in the constructor.)
+      for (final month in [1, 3, 6, 10, 11]) {
+        final n = DateTime(2026, month, 28, 23, 30);
+        final w = BatteryForecaster.nextWakeTime(n, 7 * 60);
+        expect(w.hour, 7, reason: 'month $month');
+        expect(w.minute, 0, reason: 'month $month');
+        expect(w.isAfter(n), isTrue);
+      }
+    });
+
+    test('rolls correctly across a month end', () {
+      final n = DateTime(2026, 1, 31, 23, 0);
+      expect(BatteryForecaster.nextWakeTime(n, 7 * 60),
+          DateTime(2026, 2, 1, 7, 0));
+    });
+
+    test('rolls correctly across a year end', () {
+      final n = DateTime(2026, 12, 31, 23, 0);
+      expect(BatteryForecaster.nextWakeTime(n, 6 * 60 + 30),
+          DateTime(2027, 1, 1, 6, 30));
+    });
   });
 
   group('inEveningWindow — only warn while it is still actionable', () {
@@ -259,5 +288,27 @@ void main() {
       wakeAt: wake,
     );
     expect(BatteryForecaster.describe(real, wakeAt: wake), contains('%/h'));
+  });
+
+  test('describe() only claims "before you wake" when that is actually true',
+      () {
+    // Dies at ~07:30 on this rate — i.e. AFTER a 07:00 wake.
+    final survives = f.forecast(
+      samples: run(endPct: 40, ratePctPerHour: 2),
+      now: now,
+      wakeAt: wake,
+    );
+    expect(survives.predictedEmptyAt!.isAfter(wake), isTrue);
+    expect(BatteryForecaster.describe(survives, wakeAt: wake),
+        isNot(contains('before you wake')),
+        reason: 'the text must follow the numbers, not the call site');
+
+    final dies = f.forecast(
+      samples: run(endPct: 15, ratePctPerHour: 2),
+      now: now,
+      wakeAt: wake,
+    );
+    expect(BatteryForecaster.describe(dies, wakeAt: wake),
+        contains('before you wake'));
   });
 }

--- a/test/battery_forecast_test.dart
+++ b/test/battery_forecast_test.dart
@@ -1,0 +1,263 @@
+// Tests for the overnight battery forecast. The whole point of this policy is
+// that it abstains rather than guesses, so most of these assert SILENCE.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/notify/battery_forecast.dart';
+
+void main() {
+  const f = BatteryForecaster();
+
+  final now = DateTime(2026, 7, 28, 20, 0); // 20:00 local
+  final wake = DateTime(2026, 7, 29, 7, 0); // 07:00 next day → 11 h away
+  int secOf(DateTime d) => d.millisecondsSinceEpoch ~/ 1000;
+
+  /// A steady discharge run ending `now` at [endPct], losing [ratePctPerHour],
+  /// sampled every [everyMin] minutes over [hours].
+  List<BatterySample> run({
+    required double endPct,
+    required double ratePctPerHour,
+    double hours = 6,
+    int everyMin = 30,
+    bool charging = false,
+  }) {
+    final out = <BatterySample>[];
+    final steps = (hours * 60 / everyMin).round();
+    for (var i = 0; i <= steps; i++) {
+      final minsAgo = i * everyMin;
+      out.add(BatterySample(
+        tsSec: secOf(now.subtract(Duration(minutes: minsAgo))),
+        pct: endPct + ratePctPerHour * (minsAgo / 60.0),
+        charging: charging,
+      ));
+    }
+    return out;
+  }
+
+  group('abstains rather than guessing', () {
+    test('no samples at all', () {
+      final r = f.forecast(samples: const [], now: now, wakeAt: wake);
+      expect(r.isUsable, isFalse);
+      expect(r.drainPctPerHour, isNull);
+      expect(r.note, startsWith('need_history:'));
+    });
+
+    test('on the charger — the question is moot', () {
+      final r = f.forecast(
+        samples: run(endPct: 40, ratePctPerHour: 2, charging: true),
+        now: now,
+        wakeAt: wake,
+      );
+      expect(r.note, ForecastNote.charging);
+      expect(r.predictedPctAtWake, isNull);
+    });
+
+    test('too few samples in the run', () {
+      final r = f.forecast(
+        samples: run(endPct: 50, ratePctPerHour: 2, hours: 1, everyMin: 30),
+        now: now,
+        wakeAt: wake,
+      );
+      expect(r.isUsable, isFalse);
+      expect(r.note, startsWith('need_'));
+    });
+
+    test('enough samples but too short a span to trust a slope', () {
+      // 6 samples inside 30 minutes: plenty of points, no leverage.
+      final r = f.forecast(
+        samples: run(endPct: 50, ratePctPerHour: 2, hours: 0.5, everyMin: 6),
+        now: now,
+        wakeAt: wake,
+      );
+      expect(r.isUsable, isFalse);
+      expect(r.note, startsWith('need_span:'));
+    });
+
+    test('a flat battery series is not a drain rate', () {
+      final r = f.forecast(
+        samples: run(endPct: 80, ratePctPerHour: 0),
+        now: now,
+        wakeAt: wake,
+      );
+      expect(r.note, ForecastNote.notDraining);
+    });
+
+    test('an implausible rate is treated as an artefact, not a crisis', () {
+      final r = f.forecast(
+        samples: run(endPct: 10, ratePctPerHour: 60),
+        now: now,
+        wakeAt: wake,
+      );
+      expect(r.note, ForecastNote.rateImplausible);
+      expect(f.willNotSurvive(r), isFalse,
+          reason: 'an abstention must never raise an alarm');
+    });
+
+    test('stale samples are ignored entirely', () {
+      final old = [
+        for (var i = 0; i < 20; i++)
+          BatterySample(
+            tsSec: secOf(now.subtract(Duration(hours: 72 + i))),
+            pct: 90.0 - i,
+            charging: false,
+          ),
+      ];
+      final r = f.forecast(samples: old, now: now, wakeAt: wake);
+      expect(r.isUsable, isFalse);
+    });
+  });
+
+  group('projects a real discharge run', () {
+    test('a steady 2%/h run from 40% does not survive 11 hours', () {
+      final r = f.forecast(
+        samples: run(endPct: 40, ratePctPerHour: 2),
+        now: now,
+        wakeAt: wake,
+      );
+      expect(r.isUsable, isTrue);
+      expect(r.drainPctPerHour, closeTo(2.0, 0.15));
+      expect(r.currentPct, closeTo(40, 0.01));
+      // 40 − 2×11 = 18 … below zero? No: 18 is positive, so it SURVIVES.
+      expect(r.predictedPctAtWake, closeTo(18, 2));
+      expect(f.willNotSurvive(r), isFalse);
+    });
+
+    test('the same rate from 15% does not make it to morning', () {
+      final r = f.forecast(
+        samples: run(endPct: 15, ratePctPerHour: 2),
+        now: now,
+        wakeAt: wake,
+      );
+      expect(r.isUsable, isTrue);
+      expect(f.willNotSurvive(r), isTrue);
+      expect(r.predictedPctAtWake, lessThan(0),
+          reason: 'the shortfall is reported, not clamped to zero');
+      expect(r.predictedEmptyAt!.isBefore(wake), isTrue);
+    });
+
+    test('the empty-at time lands where the rate says it should', () {
+      final r = f.forecast(
+        samples: run(endPct: 20, ratePctPerHour: 4),
+        now: now,
+        wakeAt: wake,
+      );
+      // 20% at 4%/h ⇒ ~5 h ⇒ about 01:00.
+      expect(r.predictedEmptyAt!.difference(now).inMinutes, closeTo(300, 45));
+    });
+
+    test('a single stuck reading does not drag the estimate (Theil–Sen)', () {
+      final clean = run(endPct: 30, ratePctPerHour: 3);
+      final withOutlier = [...clean];
+      // Corrupt one mid-run sample by 25 points — an OLS fit would visibly tilt.
+      withOutlier[3] = BatterySample(
+        tsSec: withOutlier[3].tsSec,
+        pct: withOutlier[3].pct + 25,
+        charging: false,
+      );
+      final a = f.forecast(samples: clean, now: now, wakeAt: wake);
+      final b = f.forecast(samples: withOutlier, now: now, wakeAt: wake);
+      expect(b.drainPctPerHour, closeTo(a.drainPctPerHour!, 0.5));
+    });
+  });
+
+  group('run detection', () {
+    test('a charge event ends the run — the rate is measured after it only', () {
+      // Older: charging at a high level. Newer: a clean 3%/h discharge.
+      final recent = run(endPct: 55, ratePctPerHour: 3, hours: 5);
+      final older = [
+        for (var i = 1; i <= 10; i++)
+          BatterySample(
+            tsSec: secOf(now.subtract(Duration(hours: 5, minutes: i * 20))),
+            pct: 60 + i.toDouble(),
+            charging: true,
+          ),
+      ];
+      final r = f.forecast(
+        samples: [...recent, ...older],
+        now: now,
+        wakeAt: wake,
+      );
+      expect(r.isUsable, isTrue);
+      expect(r.drainPctPerHour, closeTo(3.0, 0.4),
+          reason: 'a rate measured across a charge is not a rate');
+      expect(r.samplesUsed, lessThanOrEqualTo(recent.length));
+    });
+
+    test('unordered input is handled', () {
+      final s = run(endPct: 25, ratePctPerHour: 2.5)..shuffle();
+      final r = f.forecast(samples: s, now: now, wakeAt: wake);
+      expect(r.isUsable, isTrue);
+      expect(r.drainPctPerHour, closeTo(2.5, 0.3));
+    });
+  });
+
+  group('nextWakeTime', () {
+    test('later today when the wake minute is still ahead', () {
+      final n = DateTime(2026, 7, 28, 5, 0);
+      final w = BatteryForecaster.nextWakeTime(n, 7 * 60);
+      expect(w, DateTime(2026, 7, 28, 7, 0));
+    });
+
+    test('tomorrow when it has already passed — the evening case', () {
+      final n = DateTime(2026, 7, 28, 21, 30);
+      final w = BatteryForecaster.nextWakeTime(n, 7 * 60);
+      expect(w, DateTime(2026, 7, 29, 7, 0));
+    });
+
+    test('exactly at the wake minute rolls to tomorrow, never zero-length', () {
+      final n = DateTime(2026, 7, 28, 7, 0);
+      final w = BatteryForecaster.nextWakeTime(n, 7 * 60);
+      expect(w, DateTime(2026, 7, 29, 7, 0));
+      expect(w.isAfter(n), isTrue);
+    });
+  });
+
+  group('inEveningWindow — only warn while it is still actionable', () {
+    const bed22 = 22 * 60;
+
+    test('fires in the run-up to a 22:00 bedtime', () {
+      expect(BatteryForecaster.inEveningWindow(19 * 60, bed22), isTrue);
+      expect(BatteryForecaster.inEveningWindow(21 * 60 + 59, bed22), isTrue);
+    });
+
+    test('silent in the middle of the night — waking you helps nobody', () {
+      expect(BatteryForecaster.inEveningWindow(2 * 60, bed22), isFalse);
+      expect(BatteryForecaster.inEveningWindow(4 * 60, bed22), isFalse);
+    });
+
+    test('silent in the morning — forgotten long before evening', () {
+      expect(BatteryForecaster.inEveningWindow(9 * 60, bed22), isFalse);
+      expect(BatteryForecaster.inEveningWindow(13 * 60, bed22), isFalse);
+    });
+
+    test('boundaries: inclusive at the start, exclusive at bedtime', () {
+      expect(BatteryForecaster.inEveningWindow(18 * 60, bed22), isTrue);
+      expect(BatteryForecaster.inEveningWindow(18 * 60 - 1, bed22), isFalse);
+      expect(BatteryForecaster.inEveningWindow(bed22, bed22), isFalse);
+    });
+
+    test('wraps midnight for a late bedtime (01:00 ⇒ 21:00–01:00)', () {
+      const bed1am = 60;
+      expect(BatteryForecaster.inEveningWindow(23 * 60, bed1am), isTrue);
+      expect(BatteryForecaster.inEveningWindow(30, bed1am), isTrue);
+      expect(BatteryForecaster.inEveningWindow(20 * 60, bed1am), isFalse);
+      expect(BatteryForecaster.inEveningWindow(2 * 60, bed1am), isFalse);
+    });
+
+    test('an early bedtime wraps the other way (21:00 for a 00:00 bed)', () {
+      expect(BatteryForecaster.inEveningWindow(22 * 60, 0), isTrue);
+      expect(BatteryForecaster.inEveningWindow(19 * 60, 0), isFalse);
+    });
+  });
+
+  test('describe() only speaks when there are numbers behind it', () {
+    final abstained = f.forecast(samples: const [], now: now, wakeAt: wake);
+    expect(BatteryForecaster.describe(abstained, wakeAt: wake), isEmpty);
+
+    final real = f.forecast(
+      samples: run(endPct: 15, ratePctPerHour: 2),
+      now: now,
+      wakeAt: wake,
+    );
+    expect(BatteryForecaster.describe(real, wakeAt: wake), contains('%/h'));
+  });
+}

--- a/test/find_band_view_test.dart
+++ b/test/find_band_view_test.dart
@@ -1,0 +1,110 @@
+// Widget tests for the find-my-strap board. FindBandView takes plain values,
+// so the states that are awkward to produce with a real radio (no link, a
+// faint signal, a warm trend) are all reachable here.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ble/proximity_policy.dart';
+import 'package:openstrap_edge/ui/find/find_band_screen.dart';
+
+void main() {
+  Widget wrap(Widget child) => MaterialApp(home: child);
+
+  ProximityReading reading({
+    ProximityZone zone = ProximityZone.near,
+    ProximityTrend trend = ProximityTrend.steady,
+    double? rssi = -70,
+    int samples = 10,
+  }) =>
+      ProximityReading(
+        zone: zone,
+        trend: trend,
+        samples: samples,
+        smoothedRssi: rssi,
+        rawRssi: rssi?.round(),
+      );
+
+  testWidgets('disconnected says so plainly instead of hunting forever',
+      (tester) async {
+    await tester.pumpWidget(wrap(
+      FindBandView(connected: false, reading: reading()),
+    ));
+    expect(find.textContaining('Can\'t reach your strap'), findsOneWidget);
+    expect(find.text('Buzz now'), findsNothing,
+        reason: 'buzzing needs the link the screen just said it lacks');
+  });
+
+  testWidgets('connected shows the zone label and the hunt controls',
+      (tester) async {
+    await tester.pumpWidget(wrap(
+      FindBandView(
+        connected: true,
+        reading: reading(zone: ProximityZone.immediate),
+      ),
+    ));
+    expect(find.text(ProximityZone.immediate.label), findsOneWidget);
+    expect(find.text('Buzz now'), findsOneWidget);
+    expect(find.text('Keep buzzing'), findsOneWidget);
+  });
+
+  testWidgets('the trend is surfaced as the warmer/colder cue', (tester) async {
+    await tester.pumpWidget(wrap(
+      FindBandView(
+        connected: true,
+        reading: reading(trend: ProximityTrend.warmer),
+      ),
+    ));
+    // The design system renders gauge sub-labels as uppercase overlines, so
+    // assert on the rendered form rather than the raw string.
+    expect(find.text(ProximityTrend.warmer.label.toUpperCase()), findsOneWidget);
+  });
+
+  testWidgets('signal is reported in dBm, never in metres', (tester) async {
+    await tester.pumpWidget(wrap(
+      FindBandView(connected: true, reading: reading(rssi: -63.4)),
+    ));
+    expect(find.textContaining('dBm'), findsOneWidget);
+    expect(find.textContaining(' m '), findsNothing);
+    expect(find.textContaining('metre'), findsNothing);
+  });
+
+  testWidgets('a warming-up reading renders without a fabricated signal',
+      (tester) async {
+    await tester.pumpWidget(wrap(
+      FindBandView(
+        connected: true,
+        reading: reading(
+          zone: ProximityZone.unknown,
+          trend: ProximityTrend.unknown,
+          rssi: null,
+          samples: 1,
+        ),
+      ),
+    ));
+    expect(find.text(ProximityZone.unknown.label), findsOneWidget);
+    expect(find.textContaining('dBm'), findsNothing,
+        reason: 'no smoothed value yet ⇒ no number shown at all');
+  });
+
+  testWidgets('buzz now and the auto-buzz toggle are wired', (tester) async {
+    var buzzes = 0;
+    bool? toggled;
+    await tester.pumpWidget(wrap(
+      FindBandView(
+        connected: true,
+        reading: reading(),
+        autoBuzz: true,
+        onBuzzNow: () => buzzes++,
+        onAutoBuzzChanged: (v) => toggled = v,
+      ),
+    ));
+
+    await tester.tap(find.text('Buzz now'));
+    await tester.pump();
+    expect(buzzes, 1);
+
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pump();
+    expect(toggled, isFalse);
+  });
+}

--- a/test/proximity_policy_test.dart
+++ b/test/proximity_policy_test.dart
@@ -1,0 +1,205 @@
+// Tests for the find-my-band proximity policy. RSSI is noisy enough that the
+// smoothing and the hysteresis ARE the feature — a raw reading would flicker
+// between labels several times a second while the phone sits still.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ble/proximity_policy.dart';
+
+void main() {
+  group('warm-up', () {
+    test('the first samples report unknown rather than a confident zone', () {
+      final t = ProximityTracker();
+      final first = t.add(-50);
+      expect(first.zone, ProximityZone.unknown,
+          reason: 'one read is as likely to be a multipath null as the truth');
+      t.add(-50);
+      final third = t.add(-50);
+      expect(third.zone, ProximityZone.immediate);
+    });
+
+    test('trend is unknown until there is enough history', () {
+      final t = ProximityTracker();
+      expect(t.add(-70).trend, ProximityTrend.unknown);
+      expect(t.current.smoothedRssi, -70);
+    });
+
+    test('current does not advance the sample count', () {
+      final t = ProximityTracker()..add(-60);
+      final a = t.current.samples;
+      final b = t.current.samples;
+      expect(a, b);
+      expect(a, 1);
+    });
+  });
+
+  group('zones', () {
+    ProximityTracker settled(int rssi) {
+      final t = ProximityTracker();
+      for (var i = 0; i < 20; i++) {
+        t.add(rssi);
+      }
+      return t;
+    }
+
+    test('a strong signal is immediate', () {
+      expect(settled(-45).current.zone, ProximityZone.immediate);
+    });
+
+    test('a mid signal is near', () {
+      expect(settled(-70).current.zone, ProximityZone.near);
+    });
+
+    test('a weak signal is far', () {
+      expect(settled(-83).current.zone, ProximityZone.far);
+    });
+
+    test('a very weak signal admits it is barely usable', () {
+      expect(settled(-95).current.zone, ProximityZone.veryFar);
+    });
+  });
+
+  group('smoothing', () {
+    test('one dropout does not move the label', () {
+      final t = ProximityTracker();
+      for (var i = 0; i < 15; i++) {
+        t.add(-55);
+      }
+      expect(t.current.zone, ProximityZone.immediate);
+
+      // A single catastrophic read — a hand over the band, a multipath null.
+      final after = t.add(-100);
+      expect(after.zone, ProximityZone.immediate,
+          reason: 'a lone bad sample must not throw the hunt off');
+    });
+
+    test('a sustained change does move it', () {
+      final t = ProximityTracker();
+      for (var i = 0; i < 15; i++) {
+        t.add(-50);
+      }
+      expect(t.current.zone, ProximityZone.immediate);
+      for (var i = 0; i < 25; i++) {
+        t.add(-92);
+      }
+      expect(t.current.zone, ProximityZone.veryFar);
+    });
+
+    test('the EWMA sits between the old value and the new sample', () {
+      final t = ProximityTracker(alpha: 0.5);
+      t.add(-40);
+      final r = t.add(-60);
+      expect(r.smoothedRssi, closeTo(-50, 0.001));
+    });
+  });
+
+  group('hysteresis', () {
+    test('a signal parked on a boundary does not flicker', () {
+      // -60 is exactly the immediate/near floor.
+      final t = ProximityTracker();
+      for (var i = 0; i < 15; i++) {
+        t.add(-60);
+      }
+      final settledZone = t.current.zone;
+
+      // Wobble either side of the boundary by less than the hysteresis margin.
+      final seen = <ProximityZone>{};
+      for (var i = 0; i < 30; i++) {
+        seen.add(t.add(i.isEven ? -59 : -61).zone);
+      }
+      expect(seen, {settledZone},
+          reason: 'boundary noise must not repaint the label');
+    });
+
+    test('a decisive crossing is still respected', () {
+      final t = ProximityTracker();
+      for (var i = 0; i < 15; i++) {
+        t.add(-62);
+      }
+      expect(t.current.zone, ProximityZone.near);
+      for (var i = 0; i < 20; i++) {
+        t.add(-50);
+      }
+      expect(t.current.zone, ProximityZone.immediate);
+    });
+  });
+
+  group('trend — the actual hot/cold guidance', () {
+    test('walking toward the band reads warmer', () {
+      final t = ProximityTracker();
+      for (var rssi = -90; rssi <= -50; rssi += 2) {
+        t.add(rssi);
+      }
+      expect(t.current.trend, ProximityTrend.warmer);
+    });
+
+    test('walking away reads colder', () {
+      final t = ProximityTracker();
+      for (var rssi = -50; rssi >= -90; rssi -= 2) {
+        t.add(rssi);
+      }
+      expect(t.current.trend, ProximityTrend.colder);
+    });
+
+    test('standing still reads steady, not a coin flip', () {
+      final t = ProximityTracker();
+      for (var i = 0; i < 40; i++) {
+        t.add(i.isEven ? -70 : -71);
+      }
+      expect(t.current.trend, ProximityTrend.steady);
+    });
+  });
+
+  group('strength bar', () {
+    test('is null before any sample and bounded after', () {
+      final t = ProximityTracker();
+      expect(t.current.strength, isNull);
+      for (var i = 0; i < 10; i++) {
+        t.add(-20); // absurdly strong
+      }
+      expect(t.current.strength, 1.0);
+
+      final weak = ProximityTracker();
+      for (var i = 0; i < 10; i++) {
+        weak.add(-120); // absurdly weak
+      }
+      expect(weak.current.strength, 0.0);
+    });
+
+    test('rises monotonically with signal', () {
+      double at(int rssi) {
+        final t = ProximityTracker();
+        for (var i = 0; i < 30; i++) {
+          t.add(rssi);
+        }
+        return t.current.strength!;
+      }
+
+      expect(at(-90), lessThan(at(-70)));
+      expect(at(-70), lessThan(at(-50)));
+    });
+  });
+
+  test('reset clears the state so a new hunt is not seeded by the last', () {
+    final t = ProximityTracker();
+    for (var i = 0; i < 20; i++) {
+      t.add(-45);
+    }
+    expect(t.current.zone, ProximityZone.immediate);
+    t.reset();
+    expect(t.current.zone, ProximityZone.unknown);
+    expect(t.current.smoothedRssi, isNull);
+    expect(t.current.samples, 0);
+    // First sample after a reset seeds the EWMA outright, not from the old one.
+    expect(t.add(-90).smoothedRssi, -90);
+  });
+
+  test('every zone and trend has user-facing wording', () {
+    for (final z in ProximityZone.values) {
+      expect(z.label, isNotEmpty);
+      expect(z.hint, isNotEmpty);
+    }
+    for (final t in ProximityTrend.values) {
+      expect(t.label, isNotNull);
+    }
+  });
+}


### PR DESCRIPTION
### **User description**
Two features built entirely from hardware and data the app already had and never used. No analytics output changes, so **`kAlgoVersion` stays at 50**.

## 1. Overnight battery forecast

A strap that dies at 03:00 doesn't cost you a battery bar — it costs the whole night. No nocturnal HRV, no stages, no recovery score in the morning, and a hole in the rolling baselines that quietly degrades baseline-relative metrics for days after. The band has been reporting battery every few minutes and `band_battery` has been storing it (with millivolts, on a `ts DESC` index) since v21. Nothing ever read it for this.

`BatteryForecaster` is pure — no DB, no clock of its own, `now` is a parameter — and estimates the discharge rate over the **current run**, then projects to the user's wake time (quiet-hours end).

**Estimator: Theil–Sen**, the median of pairwise slopes (Theil 1950; Sen 1968), rather than least squares. The input is quantised whole percentage points at irregular intervals, so a single stuck or rounded reading visibly tilts an OLS fit; a median of slopes ignores it. There's a test that injects a 25-point outlier and asserts the estimate barely moves.

**Only the current discharge run counts.** A rate measured across a charge isn't a rate, so the walk backwards stops at a charging sample — or at a level *rise*, which is a charge nobody flagged. That rise check compares against the **median of the last few accepted samples**, not the previous one: otherwise a single spuriously-high reading makes the next perfectly good sample look like a charge and truncates the run right there. That was a real bug — the outlier test abstained instead of exercising the estimator, which is how it surfaced.

**It abstains rather than guessing**, with a machine-readable note (`need_history:have=H,need=N`, mirroring the analytics cold-start convention): while charging, too few samples, too short a span, a flat series, an implausible rate, or stale data. `willNotSurvive()` returns false for *every* abstention — an unknown rate must never raise an alarm. The user can always read the battery number themselves, and a false "you're fine" is worse than silence.

**It only fires when it's actionable** — the evening run-up to bedtime, while there's still time to plug it in. Waking someone at 02:00 to say the band died an hour ago helps nobody; a 09:00 warning is forgotten by evening. The window arithmetic wraps midnight (a 01:00 bedtime means 21:00–01:00) and is unit-tested rather than inlined.

Delivery goes through `NotificationCenter.emit` (not `showDevice`), so it inherits prefs gating, quiet hours and the cross-isolate `notif_fired` dedupe. Key is `$day:battery_overnight` — once per day, auto-pruned at 14 days. It's triggered off a fresh battery reading in `_onEngineState`, throttled to 15 minutes, and wrapped so a forecast failure can never take down the state update carrying actual band data.

## 2. Find my strap

Both halves were already present and unconnected: a haptic motor we can fire on command (`runHapticsPattern` 0x4F) and an RSSI we never read. The strap buzzes on a timer while `ProximityTracker` turns signal into a coarse zone plus a warmer/colder trend.

**RSSI is not distance, and the screen refuses to pretend otherwise.** Converting it to metres needs a calibrated TX power and a free-space assumption, and a strap down the side of a mattress breaks that assumption completely — "1.4 m" would be confident and wrong, which is the one thing this app doesn't do. Coarse zones and an honest trend are what the signal actually supports. There's a widget test asserting the UI shows dBm and never metres.

**Two filters, because raw RSSI is unusable for this:**

- **Median-of-3 ahead of the EWMA.** An EWMA alone cannot survive impulse noise: at alpha 0.35 a single −100 dBm dropout (a hand over the band, a multipath null — both routine mid-hunt) drags the average 15 dB in one step, enough to repaint the zone and send someone walking the wrong way. This was found by the test that asserted it *shouldn't* — the original implementation failed it, and the fix is in the code, not the test.
- **Hysteresis on the zone boundaries**, so a signal parked on a threshold doesn't flicker between labels several times a second.

**The hunt never scans.** It reads RSSI off the connected device: buzzing needs the link anyway, so a strap we can't reach is one this screen couldn't help with regardless. That also means it costs one small GATT read per poll — no radio mode change, no interference with an in-flight offload. When there's no link the screen says so plainly rather than showing a hopeful gauge forever.

Entry point is the device sheet in Profile, beside Rename and Smart alarm.

## Testing

- **1038 tests pass** (up from 990; +48 across three new suites: `battery_forecast_test`, `proximity_policy_test`, `find_band_view_test`).
- `flutter analyze` clean.
- Both decision layers are pure classes testable without a radio, a database or a clock — `FindBandView` takes plain values, so states that are awkward to produce on real hardware (no link, faint signal, warming-up with no reading yet) are all covered.
- Sibling pins untouched; `pubspec.lock` retains its git provenance (protocol `a98cd70`, analytics `f5ccae6`).

## Not yet verified on hardware

Both features need a real band to confirm end-to-end, and neither can be proven by tests:

- The forecast's accuracy depends on how linear real discharge is across a night — the estimator is honest about *its* fit, but whether a 6-hour evening rate predicts an 11-hour overnight one is an empirical question. Worth watching whether it warns too eagerly or too rarely before trusting it.
- The RSSI zone thresholds are conventional BLE bands, not measured against this strap's antenna. They may need shifting once someone actually hunts for one under a duvet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, tests


___

### **Description**
- Adds overnight battery forecast warning: projects discharge rate to wake time and notifies user to charge before sleep data is lost

- Adds "Find my strap" screen: buzzes the band and tracks RSSI with EWMA smoothing, hysteresis, and warmer/colder trend guidance

- Both features are backed by comprehensive unit and widget tests covering abstention, smoothing, hysteresis, and edge cases

- No analytics output changes; `kAlgoVersion` is unchanged at 50


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["band_battery DB rows"] -- "recentBandBatterySamples()" --> B["BatteryForecaster\n(Theil–Sen, pure)"]
  B -- "willNotSurvive()" --> C["NotificationCenter.emit\n'Charge your strap before bed'"]
  B -- "inEveningWindow()" --> C
  D["BleEngine.readRssi()"] -- "dBm reading" --> E["ProximityTracker\n(EWMA + hysteresis)"]
  E -- "ProximityReading\n(zone, trend, strength)" --> F["FindBandScreen / FindBandView"]
  G["AppState._maybeWarnOvernightBattery()"] -- "throttled 15 min" --> B
  G -- "buzzBand() / readBandRssi()" --> D
  H["ProfileScreen _DeviceSheet"] -- "push route" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>battery_forecast.dart</strong><dd><code>Pure Theil–Sen battery forecaster with abstention logic</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/164/files#diff-5a0c60221b3267f023a98d0c59e4d27a98639da1e813e5a0d6b987f61329667b">+348/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>proximity_policy.dart</strong><dd><code>Pure RSSI smoother with EWMA, hysteresis, and zone/trend labels</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/164/files#diff-cf8ffabba4448cd4311a214ac282719239f56b2a36cf7ec1a7463b522ef6435e">+262/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>find_band_screen.dart</strong><dd><code>Find-my-strap hunt screen with buzz and signal tracking</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/164/files#diff-b5ac07a95814d2daaf923772d7a97db13a5c1db39c41620434a071965d3aa037">+246/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ble_engine.dart</strong><dd><code>Add readRssi() for live link signal strength</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/164/files#diff-6ab6bfb845fca8d59abbc4cb3d3afc4d41e6ccd63608a71bb397ba7a748c7b85">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_state.dart</strong><dd><code>Wire overnight battery forecast and find-band helpers into AppState</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/164/files#diff-d56ba858e512e18dc3962da198adee46d354aca39ff7c1b4a11d5f19b9afc1ae">+91/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>profile_screen.dart</strong><dd><code>Add Find my strap entry in device sheet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/164/files#diff-84850f115ee94849e171ca073ceabf7528d37007bea1de48e67fe0649d96e849">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>battery_forecast_test.dart</strong><dd><code>Unit tests for BatteryForecaster abstention and projection</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/164/files#diff-e844bfc977400ffd8f8ba5044bb2033c7d04b85d5d84dff9fb445e4b934bd6ff">+263/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>proximity_policy_test.dart</strong><dd><code>Unit tests for ProximityTracker smoothing, hysteresis, and trend</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/164/files#diff-22834ed6647150e295ba0224e9ddc4768b0bd1f6b238c66b605419372b63ce0e">+205/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>find_band_view_test.dart</strong><dd><code>Widget tests for FindBandView across connected and disconnected states</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/164/files#diff-4c75fcdeebb93aa4d7d52e8ec8156d5ca66e641634a3119003d5046f29d78331">+110/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Find my strap” screen with proximity zone/trend guidance and auto/manual buzzing from the connected device view.
  * Added proximity tracking and smoothing for stable zone/trend labeling.
  * Added overnight battery forecasting with a “charge before bed” notification.
* **Bug Fixes**
  * Improved BLE RSSI handling to safely return unknown/unavailable state instead of failing during disconnects or timeouts.
  * Throttled overnight battery warnings to at most once per 15 minutes.
* **Tests**
  * Added unit/widget test coverage for proximity guidance, strap-finding UI, and battery forecasting edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->