### PR TITLE
Fix #170: cycling/rowing workouts weren't being suggested

### DIFF
--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -350,7 +350,19 @@ import 'substrate.dart';
 // green: steps.dart carries the new step API, rr_correction.dart has the
 // signed-dRR `seg.add(x[k])`, advanced_stager.dart has maxAccelCarryForwardSec,
 // live.dart has kKnownRecordVersions.
-const int kAlgoVersion = 50;
+
+// v51: edge#170 — autoDetectWorkouts' motion-confirmation gate (tuned for
+// arm-swing activities) silently dropped every low-limb-swing cardio window
+// (cycling/rowing: the wrist stays still on a handlebar/oar) no matter how
+// strong the HR signal was. analytics#32 (PR-branch head, pinned above —
+// repin to main once merged) adds an HR-ONSET bypass: the gate is skipped
+// only when mean bpm over the candidate's first 3 min rises >=25 bpm versus
+// the 3 min immediately before it (Whipp & Wasserman 1972 phase-II kinetics),
+// which fires on genuine exercise starts but NOT on slow-drifting elevations
+// (fever/heat/anxiety) that have no discernible onset — so this changes which
+// suggestions autoDetectWorkouts emits without loosening the false-positive
+// gate it exists to protect.
+const int kAlgoVersion = 51;
 
 /// Raw is kept this many days past derivation, then pruned (derived stays).
 const int rawRetentionDays = 3;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -964,8 +964,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "422c8b8b9631770b07bc571b6fbe904ef59e5052"
-      resolved-ref: "422c8b8b9631770b07bc571b6fbe904ef59e5052"
+      ref: cbbe06addec1cb78b4ea2c75f64e8a281ac09294
+      resolved-ref: cbbe06addec1cb78b4ea2c75f64e8a281ac09294
       url: "https://github.com/OpenStrap/analytics.git"
     source: git
     version: "1.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -964,8 +964,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "5d421918b5111f0158ccdfd9fa7f99eda1fa87b4"
-      resolved-ref: "5d421918b5111f0158ccdfd9fa7f99eda1fa87b4"
+      ref: "422c8b8b9631770b07bc571b6fbe904ef59e5052"
+      resolved-ref: "422c8b8b9631770b07bc571b6fbe904ef59e5052"
       url: "https://github.com/OpenStrap/analytics.git"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,13 +49,16 @@ dependencies:
   openstrap_analytics:
     git:
       url: https://github.com/OpenStrap/analytics.git
-      # Tip of analytics main — OpenStrap/analytics#31 merged: cardioStager's
-      # per-epoch robustZ scale is now computed once per night instead of
-      # re-sorted every epoch (reviewed for DST/incremental-drain staleness —
-      # none found; it's a pure perf hoist).
-      # Verified present at THIS sha, not assumed from the PR being merged:
-      # cardio_stager.dart builds a RobustScale once and robustZ delegates to it.
-      ref: 5d421918b5111f0158ccdfd9fa7f99eda1fa87b4
+      # PR-BRANCH HEAD, not main — OpenStrap/analytics#32 (fix/issue-170-...)
+      # is open, not yet merged. Repin to the merge commit on main once it
+      # lands (same pattern v49 used briefly for protocol/analytics PR heads).
+      # autoDetectWorkouts now bypasses the motion-confirmation gate on a
+      # genuine HR-onset (fast rise vs. immediately-preceding baseline),
+      # fixing low-limb-swing cardio (cycling/rowing) going undetected while
+      # still rejecting slow-drifting elevations (fever/heat/anxiety) that
+      # have no discernible onset.
+      # Verified present at THIS sha: `git show <sha>:lib/src/onehz/workout/auto_detect.dart | grep onsetRiseBpm`.
+      ref: 422c8b8b9631770b07bc571b6fbe904ef59e5052
 
   # BLE — flutter_blue_plus is the maintained cross-platform GATT client.
   flutter_blue_plus: ^1.36.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,7 +58,10 @@ dependencies:
       # still rejecting slow-drifting elevations (fever/heat/anxiety) that
       # have no discernible onset.
       # Verified present at THIS sha: `git show <sha>:lib/src/onehz/workout/auto_detect.dart | grep onsetRiseBpm`.
-      ref: 422c8b8b9631770b07bc571b6fbe904ef59e5052
+      # Moved to the branch's new head (cbbe06a) after CodeRabbit caught a real
+      # off-by-one in the onset window on analytics#32 (earlyMean was 181s vs
+      # preMean's 180s) — fixed there, not worth a separate edge changelog line.
+      ref: cbbe06addec1cb78b4ea2c75f64e8a281ac09294
 
   # BLE — flutter_blue_plus is the maintained cross-platform GATT client.
   flutter_blue_plus: ^1.36.8


### PR DESCRIPTION
### **User description**
Fixes #170.

## Root cause
`autoDetectWorkouts`'s motion-confirmation gate (`motionConfirmMean = 0.15`, mean L2 gravity-delta/s) is tuned for arm-swing activities like walking/running. It unconditionally drops any sustained-elevated-HR window where the wrist stays still — exactly what happens gripping a handlebar/oar during cycling/rowing — regardless of how strong the HR signal is. That's why a real 1h50m road cycling session (avg ~117W, HR 100-140, peak 157 bpm) produced no suggestion at all.

## Fix
- Depends on **OpenStrap/analytics#32** (pinned above at its PR-branch head — repin to `main` once that merges): `AutoWorkoutDetector` now bypasses the motion gate on a genuine **HR onset** — mean bpm over the first 3 min of the candidate span must rise ≥25 bpm vs. the 3 min immediately before it (Whipp & Wasserman 1972 phase-II kinetics: real exertion shows a fast HR rise right at onset).
- A raw %HRR-level bypass was tried and rejected first: it reopens the exact false positive the motion gate exists to catch, since level alone can't distinguish "just started exercising" from "already elevated" (fever, anxiety, heat). The onset check does distinguish them — a slow drift shows no sharp rise and stays gated.
- `kAlgoVersion` 50 → 51 (this changes which suggestions `autoDetectWorkouts` emits).

## Test plan
- [x] `dart test` in analytics — 386 passed, no failures (see analytics#32 for the new onset-gate tests).
- [x] `flutter test --concurrency=1` — 1055 passed, no regressions.
- [x] `flutter analyze` — clean.
- [x] Verified the new pin resolves (`pubspec.lock` `resolved-ref` matches) with `pubspec_overrides.yaml` moved aside, per the repo's CI-reproduction convention.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes cycling/rowing workouts never being auto-detected (issue #170)

- Repins `openstrap_analytics` to PR-branch head of analytics#32 (HR-onset bypass)

- Bumps `kAlgoVersion` 50 → 51 (changes `autoDetectWorkouts` suggestions output)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Motion gate\n(arm-swing tuned)"]
  B["Cycling/rowing window\n(wrist still on handlebar/oar)"]
  C["HR-onset check\n(≥25 bpm rise in first 3 min)"]
  D["Workout suggestion\nemitted"]
  E["Slow-drift elevation\n(fever/heat/anxiety)"]
  F["Suggestion suppressed\n(no onset detected)"]
  B -- "previously dropped" --> A
  B -- "now: onset check" --> C
  C -- "fast rise detected" --> D
  E -- "no sharp rise" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>derivation_engine.dart</strong><dd><code>Bump kAlgoVersion to 51 for workout detection fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/compute/derivation_engine.dart

<ul><li>Bumps <code>kAlgoVersion</code> from 50 to 51<br> <li> Adds detailed changelog comment explaining the HR-onset bypass fix for <br>cycling/rowing detection<br> <li> Documents that the analytics#32 pin is a PR-branch head pending merge <br>to main</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/171/files#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pubspec.yaml</strong><dd><code>Repin analytics to HR-onset bypass PR-branch head</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pubspec.yaml

<ul><li>Repins <code>openstrap_analytics</code> git ref from <code>5d421918...</code> (analytics#31 tip) <br>to <code>422c8b8b...</code> (analytics#32 PR-branch head)<br> <li> Updates comment to note this is a PR-branch head, not main, and must <br>be repinned to merge commit once analytics#32 lands<br> <li> Documents verification method for the new pin (<code>onsetRiseBpm</code> presence <br>in <code>auto_detect.dart</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/171/files#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25">+10/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workout auto-detection for activities with limited lower-body movement.
  * Added a heart-rate rise threshold to distinguish genuine exercise from gradual, non-exercise elevations.
* **Improvements**
  * Updated analytics behavior to improve workout detection accuracy and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->