### PR TITLE
Stop replayed chargingOn events re-notifying (#179)

### DIFF
--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -1965,6 +1965,12 @@ class BleEngine {
     }
     if (f.containsKey('charging')) {
       state.charging = f['charging'] as bool;
+      // Carry the EVENT's own strap timestamp alongside the flag. The strap
+      // dumps its buffered event log on connect and re-sends events it has
+      // already delivered, so a chargingOn frame is not evidence that the puck
+      // went on just now — only its timestamp is. Consumers that treat the
+      // transition as live (DeviceAlerts) gate on this; see #179.
+      state.chargingTs = (f['ts_epoch'] as num?)?.toInt();
       onState(state);
     }
     if (f.containsKey('on_wrist')) {

--- a/lib/data/models.dart
+++ b/lib/data/models.dart
@@ -126,6 +126,18 @@ class DeviceState {
   String? serial;
   double? batteryPct;
   bool? charging;
+
+  /// Strap timestamp (unix sec) of the chargingOn/chargingOff EVENT that last
+  /// set [charging] — null when unknown.
+  ///
+  /// [charging] alone cannot distinguish "the puck just went on" from "the strap
+  /// replayed a chargingOn out of its flash backlog hours later" (see
+  /// charge_alert_policy.dart). It is deliberately kept beside the flag rather
+  /// than folded into it: the flag is still the LATEST KNOWN charging state and
+  /// the UI should show it, while anything that treats the transition as a live
+  /// event (notifications) has to check the age first.
+  int? chargingTs;
+
   bool? wristOn;
   int? liveHr; // latest live HR from the foreground stream
   int? liveHrAt; // epoch ms

--- a/lib/notify/charge_alert_policy.dart
+++ b/lib/notify/charge_alert_policy.dart
@@ -1,0 +1,148 @@
+// charge_alert_policy.dart — decides whether a "charging started" band event is
+// NEWS (worth buzzing the user) or NOISE (a backlog replay of something that
+// already happened).
+//
+// WHY THIS EXISTS (issue #179 — "repeated 'band is on the charger' well after
+// the charger was removed"):
+//
+// The strap buffers its event log in flash and dumps it on connect, and it
+// re-sends events that were already delivered. Both are measurable in a real
+// user export: 410 of 6,980 events arrived more than an hour after they
+// occurred (worst case 8h26m, an 8-hour backlog dumped in ~90 s), and 140
+// distinct (event_id, ts) pairs were delivered more than once — up to 4× —
+// with a different frame `seq` each time, so nothing upstream de-dupes them.
+// `db.dart`'s insertEvent already notes "the band re-sends events", and
+// GestureDispatcher already carries a recency window for exactly this reason
+// ("older than this = a drained/historical tap"). The charging alert never got
+// the same treatment: it fired on any false→true edge, with the edge state held
+// only in RAM — so every Android process restart (EdgeApplication pre-warm,
+// KeepAliveWorker, FGS START_STICKY) re-armed it and the next replayed
+// chargingOn buzzed again.
+//
+// Two independent guards, because neither is sufficient alone:
+//   • RECENCY — an event describing a plug-in from hours ago is not news.
+//     Handles first-time delivery of a stale backlogged event.
+//   • IDENTITY — never announce a charge session at or before the last one
+//     already announced, persisted across process restarts. Handles exact
+//     re-sends and restart-driven re-arming, both of which are recent enough
+//     to pass the recency check.
+//
+// Pure and synchronous: the caller owns the clock, the persisted values and the
+// notification plugin. See device_alerts.dart for the wiring.
+
+/// Why a charging event did (or did not) raise an alert. Returned instead of a
+/// bare bool so the caller can log the reason — the failure this fixes was
+/// invisible in logs precisely because nothing recorded WHY a notification
+/// fired.
+enum ChargeAlertVerdict {
+  /// Genuine new charge session — show the notification.
+  announce,
+
+  /// We already believe we are charging (in-process edge state) — the strap
+  /// re-sent chargingOn, or another field on the same DeviceState changed and
+  /// re-delivered the unchanged charging flag.
+  alreadyCharging,
+
+  /// The event describes a plug-in that happened long enough ago that it is
+  /// history, not news — a flash-backlog replay.
+  stale,
+
+  /// This exact charge session was already announced (same or older strap
+  /// timestamp than the last announcement) — a re-send, or a fresh process
+  /// re-processing an event the previous process already alerted on.
+  alreadyAnnounced,
+
+  /// The event carries no usable timestamp AND we announced recently enough
+  /// that another alert would be a duplicate.
+  cooldown,
+}
+
+class ChargeAlertPolicy {
+  const ChargeAlertPolicy._();
+
+  /// How recent a chargingOn event must be to count as news.
+  ///
+  /// Deliberately generous. The point is to reject the HOURS-stale backlog
+  /// dump, not to demand instant delivery: in the same real export, genuine
+  /// first-delivery charging events lagged 0 s, 105 s and 226 s behind the
+  /// strap timestamp (the app reconnecting a few minutes after the puck went
+  /// on). A tight window would silence those real alerts and fix nothing —
+  /// exact replays are caught by the identity check below, not by this one.
+  static const int liveWindowSec = 900; // 15 min
+
+  /// Above this age a timestamp is not evidence of anything — the strap ships
+  /// with its RTC unset and can wander before SET_CLOCK lands. We refuse to
+  /// judge staleness from it (mirrors GestureDispatcher's `_plausibleAgeCapSec`)
+  /// and fall back to the untimed path.
+  static const int implausibleAgeSec = 86400;
+
+  /// Below this a strap timestamp is clearly a wrong/unset RTC rather than a
+  /// real unix time — the same plausible-unix floor the sync clock policies use.
+  static const int plausibleUnixFloor = 1700000000;
+
+  /// Tolerance for a strap clock that reads slightly AHEAD of the phone. Inside
+  /// this the event is still "now"; beyond it the timestamp is not usable.
+  static const int futureSlackSec = 300;
+
+  /// Minimum gap between alerts when the event carries no usable timestamp, so
+  /// an unset-RTC strap can't buzz on every reconnect.
+  static const int untimedCooldownSec = 3600; // 1 h
+
+  /// The identity check is not applied to an announcement older than this.
+  ///
+  /// Without an expiry, a strap clock that jumps BACKWARDS (into a still-
+  /// plausible range, so the floor above doesn't catch it) would leave every
+  /// future session comparing `<=` against a high-water timestamp that never
+  /// gets beaten — charging alerts would go permanently silent, a worse and far
+  /// less visible bug than the one being fixed. Expiring the comparison costs
+  /// nothing: a replay old enough to reach this point is already rejected by
+  /// the recency window.
+  static const int identityExpirySec = 43200; // 12 h
+
+  /// Whether [tsEpoch] can be trusted as a real strap wall-clock reading.
+  static bool timestampUsable(int? tsEpoch, {required int wallNowSec}) {
+    if (tsEpoch == null || tsEpoch < plausibleUnixFloor) return false;
+    final age = wallNowSec - tsEpoch;
+    if (age < -futureSlackSec) return false; // strap clock ahead of the phone
+    return age < implausibleAgeSec;
+  }
+
+  /// Decide whether a chargingOn edge should raise a notification.
+  ///
+  /// [eventTsEpoch] is the strap timestamp of the event that set `charging`
+  /// (null when unknown). [wasCharging] is the in-process edge state (null =
+  /// nothing seen yet this process). [lastAnnouncedEventTs] and
+  /// [lastAnnouncedWallSec] are the persisted results of the previous
+  /// announcement — they are what survives an Android process restart.
+  static ChargeAlertVerdict evaluate({
+    required int? eventTsEpoch,
+    required int wallNowSec,
+    required bool? wasCharging,
+    required int? lastAnnouncedEventTs,
+    required int? lastAnnouncedWallSec,
+  }) {
+    if (wasCharging == true) return ChargeAlertVerdict.alreadyCharging;
+
+    if (!timestampUsable(eventTsEpoch, wallNowSec: wallNowSec)) {
+      // No usable strap clock → we cannot tell news from replay. Fall back to a
+      // blunt wall-clock cooldown rather than guessing.
+      if (lastAnnouncedWallSec != null &&
+          wallNowSec - lastAnnouncedWallSec < untimedCooldownSec) {
+        return ChargeAlertVerdict.cooldown;
+      }
+      return ChargeAlertVerdict.announce;
+    }
+
+    final ts = eventTsEpoch!;
+    if (wallNowSec - ts > liveWindowSec) return ChargeAlertVerdict.stale;
+
+    final identityLive = lastAnnouncedWallSec == null ||
+        wallNowSec - lastAnnouncedWallSec <= identityExpirySec;
+    if (identityLive &&
+        lastAnnouncedEventTs != null &&
+        ts <= lastAnnouncedEventTs) {
+      return ChargeAlertVerdict.alreadyAnnounced;
+    }
+    return ChargeAlertVerdict.announce;
+  }
+}

--- a/lib/notify/charge_alert_policy.dart
+++ b/lib/notify/charge_alert_policy.dart
@@ -30,6 +30,8 @@
 // Pure and synchronous: the caller owns the clock, the persisted values and the
 // notification plugin. See device_alerts.dart for the wiring.
 
+import '../sync/sync_policy.dart' show kMinPlausibleUnix;
+
 /// Why a charging event did (or did not) raise an alert. Returned instead of a
 /// bare bool so the caller can log the reason — the failure this fixes was
 /// invisible in logs precisely because nothing recorded WHY a notification
@@ -70,19 +72,25 @@ class ChargeAlertPolicy {
   /// exact replays are caught by the identity check below, not by this one.
   static const int liveWindowSec = 900; // 15 min
 
-  /// Above this age a timestamp is not evidence of anything — the strap ships
-  /// with its RTC unset and can wander before SET_CLOCK lands. We refuse to
-  /// judge staleness from it (mirrors GestureDispatcher's `_plausibleAgeCapSec`)
-  /// and fall back to the untimed path.
-  static const int implausibleAgeSec = 86400;
-
-  /// Below this a strap timestamp is clearly a wrong/unset RTC rather than a
-  /// real unix time — the same plausible-unix floor the sync clock policies use.
-  static const int plausibleUnixFloor = 1700000000;
-
   /// Tolerance for a strap clock that reads slightly AHEAD of the phone. Inside
   /// this the event is still "now"; beyond it the timestamp is not usable.
   static const int futureSlackSec = 300;
+
+  /// NOTE — there is deliberately NO upper age bound on usability.
+  ///
+  /// An earlier draft mirrored GestureDispatcher's 24 h `_plausibleAgeCapSec`,
+  /// treating anything older as "can't tell → allow". That is right for a tap
+  /// (whose backlog is bounded) and wrong here: the strap banks days of data, so
+  /// a two-day-old chargingOn is a REAL old event, not a broken clock — and
+  /// routing it to the untimed path made it announce, reintroducing the exact
+  /// bug at a longer horizon. An unset RTC reads near zero and is caught by
+  /// [kMinPlausibleUnix]; a plausible-but-old timestamp is simply [stale].
+  ///
+  /// The residual risk is a strap clock that drifts backwards by more than
+  /// [liveWindowSec] without falling under the floor: its charging events would
+  /// all read as stale and stop notifying. That needs ~15 min of drift, against
+  /// a 32768 Hz RTC that is re-set on every connect, and it fails in the quiet
+  /// direction rather than the spamming one.
 
   /// Minimum gap between alerts when the event carries no usable timestamp, so
   /// an unset-RTC strap can't buzz on every reconnect.
@@ -101,11 +109,16 @@ class ChargeAlertPolicy {
 
   /// Whether [tsEpoch] can be trusted as a real strap wall-clock reading.
   static bool timestampUsable(int? tsEpoch, {required int wallNowSec}) {
-    if (tsEpoch == null || tsEpoch < plausibleUnixFloor) return false;
-    final age = wallNowSec - tsEpoch;
-    if (age < -futureSlackSec) return false; // strap clock ahead of the phone
-    return age < implausibleAgeSec;
+    if (tsEpoch == null || tsEpoch < kMinPlausibleUnix) return false;
+    return wallNowSec - tsEpoch >= -futureSlackSec; // not ahead of the phone
   }
+
+  /// Whether [tsEpoch] describes an event old enough to be backlog rather than
+  /// news. False when the timestamp is unusable — we don't guess from a clock we
+  /// don't trust.
+  static bool isStale(int? tsEpoch, {required int wallNowSec}) =>
+      timestampUsable(tsEpoch, wallNowSec: wallNowSec) &&
+      wallNowSec - tsEpoch! > liveWindowSec;
 
   /// Decide whether a chargingOn edge should raise a notification.
   ///
@@ -134,7 +147,7 @@ class ChargeAlertPolicy {
     }
 
     final ts = eventTsEpoch!;
-    if (wallNowSec - ts > liveWindowSec) return ChargeAlertVerdict.stale;
+    if (isStale(ts, wallNowSec: wallNowSec)) return ChargeAlertVerdict.stale;
 
     final identityLive = lastAnnouncedWallSec == null ||
         wallNowSec - lastAnnouncedWallSec <= identityExpirySec;

--- a/lib/notify/device_alerts.dart
+++ b/lib/notify/device_alerts.dart
@@ -5,49 +5,209 @@
 // never on every tick:
 //   • Low battery (< 15%, not charging): once per drain. Re-arms only after the
 //     battery recovers past 25% (hysteresis) or goes back on the charger.
-//   • Charging started: once per plug-in (false/unknown → true).
+//   • Charging started: once per plug-in, gated by [ChargeAlertPolicy].
+//
+// THE EDGE STATE IS PERSISTED (issue #179). It used to live only in RAM, which
+// is wrong on Android specifically: EdgeApplication pre-warms a Dart engine on
+// every process create, and KeepAliveWorker + the START_STICKY foreground
+// service mean the process is recreated routinely. Each restart reset
+// `_wasCharging` to null and re-armed the low-battery hysteresis, so the next
+// replayed chargingOn from the strap's flash backlog buzzed all over again —
+// the "repeated 'band is on the charger'" report. Anything that must fire "once
+// per real event" cannot key off in-memory state alone here.
 //
 // Presentation goes through NotificationService, the single display layer that a
 // future FCM/server-push system also uses — so adding push later doesn't touch
 // this file or risk colliding with these alerts.
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'charge_alert_policy.dart';
 import 'notification_service.dart';
+
+/// Narrow presentation seam. [NotificationService] has a private constructor and
+/// cannot be subclassed from a test, so the alert logic would otherwise only be
+/// exercisable against the real platform plugin.
+abstract class DeviceAlertSink {
+  Future<void> show({
+    required int id,
+    required String title,
+    required String body,
+  });
+  Future<void> cancel(int id);
+}
+
+class _NotificationServiceSink implements DeviceAlertSink {
+  const _NotificationServiceSink();
+
+  @override
+  Future<void> show({
+    required int id,
+    required String title,
+    required String body,
+  }) =>
+      NotificationService.instance.showDevice(id: id, title: title, body: body);
+
+  @override
+  Future<void> cancel(int id) => NotificationService.instance.cancel(id);
+}
+
+/// Narrow persistence seam for the alert edge state (see the header note on why
+/// it must outlive the process).
+abstract class DeviceAlertStore {
+  Future<int?> readInt(String key);
+  Future<void> writeInt(String key, int value);
+}
+
+class _PrefsDeviceAlertStore implements DeviceAlertStore {
+  const _PrefsDeviceAlertStore();
+
+  @override
+  Future<int?> readInt(String key) async {
+    try {
+      return (await SharedPreferences.getInstance()).getInt(key);
+    } catch (_) {
+      return null; // a notification must never take down the state update
+    }
+  }
+
+  @override
+  Future<void> writeInt(String key, int value) async {
+    try {
+      await (await SharedPreferences.getInstance()).setInt(key, value);
+    } catch (_) {}
+  }
+}
 
 class DeviceAlerts {
   static const double _lowPct = 15;
   static const double _rearmPct = 25; // hysteresis so we don't re-fire near 15%
 
+  static const String _kLastChargeTs = 'device_alerts.last_charge_event_ts';
+  static const String _kLastChargeWall = 'device_alerts.last_charge_wall_sec';
+  static const String _kLowArmed = 'device_alerts.low_armed';
+
   bool _lowArmed = true; // may we raise a low-battery alert?
   bool? _wasCharging; // previous charging state (null = not seen yet)
+  int? _lastAnnouncedEventTs; // strap ts of the last announced charge session
+  int? _lastAnnouncedWallSec; // wall time of that announcement
 
-  final NotificationService _notes;
-  DeviceAlerts([NotificationService? notes])
-      : _notes = notes ?? NotificationService.instance;
+  final DeviceAlertSink _notes;
+  final DeviceAlertStore _store;
+
+  /// Guards the restore so a burst of BLE updates arriving before the first
+  /// read completes can't each decide independently to announce. Every entry
+  /// into [onDeviceState]'s async body awaits it.
+  Future<void>? _restored;
+
+  /// Serializes the async bodies. Without it, two updates in the same event-loop
+  /// turn both pass the checks before either has written back its state — which
+  /// is exactly the double-notification this file exists to prevent, just at a
+  /// smaller time scale.
+  Future<void> _queue = Future<void>.value();
+
+  DeviceAlerts({DeviceAlertSink? sink, DeviceAlertStore? store})
+      : _notes = sink ?? const _NotificationServiceSink(),
+        _store = store ?? const _PrefsDeviceAlertStore();
+
+  /// Completes when all queued alert work has settled. Tests only.
+  @visibleForTesting
+  Future<void> get settled => _queue;
+
+  /// Never completes with an error. [_restored] is memoised, so a failed restore
+  /// would otherwise be re-awaited — and re-thrown — by every later update,
+  /// silently killing ALL alerts for the life of the process. Falling back to
+  /// defaults costs at most one duplicate announcement.
+  Future<void> _restore() async {
+    try {
+      _lastAnnouncedEventTs = await _store.readInt(_kLastChargeTs);
+      _lastAnnouncedWallSec = await _store.readInt(_kLastChargeWall);
+      final armed = await _store.readInt(_kLowArmed);
+      if (armed != null) _lowArmed = armed != 0;
+    } catch (_) {}
+  }
+
+  Future<void> _setLowArmed(bool armed) async {
+    if (_lowArmed == armed) return;
+    _lowArmed = armed;
+    await _store.writeInt(_kLowArmed, armed ? 1 : 0);
+  }
 
   /// Call with the latest device state. Cheap and safe to call on every update.
-  void onDeviceState({double? batteryPct, bool? charging}) {
-    // Charging just started → notify once; clear any stale low alert and re-arm
-    // so the next drain can alert again.
-    if (charging == true && _wasCharging != true) {
-      _notes.showDevice(
-        id: NotificationService.idCharging,
-        title: 'Charging',
-        body: 'Your band is on the charger.',
+  ///
+  /// [chargingTs] is the strap timestamp of the event that last set [charging]
+  /// (see DeviceState.chargingTs) — the signal that separates a live plug-in
+  /// from a replayed one.
+  void onDeviceState({double? batteryPct, bool? charging, int? chargingTs}) {
+    final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    _queue = _queue.then((_) async {
+      _restored ??= _restore();
+      await _restored;
+      await _apply(
+        batteryPct: batteryPct,
+        charging: charging,
+        chargingTs: chargingTs,
+        nowSec: nowSec,
       );
-      _notes.cancel(NotificationService.idLowBattery);
-      _lowArmed = true;
+    }).catchError((_) {
+      // An alert is a nicety; it must never break the state pipeline, and a
+      // throw must not poison the queue for every later update.
+    });
+  }
+
+  Future<void> _apply({
+    required double? batteryPct,
+    required bool? charging,
+    required int? chargingTs,
+    required int nowSec,
+  }) async {
+    // Charger removed → clear the "Charging" card. It is a STATE claim, so
+    // leaving it in the tray after the puck comes off is wrong on its own; it
+    // also re-arms `onlyAlertOnce`, which only suppresses re-alerting while a
+    // notification with that id is still showing.
+    if (charging == false && _wasCharging != false) {
+      await _notes.cancel(NotificationService.idCharging);
+    }
+
+    if (charging == true) {
+      final verdict = ChargeAlertPolicy.evaluate(
+        eventTsEpoch: chargingTs,
+        wallNowSec: nowSec,
+        wasCharging: _wasCharging,
+        lastAnnouncedEventTs: _lastAnnouncedEventTs,
+        lastAnnouncedWallSec: _lastAnnouncedWallSec,
+      );
+      if (verdict == ChargeAlertVerdict.announce) {
+        await _notes.show(
+          id: NotificationService.idCharging,
+          title: 'Charging',
+          body: 'Your band is on the charger.',
+        );
+        _lastAnnouncedWallSec = nowSec;
+        await _store.writeInt(_kLastChargeWall, nowSec);
+        if (ChargeAlertPolicy.timestampUsable(chargingTs, wallNowSec: nowSec)) {
+          _lastAnnouncedEventTs = chargingTs;
+          await _store.writeInt(_kLastChargeTs, chargingTs!);
+        }
+        // A real plug-in clears any stale low alert and re-arms the next drain.
+        await _notes.cancel(NotificationService.idLowBattery);
+        await _setLowArmed(true);
+      }
     }
     if (charging != null) _wasCharging = charging;
 
     if (batteryPct == null) return;
-    if (batteryPct >= _rearmPct) _lowArmed = true; // recovered → arm for next time
+    if (batteryPct >= _rearmPct) {
+      await _setLowArmed(true); // recovered → arm for next time
+    }
     if (charging != true && batteryPct < _lowPct && _lowArmed) {
-      _notes.showDevice(
+      await _notes.show(
         id: NotificationService.idLowBattery,
         title: 'Low battery',
         body: 'Your band is at ${batteryPct.round()}%. Charge it soon.',
       );
-      _lowArmed = false;
+      await _setLowArmed(false);
     }
   }
 }

--- a/lib/notify/device_alerts.dart
+++ b/lib/notify/device_alerts.dart
@@ -86,7 +86,19 @@ class DeviceAlerts {
 
   static const String _kLastChargeTs = 'device_alerts.last_charge_event_ts';
   static const String _kLastChargeWall = 'device_alerts.last_charge_wall_sec';
+
+  /// Note the asymmetry if the store is ever unavailable: the charging alert
+  /// still has the recency window as a second line of defence, but a battery
+  /// percentage carries no timestamp, so low-battery has only this key. With a
+  /// dead store it degrades to the pre-#179 behaviour (re-armed per process),
+  /// which is the right way to fail — there is no way to remember a latch
+  /// without somewhere to remember it.
   static const String _kLowArmed = 'device_alerts.low_armed';
+
+  @visibleForTesting
+  static const String debugLastChargeTsKey = _kLastChargeTs;
+  @visibleForTesting
+  static const String debugLastChargeWallKey = _kLastChargeWall;
 
   bool _lowArmed = true; // may we raise a low-battery alert?
   bool? _wasCharging; // previous charging state (null = not seen yet)
@@ -130,7 +142,8 @@ class DeviceAlerts {
       // half — wall set, event ts null, which would disable the identity check
       // — is already unreachable; keeping the invariant local means it stays
       // unreachable if someone reorders the reads.)
-      _lastAnnouncedEventTs = eventTs;
+      // 0 is the "cleared" sentinel written by an untimed announcement.
+      _lastAnnouncedEventTs = (eventTs != null && eventTs > 0) ? eventTs : null;
       _lastAnnouncedWallSec = wallSec;
       if (armed != null) _lowArmed = armed != 0;
     } catch (_) {
@@ -215,6 +228,17 @@ class DeviceAlerts {
       if (ChargeAlertPolicy.timestampUsable(chargingTs, wallNowSec: nowSec)) {
         _lastAnnouncedEventTs = chargingTs;
         persistEventTs = chargingTs;
+      } else {
+        // Announced without a usable clock, so we have no identity for THIS
+        // session. Leaving the previous high-water in place would let it judge a
+        // session it knows nothing about: the next usable timestamp that happens
+        // to fall at or below it gets suppressed, and the user silently loses a
+        // real "on the charger" confirmation. Clear it (0 = none; every real
+        // strap timestamp is far above it) so only the wall-clock cooldown
+        // guards this path — which is exactly what the untimed branch of
+        // ChargeAlertPolicy assumes.
+        _lastAnnouncedEventTs = null;
+        persistEventTs = 0;
       }
     }
     // Tracks the LATEST KNOWN charging state, including from events too stale to

--- a/lib/notify/device_alerts.dart
+++ b/lib/notify/device_alerts.dart
@@ -90,6 +90,7 @@ class DeviceAlerts {
 
   bool _lowArmed = true; // may we raise a low-battery alert?
   bool? _wasCharging; // previous charging state (null = not seen yet)
+  bool _cancelledForOff = false; // already cleared the card for this off-state
   int? _lastAnnouncedEventTs; // strap ts of the last announced charge session
   int? _lastAnnouncedWallSec; // wall time of that announcement
 
@@ -121,17 +122,21 @@ class DeviceAlerts {
   /// defaults costs at most one duplicate announcement.
   Future<void> _restore() async {
     try {
-      _lastAnnouncedEventTs = await _store.readInt(_kLastChargeTs);
-      _lastAnnouncedWallSec = await _store.readInt(_kLastChargeWall);
+      final eventTs = await _store.readInt(_kLastChargeTs);
+      final wallSec = await _store.readInt(_kLastChargeWall);
       final armed = await _store.readInt(_kLowArmed);
+      // Assigned together so the identity pair is never half-applied by a read
+      // that throws part-way. (With the read order above the dangerous
+      // half — wall set, event ts null, which would disable the identity check
+      // — is already unreachable; keeping the invariant local means it stays
+      // unreachable if someone reorders the reads.)
+      _lastAnnouncedEventTs = eventTs;
+      _lastAnnouncedWallSec = wallSec;
       if (armed != null) _lowArmed = armed != 0;
-    } catch (_) {}
-  }
-
-  Future<void> _setLowArmed(bool armed) async {
-    if (_lowArmed == armed) return;
-    _lowArmed = armed;
-    await _store.writeInt(_kLowArmed, armed ? 1 : 0);
+    } catch (_) {
+      _lastAnnouncedEventTs = null;
+      _lastAnnouncedWallSec = null;
+    }
   }
 
   /// Call with the latest device state. Cheap and safe to call on every update.
@@ -162,52 +167,100 @@ class DeviceAlerts {
     required int? chargingTs,
     required int nowSec,
   }) async {
+    // ── DECIDE ────────────────────────────────────────────────────────────────
+    // Every latch is committed BEFORE the first await. AGENTS.md §4.3 ("sticky
+    // boolean latches never reset on the failure path") is the exact hazard: a
+    // flag written after an await is a flag a throwing sink or store leaves
+    // un-written, and onDeviceState's catchError makes that silent — the alert
+    // then re-fires on the very next update, which is the bug this file exists
+    // to prevent. Nothing below reads the results of the I/O, so deciding first
+    // costs nothing.
+
     // Charger removed → clear the "Charging" card. It is a STATE claim, so
     // leaving it in the tray after the puck comes off is wrong on its own; it
     // also re-arms `onlyAlertOnce`, which only suppresses re-alerting while a
     // notification with that id is still showing.
-    if (charging == false && _wasCharging != false) {
-      await _notes.cancel(NotificationService.idCharging);
-    }
+    //
+    // A STALE chargingOff must not clear it: the strap replays old events, so a
+    // chargingOff from a previous session can arrive while the band is genuinely
+    // on the charger right now, and cancelling then would hide a card that is
+    // telling the truth.
+    //
+    // The "already cancelled" latch is separate from [_wasCharging] on purpose.
+    // Keying the cancel off the charging TRANSITION looks equivalent and isn't:
+    // a stale chargingOff still has to update _wasCharging (it is the latest
+    // known state), which consumes the transition, and the real removal that
+    // follows would then find nothing to act on and leave the card stranded.
+    final cancelChargingCard = charging == false &&
+        !_cancelledForOff &&
+        !ChargeAlertPolicy.isStale(chargingTs, wallNowSec: nowSec);
+    if (cancelChargingCard) _cancelledForOff = true;
+    // Any chargingOn — even one too stale to announce — means a card may exist
+    // again, so the next removal must be free to clear it.
+    if (charging == true) _cancelledForOff = false;
 
-    if (charging == true) {
-      final verdict = ChargeAlertPolicy.evaluate(
-        eventTsEpoch: chargingTs,
-        wallNowSec: nowSec,
-        wasCharging: _wasCharging,
-        lastAnnouncedEventTs: _lastAnnouncedEventTs,
-        lastAnnouncedWallSec: _lastAnnouncedWallSec,
-      );
-      if (verdict == ChargeAlertVerdict.announce) {
-        await _notes.show(
-          id: NotificationService.idCharging,
-          title: 'Charging',
-          body: 'Your band is on the charger.',
-        );
-        _lastAnnouncedWallSec = nowSec;
-        await _store.writeInt(_kLastChargeWall, nowSec);
-        if (ChargeAlertPolicy.timestampUsable(chargingTs, wallNowSec: nowSec)) {
-          _lastAnnouncedEventTs = chargingTs;
-          await _store.writeInt(_kLastChargeTs, chargingTs!);
-        }
-        // A real plug-in clears any stale low alert and re-arms the next drain.
-        await _notes.cancel(NotificationService.idLowBattery);
-        await _setLowArmed(true);
+    final announce = charging == true &&
+        ChargeAlertPolicy.evaluate(
+              eventTsEpoch: chargingTs,
+              wallNowSec: nowSec,
+              wasCharging: _wasCharging,
+              lastAnnouncedEventTs: _lastAnnouncedEventTs,
+              lastAnnouncedWallSec: _lastAnnouncedWallSec,
+            ) ==
+            ChargeAlertVerdict.announce;
+
+    int? persistEventTs;
+    if (announce) {
+      _lastAnnouncedWallSec = nowSec;
+      if (ChargeAlertPolicy.timestampUsable(chargingTs, wallNowSec: nowSec)) {
+        _lastAnnouncedEventTs = chargingTs;
+        persistEventTs = chargingTs;
       }
     }
+    // Tracks the LATEST KNOWN charging state, including from events too stale to
+    // announce — otherwise a stale on/off pair would leave us believing we are
+    // still charging and swallow the next genuine plug-in as `alreadyCharging`.
     if (charging != null) _wasCharging = charging;
 
-    if (batteryPct == null) return;
-    if (batteryPct >= _rearmPct) {
-      await _setLowArmed(true); // recovered → arm for next time
+    // Low-battery hysteresis, same precedence as before: a real plug-in re-arms
+    // the next drain, so does a battery that recovered past the ceiling.
+    var lowArmed = _lowArmed;
+    if (announce) lowArmed = true;
+    if (batteryPct != null && batteryPct >= _rearmPct) lowArmed = true;
+    final fireLow = batteryPct != null &&
+        charging != true &&
+        batteryPct < _lowPct &&
+        lowArmed;
+    if (fireLow) lowArmed = false;
+    final lowArmedChanged = lowArmed != _lowArmed;
+    _lowArmed = lowArmed;
+
+    // ── ACT ───────────────────────────────────────────────────────────────────
+    if (cancelChargingCard) {
+      await _notes.cancel(NotificationService.idCharging);
     }
-    if (charging != true && batteryPct < _lowPct && _lowArmed) {
+    if (announce) {
+      await _notes.show(
+        id: NotificationService.idCharging,
+        title: 'Charging',
+        body: 'Your band is on the charger.',
+      );
+      await _store.writeInt(_kLastChargeWall, nowSec);
+      if (persistEventTs != null) {
+        await _store.writeInt(_kLastChargeTs, persistEventTs);
+      }
+      // A real plug-in clears any stale low alert.
+      await _notes.cancel(NotificationService.idLowBattery);
+    }
+    if (fireLow) {
       await _notes.show(
         id: NotificationService.idLowBattery,
         title: 'Low battery',
         body: 'Your band is at ${batteryPct.round()}%. Charge it soon.',
       );
-      await _setLowArmed(false);
+    }
+    if (lowArmedChanged) {
+      await _store.writeInt(_kLowArmed, lowArmed ? 1 : 0);
     }
   }
 }

--- a/lib/notify/device_alerts.dart
+++ b/lib/notify/device_alerts.dart
@@ -260,31 +260,46 @@ class DeviceAlerts {
     _lowArmed = lowArmed;
 
     // ── ACT ───────────────────────────────────────────────────────────────────
+    // Each step is isolated, because presentation and persistence must not be
+    // able to take each other down. Sequencing them plainly forces a choice
+    // between two bad failure modes: show-then-persist means a throwing plugin
+    // skips the write, so the session re-announces after a restart; persist-
+    // then-show means a throwing store swallows the alert entirely. Neither is
+    // acceptable, and neither step reads the other's result — so all of them are
+    // attempted independently.
     if (cancelChargingCard) {
-      await _notes.cancel(NotificationService.idCharging);
+      await _io(() => _notes.cancel(NotificationService.idCharging));
     }
     if (announce) {
-      await _notes.show(
-        id: NotificationService.idCharging,
-        title: 'Charging',
-        body: 'Your band is on the charger.',
-      );
-      await _store.writeInt(_kLastChargeWall, nowSec);
+      await _io(() => _notes.show(
+            id: NotificationService.idCharging,
+            title: 'Charging',
+            body: 'Your band is on the charger.',
+          ));
+      await _io(() => _store.writeInt(_kLastChargeWall, nowSec));
       if (persistEventTs != null) {
-        await _store.writeInt(_kLastChargeTs, persistEventTs);
+        await _io(() => _store.writeInt(_kLastChargeTs, persistEventTs!));
       }
       // A real plug-in clears any stale low alert.
-      await _notes.cancel(NotificationService.idLowBattery);
+      await _io(() => _notes.cancel(NotificationService.idLowBattery));
     }
     if (fireLow) {
-      await _notes.show(
-        id: NotificationService.idLowBattery,
-        title: 'Low battery',
-        body: 'Your band is at ${batteryPct.round()}%. Charge it soon.',
-      );
+      await _io(() => _notes.show(
+            id: NotificationService.idLowBattery,
+            title: 'Low battery',
+            body: 'Your band is at ${batteryPct.round()}%. Charge it soon.',
+          ));
     }
     if (lowArmedChanged) {
-      await _store.writeInt(_kLowArmed, lowArmed ? 1 : 0);
+      await _io(() => _store.writeInt(_kLowArmed, lowArmed ? 1 : 0));
     }
+  }
+
+  /// Run one presentation/persistence step, absorbing its failure. See the ACT
+  /// block above for why these are isolated rather than sequenced.
+  Future<void> _io(Future<void> Function() step) async {
+    try {
+      await step();
+    } catch (_) {}
   }
 }

--- a/lib/notify/notification_service.dart
+++ b/lib/notify/notification_service.dart
@@ -298,6 +298,14 @@ class NotificationService {
         importance: _importanceFor(c),
         priority: _priorityFor(c),
         icon: '@mipmap/launcher_icon',
+        // Device alerts reuse FIXED ids (idLowBattery/idCharging), so a re-post
+        // is an UPDATE of a card the user is already looking at — it shouldn't
+        // buzz again. Android only, and deliberately NOT load-bearing: the flag
+        // suppresses sound only while a notification with that id is still
+        // showing, so dismissing the card re-arms it. The real de-dupe lives in
+        // DeviceAlerts/ChargeAlertPolicy; this just stops a redundant update
+        // from making noise. iOS has no equivalent on DarwinNotificationDetails.
+        onlyAlertOnce: c == NotifCategory.device,
       ),
       iOS: const DarwinNotificationDetails(),
     );

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2188,7 +2188,11 @@ class AppState extends ChangeNotifier {
 
   void _onEngineState(DeviceState s) {
     // Battery-low / charging OS notifications (edge-triggered + de-duped inside).
-    _deviceAlerts.onDeviceState(batteryPct: s.batteryPct, charging: s.charging);
+    _deviceAlerts.onDeviceState(
+      batteryPct: s.batteryPct,
+      charging: s.charging,
+      chargingTs: s.chargingTs,
+    );
     final roundedPct = s.batteryPct?.round();
     if (roundedPct != _storedBatteryPct ||
         s.charging != _storedBatteryCharging ||

--- a/test/device_alerts_test.dart
+++ b/test/device_alerts_test.dart
@@ -56,6 +56,25 @@ class _FakeStore implements DeviceAlertStore {
   Future<void> writeInt(String key, int value) async => values[key] = value;
 }
 
+/// A sink whose presentation always fails — the platform plugin unavailable in
+/// a headless wake. Counts attempts so a stuck latch shows up as a retry storm.
+class _ThrowingSink implements DeviceAlertSink {
+  int attempts = 0;
+
+  @override
+  Future<void> show({
+    required int id,
+    required String title,
+    required String body,
+  }) async {
+    attempts++;
+    throw StateError('unavailable');
+  }
+
+  @override
+  Future<void> cancel(int id) async {}
+}
+
 /// A store whose reads always fail — e.g. SharedPreferences unavailable during a
 /// headless wake. Alerts must degrade to "no persisted history", not stop.
 class _ThrowingStore implements DeviceAlertStore {
@@ -109,6 +128,15 @@ void main() {
       expect(verdict(eventTs: now - 30367), ChargeAlertVerdict.stale);
     });
 
+    test('a replay older than a day is still stale, not "cannot tell"', () {
+      // Regression: an earlier draft capped usability at 24 h (mirroring
+      // GestureDispatcher), which sent a multi-day-old event down the UNTIMED
+      // path — where it announced. The strap banks days of data, so an old
+      // plausible timestamp is a real old event, not a broken clock.
+      expect(verdict(eventTs: now - 2 * 86400), ChargeAlertVerdict.stale);
+      expect(verdict(eventTs: now - 7 * 86400), ChargeAlertVerdict.stale);
+    });
+
     test('already charging suppresses regardless of timestamp', () {
       expect(verdict(eventTs: now, wasCharging: true),
           ChargeAlertVerdict.alreadyCharging);
@@ -150,12 +178,9 @@ void main() {
           ChargeAlertVerdict.announce);
     });
 
-    test('timestampUsable rejects unset, ancient and far-future clocks', () {
+    test('timestampUsable rejects unset and far-future clocks', () {
       expect(ChargeAlertPolicy.timestampUsable(null, wallNowSec: now), isFalse);
       expect(ChargeAlertPolicy.timestampUsable(42, wallNowSec: now), isFalse);
-      expect(
-          ChargeAlertPolicy.timestampUsable(now - 200000, wallNowSec: now),
-          isFalse);
       expect(
           ChargeAlertPolicy.timestampUsable(now + 99999, wallNowSec: now),
           isFalse);
@@ -164,6 +189,17 @@ void main() {
       // Inside the tolerance for a strap clock running slightly fast.
       expect(ChargeAlertPolicy.timestampUsable(now + 60, wallNowSec: now),
           isTrue);
+      // Old but plausible is USABLE (and therefore judged stale, not guessed at).
+      expect(ChargeAlertPolicy.timestampUsable(now - 200000, wallNowSec: now),
+          isTrue);
+    });
+
+    test('isStale only judges timestamps it can trust', () {
+      expect(ChargeAlertPolicy.isStale(now - 3600, wallNowSec: now), isTrue);
+      expect(ChargeAlertPolicy.isStale(now - 60, wallNowSec: now), isFalse);
+      // Unset RTC → no opinion, so callers fall back rather than act on a guess.
+      expect(ChargeAlertPolicy.isStale(42, wallNowSec: now), isFalse);
+      expect(ChargeAlertPolicy.isStale(null, wallNowSec: now), isFalse);
     });
   });
 
@@ -265,6 +301,53 @@ void main() {
       expect(sink.countOf(NotificationService.idCharging), 1);
     });
 
+    test('a replayed chargingOff does not clear a live Charging card',
+        () async {
+      final a = alerts();
+      a.onDeviceState(charging: true, chargingTs: tsAged(3));
+      await a.settled;
+      expect(sink.countOf(NotificationService.idCharging), 1);
+
+      // The strap replays a chargingOff from a PREVIOUS session while the band
+      // is genuinely on the charger right now.
+      a.onDeviceState(charging: false, chargingTs: tsAged(9 * 3600));
+      await a.settled;
+      expect(sink.cancelled, isNot(contains(NotificationService.idCharging)));
+
+      // The real removal still clears it.
+      a.onDeviceState(charging: false, chargingTs: tsAged(2));
+      await a.settled;
+      expect(sink.cancelled, contains(NotificationService.idCharging));
+    });
+
+    test('a stale on/off pair does not swallow the next genuine plug-in',
+        () async {
+      final a = alerts();
+      // Whole backlogged charge session replayed at once — neither announces.
+      a.onDeviceState(charging: true, chargingTs: tsAged(9 * 3600));
+      a.onDeviceState(charging: false, chargingTs: tsAged(8 * 3600));
+      await a.settled;
+      expect(sink.countOf(NotificationService.idCharging), 0);
+
+      // The band really goes on the charger now.
+      a.onDeviceState(charging: true, chargingTs: tsAged(2));
+      await a.settled;
+      expect(sink.countOf(NotificationService.idCharging), 1);
+    });
+
+    test('a broken store never re-announces the same session', () async {
+      // Persistence is dead, so only the in-process latches stand between the
+      // strap's re-sends and a repeat. They must be committed before the I/O
+      // that throws (AGENTS.md 4.3).
+      final a = DeviceAlerts(sink: sink, store: _ThrowingStore());
+      final ts = tsAged(3);
+      for (var i = 0; i < 4; i++) {
+        a.onDeviceState(charging: true, chargingTs: ts);
+        await a.settled;
+      }
+      expect(sink.countOf(NotificationService.idCharging), 1);
+    });
+
     test('a broken store degrades to working alerts, not silence', () async {
       // The restore future is memoised, so a failure that escaped would be
       // re-thrown on every later update and kill alerts for the whole process.
@@ -351,6 +434,19 @@ void main() {
       a.onDeviceState(batteryPct: 12, charging: false, chargingTs: tsAged(1));
       await a.settled;
       expect(sink.countOf(NotificationService.idLowBattery), 2);
+    });
+
+    test('a failing sink does not leave the low latch stuck armed', () async {
+      // AGENTS.md 4.3: the disarm used to happen after the show, so a throwing
+      // sink meant _lowArmed stayed true and the alert was retried on every
+      // single update — an alert storm behind a swallowed error.
+      final failing = _ThrowingSink();
+      final a = DeviceAlerts(sink: failing, store: store);
+      for (var i = 0; i < 3; i++) {
+        a.onDeviceState(batteryPct: 12);
+        await a.settled;
+      }
+      expect(failing.attempts, 1);
     });
 
     test('a replayed plug-in does not re-arm the low alert', () async {

--- a/test/device_alerts_test.dart
+++ b/test/device_alerts_test.dart
@@ -1,0 +1,377 @@
+// Tests for the charging/low-battery alert de-dupe (issue #179 — "repeated
+// 'band is on the charger' well after the charger was removed").
+//
+// The strap dumps its buffered event log on connect and re-sends events it has
+// already delivered, so DeviceAlerts cannot treat a chargingOn frame as proof
+// that the puck went on just now. Two guards are asserted here:
+//   • RECENCY — an hours-old chargingOn is a backlog replay, not news.
+//   • IDENTITY — a charge session already announced never announces again, and
+//     the record of that survives a process restart (the Android failure: the
+//     pre-warmed engine + KeepAliveWorker + START_STICKY FGS recreate the
+//     process routinely, and the edge state used to live only in RAM).
+//
+// Both fakes are injected, so nothing here touches the platform plugin or real
+// SharedPreferences.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:openstrap_edge/notify/charge_alert_policy.dart';
+import 'package:openstrap_edge/notify/device_alerts.dart';
+import 'package:openstrap_edge/notify/notification_service.dart';
+
+class _Shown {
+  final int id;
+  final String title;
+  _Shown(this.id, this.title);
+}
+
+class _FakeSink implements DeviceAlertSink {
+  final List<_Shown> shown = [];
+  final List<int> cancelled = [];
+
+  @override
+  Future<void> show({
+    required int id,
+    required String title,
+    required String body,
+  }) async {
+    shown.add(_Shown(id, title));
+  }
+
+  @override
+  Future<void> cancel(int id) async => cancelled.add(id);
+
+  int countOf(int id) => shown.where((s) => s.id == id).length;
+}
+
+/// Survives across DeviceAlerts instances, exactly like SharedPreferences does
+/// across Android process restarts.
+class _FakeStore implements DeviceAlertStore {
+  final Map<String, int> values = {};
+
+  @override
+  Future<int?> readInt(String key) async => values[key];
+
+  @override
+  Future<void> writeInt(String key, int value) async => values[key] = value;
+}
+
+/// A store whose reads always fail — e.g. SharedPreferences unavailable during a
+/// headless wake. Alerts must degrade to "no persisted history", not stop.
+class _ThrowingStore implements DeviceAlertStore {
+  @override
+  Future<int?> readInt(String key) async => throw StateError('unavailable');
+
+  @override
+  Future<void> writeInt(String key, int value) async =>
+      throw StateError('unavailable');
+}
+
+/// Strap timestamp [ageSec] seconds in the past, relative to the wall clock the
+/// production code reads.
+int tsAged(int ageSec) =>
+    (DateTime.now().millisecondsSinceEpoch ~/ 1000) - ageSec;
+
+void main() {
+  group('ChargeAlertPolicy', () {
+    const now = 1800000000;
+
+    ChargeAlertVerdict verdict({
+      int? eventTs,
+      bool? wasCharging,
+      int? lastTs,
+      int? lastWall,
+    }) =>
+        ChargeAlertPolicy.evaluate(
+          eventTsEpoch: eventTs,
+          wallNowSec: now,
+          wasCharging: wasCharging,
+          lastAnnouncedEventTs: lastTs,
+          lastAnnouncedWallSec: lastWall,
+        );
+
+    test('a fresh plug-in announces', () {
+      expect(verdict(eventTs: now - 5), ChargeAlertVerdict.announce);
+    });
+
+    test('a delayed-but-real delivery still announces', () {
+      // Real first-delivery lags measured in a user export: 0 s, 105 s, 226 s
+      // (the app reconnecting minutes after the puck went on). These are the
+      // alerts a naive tight window would silence while fixing nothing.
+      for (final lag in [0, 105, 226]) {
+        expect(verdict(eventTs: now - lag), ChargeAlertVerdict.announce,
+            reason: 'lag=${lag}s is a real plug-in, not a replay');
+      }
+    });
+
+    test('an hours-old backlog replay is stale', () {
+      expect(verdict(eventTs: now - 3600), ChargeAlertVerdict.stale);
+      expect(verdict(eventTs: now - 30367), ChargeAlertVerdict.stale);
+    });
+
+    test('already charging suppresses regardless of timestamp', () {
+      expect(verdict(eventTs: now, wasCharging: true),
+          ChargeAlertVerdict.alreadyCharging);
+    });
+
+    test('a re-send of an announced session is suppressed by identity', () {
+      final ts = now - 60;
+      expect(verdict(eventTs: ts, lastTs: ts, lastWall: now - 60),
+          ChargeAlertVerdict.alreadyAnnounced);
+      // An OLDER session replayed after a newer one was announced.
+      expect(verdict(eventTs: ts - 30, lastTs: ts, lastWall: now - 60),
+          ChargeAlertVerdict.alreadyAnnounced);
+    });
+
+    test('a genuinely newer session beats the identity high-water', () {
+      expect(verdict(eventTs: now - 10, lastTs: now - 600, lastWall: now - 600),
+          ChargeAlertVerdict.announce);
+    });
+
+    test('identity suppression expires so a backwards strap clock cannot '
+        'silence alerts forever', () {
+      // A strap clock that jumps backwards into a still-plausible range would
+      // otherwise never beat the stored high-water again.
+      final stale = now - ChargeAlertPolicy.identityExpirySec - 1;
+      expect(verdict(eventTs: now - 10, lastTs: now + 999999, lastWall: stale),
+          ChargeAlertVerdict.announce);
+    });
+
+    test('an unusable strap timestamp falls back to a cooldown', () {
+      // Unset RTC (below the plausible-unix floor) — cannot judge staleness.
+      expect(verdict(eventTs: 42), ChargeAlertVerdict.announce);
+      expect(verdict(eventTs: 42, lastWall: now - 60), ChargeAlertVerdict.cooldown);
+      expect(verdict(eventTs: null, lastWall: now - 60),
+          ChargeAlertVerdict.cooldown);
+      expect(
+          verdict(
+              eventTs: 42,
+              lastWall: now - ChargeAlertPolicy.untimedCooldownSec - 1),
+          ChargeAlertVerdict.announce);
+    });
+
+    test('timestampUsable rejects unset, ancient and far-future clocks', () {
+      expect(ChargeAlertPolicy.timestampUsable(null, wallNowSec: now), isFalse);
+      expect(ChargeAlertPolicy.timestampUsable(42, wallNowSec: now), isFalse);
+      expect(
+          ChargeAlertPolicy.timestampUsable(now - 200000, wallNowSec: now),
+          isFalse);
+      expect(
+          ChargeAlertPolicy.timestampUsable(now + 99999, wallNowSec: now),
+          isFalse);
+      expect(ChargeAlertPolicy.timestampUsable(now - 60, wallNowSec: now),
+          isTrue);
+      // Inside the tolerance for a strap clock running slightly fast.
+      expect(ChargeAlertPolicy.timestampUsable(now + 60, wallNowSec: now),
+          isTrue);
+    });
+  });
+
+  group('DeviceAlerts charging', () {
+    late _FakeSink sink;
+    late _FakeStore store;
+
+    setUp(() {
+      sink = _FakeSink();
+      store = _FakeStore();
+    });
+
+    DeviceAlerts alerts() => DeviceAlerts(sink: sink, store: store);
+
+    test('a live plug-in notifies exactly once', () async {
+      final a = alerts();
+      a.onDeviceState(charging: true, chargingTs: tsAged(2));
+      await a.settled;
+      expect(sink.countOf(NotificationService.idCharging), 1);
+
+      // Later updates carry the same unchanged charging flag.
+      a.onDeviceState(batteryPct: 40, charging: true, chargingTs: tsAged(2));
+      a.onDeviceState(batteryPct: 41, charging: true, chargingTs: tsAged(2));
+      await a.settled;
+      expect(sink.countOf(NotificationService.idCharging), 1);
+    });
+
+    test('an hours-old replayed chargingOn never notifies', () async {
+      final a = alerts();
+      a.onDeviceState(charging: true, chargingTs: tsAged(8 * 3600));
+      await a.settled;
+      expect(sink.countOf(NotificationService.idCharging), 0);
+    });
+
+    test('the reported #179 loop: replay after removal, across restarts',
+        () async {
+      // Morning: the puck really does go on → one legitimate alert.
+      final morning = alerts();
+      final chargeTs = tsAged(4);
+      morning.onDeviceState(charging: true, chargingTs: chargeTs);
+      await morning.settled;
+      expect(sink.countOf(NotificationService.idCharging), 1);
+
+      // Charger removed.
+      morning.onDeviceState(charging: false, chargingTs: tsAged(1));
+      await morning.settled;
+      expect(sink.cancelled, contains(NotificationService.idCharging));
+
+      // The strap re-sends the SAME chargingOn (measured: up to 4x, each with a
+      // different frame seq so nothing upstream de-dupes them).
+      for (var i = 0; i < 4; i++) {
+        morning.onDeviceState(charging: true, chargingTs: chargeTs);
+        morning.onDeviceState(charging: false, chargingTs: chargeTs + 1);
+        await morning.settled;
+      }
+      expect(sink.countOf(NotificationService.idCharging), 1);
+
+      // Android recreates the process repeatedly; each restart used to re-arm
+      // the alert and the next replay buzzed again.
+      for (var i = 0; i < 5; i++) {
+        final restarted = alerts();
+        restarted.onDeviceState(charging: true, chargingTs: chargeTs);
+        await restarted.settled;
+      }
+      expect(sink.countOf(NotificationService.idCharging), 1);
+    });
+
+    test('a genuinely new charge session still notifies after a restart',
+        () async {
+      final first = alerts();
+      first.onDeviceState(charging: true, chargingTs: tsAged(600));
+      await first.settled;
+      first.onDeviceState(charging: false, chargingTs: tsAged(500));
+      await first.settled;
+      expect(sink.countOf(NotificationService.idCharging), 1);
+
+      final later = alerts(); // new process, same persisted store
+      later.onDeviceState(charging: true, chargingTs: tsAged(3));
+      await later.settled;
+      expect(sink.countOf(NotificationService.idCharging), 2);
+    });
+
+    test('charging off clears the card even on a fresh process', () async {
+      final a = alerts();
+      // _wasCharging is null here — a restart while the card sits in the tray.
+      a.onDeviceState(charging: false, chargingTs: tsAged(5));
+      await a.settled;
+      expect(sink.cancelled, contains(NotificationService.idCharging));
+    });
+
+    test('an unset strap RTC notifies once, then holds off', () async {
+      final a = alerts();
+      a.onDeviceState(charging: true, chargingTs: 0);
+      await a.settled;
+      a.onDeviceState(charging: false, chargingTs: 0);
+      await a.settled;
+      a.onDeviceState(charging: true, chargingTs: 0);
+      await a.settled;
+      expect(sink.countOf(NotificationService.idCharging), 1);
+    });
+
+    test('a broken store degrades to working alerts, not silence', () async {
+      // The restore future is memoised, so a failure that escaped would be
+      // re-thrown on every later update and kill alerts for the whole process.
+      final a = DeviceAlerts(sink: sink, store: _ThrowingStore());
+      a.onDeviceState(charging: true, chargingTs: tsAged(2));
+      await a.settled;
+      expect(sink.countOf(NotificationService.idCharging), 1);
+
+      a.onDeviceState(charging: false, chargingTs: tsAged(1));
+      await a.settled;
+      a.onDeviceState(batteryPct: 12);
+      await a.settled;
+      expect(sink.countOf(NotificationService.idLowBattery), 1);
+    });
+
+    test('a burst arriving before the restore resolves notifies once',
+        () async {
+      final a = alerts();
+      final ts = tsAged(2);
+      // No await between them: both enter while the persisted read is in flight.
+      a.onDeviceState(charging: true, chargingTs: ts);
+      a.onDeviceState(charging: true, chargingTs: ts);
+      a.onDeviceState(charging: true, chargingTs: ts);
+      await a.settled;
+      expect(sink.countOf(NotificationService.idCharging), 1);
+    });
+  });
+
+  group('DeviceAlerts low battery', () {
+    late _FakeSink sink;
+    late _FakeStore store;
+
+    setUp(() {
+      sink = _FakeSink();
+      store = _FakeStore();
+    });
+
+    DeviceAlerts alerts() => DeviceAlerts(sink: sink, store: store);
+
+    test('fires once per drain', () async {
+      final a = alerts();
+      a.onDeviceState(batteryPct: 12);
+      a.onDeviceState(batteryPct: 11);
+      a.onDeviceState(batteryPct: 10);
+      await a.settled;
+      expect(sink.countOf(NotificationService.idLowBattery), 1);
+    });
+
+    test('the once-per-drain guard survives a process restart', () async {
+      final first = alerts();
+      first.onDeviceState(batteryPct: 12);
+      await first.settled;
+      expect(sink.countOf(NotificationService.idLowBattery), 1);
+
+      // Same defect class as the charging repeat: RAM-only hysteresis re-armed
+      // on every process create.
+      for (var i = 0; i < 3; i++) {
+        final restarted = alerts();
+        restarted.onDeviceState(batteryPct: 11);
+        await restarted.settled;
+      }
+      expect(sink.countOf(NotificationService.idLowBattery), 1);
+    });
+
+    test('re-arms after recovering past the hysteresis point', () async {
+      final a = alerts();
+      a.onDeviceState(batteryPct: 12);
+      await a.settled;
+      a.onDeviceState(batteryPct: 30);
+      await a.settled;
+      a.onDeviceState(batteryPct: 12);
+      await a.settled;
+      expect(sink.countOf(NotificationService.idLowBattery), 2);
+    });
+
+    test('a real plug-in re-arms and clears the low card', () async {
+      final a = alerts();
+      a.onDeviceState(batteryPct: 12);
+      await a.settled;
+      a.onDeviceState(batteryPct: 12, charging: true, chargingTs: tsAged(2));
+      await a.settled;
+      expect(sink.cancelled, contains(NotificationService.idLowBattery));
+
+      a.onDeviceState(batteryPct: 12, charging: false, chargingTs: tsAged(1));
+      await a.settled;
+      expect(sink.countOf(NotificationService.idLowBattery), 2);
+    });
+
+    test('a replayed plug-in does not re-arm the low alert', () async {
+      final a = alerts();
+      a.onDeviceState(batteryPct: 12);
+      await a.settled;
+      expect(sink.countOf(NotificationService.idLowBattery), 1);
+
+      // Stale chargingOn: not news, and must not silently reset hysteresis.
+      a.onDeviceState(batteryPct: 12, charging: true, chargingTs: tsAged(8 * 3600));
+      await a.settled;
+      a.onDeviceState(batteryPct: 12, charging: false, chargingTs: tsAged(8 * 3600));
+      await a.settled;
+      expect(sink.countOf(NotificationService.idLowBattery), 1);
+    });
+
+    test('no low alert while charging', () async {
+      final a = alerts();
+      a.onDeviceState(batteryPct: 12, charging: true, chargingTs: tsAged(2));
+      await a.settled;
+      expect(sink.countOf(NotificationService.idLowBattery), 0);
+    });
+  });
+}

--- a/test/device_alerts_test.dart
+++ b/test/device_alerts_test.dart
@@ -335,6 +335,30 @@ void main() {
       expect(sink.countOf(NotificationService.idCharging), 1);
     });
 
+    test('an untimed announce clears the identity high-water', () async {
+      // A session announced with no usable clock has no identity of its own.
+      // Keeping the previous high-water would let it judge a session it knows
+      // nothing about and silently swallow a real confirmation.
+      // A session announced two hours ago, whose strap timestamp landed at the
+      // top of the allowed slightly-ahead-of-phone tolerance.
+      store.values[DeviceAlerts.debugLastChargeTsKey] = tsAged(-240);
+      store.values[DeviceAlerts.debugLastChargeWallKey] = tsAged(2 * 3600);
+
+      // RTC lost → announced via the untimed path (past the untimed cooldown).
+      final untimed = alerts();
+      untimed.onDeviceState(charging: true, chargingTs: 0);
+      await untimed.settled;
+      expect(sink.countOf(NotificationService.idCharging), 1);
+      expect(store.values[DeviceAlerts.debugLastChargeTsKey], 0);
+
+      // RTC restored. This session is genuinely new, but its timestamp is BELOW
+      // the old high-water, so an uncleared identity check would suppress it.
+      final restored = alerts();
+      restored.onDeviceState(charging: true, chargingTs: tsAged(5));
+      await restored.settled;
+      expect(sink.countOf(NotificationService.idCharging), 2);
+    });
+
     test('a broken store never re-announces the same session', () async {
       // Persistence is dead, so only the in-process latches stand between the
       // strap's re-sends and a repeat. They must be committed before the I/O

--- a/test/device_alerts_test.dart
+++ b/test/device_alerts_test.dart
@@ -329,10 +329,34 @@ void main() {
       await a.settled;
       expect(sink.countOf(NotificationService.idCharging), 0);
 
+      // A stale chargingOn re-opens the cancel latch; the stale chargingOff that
+      // follows must still not clear a card. Pinned because the interaction
+      // between the two latches is subtle enough to break silently.
+      expect(sink.cancelled, isNot(contains(NotificationService.idCharging)));
+
       // The band really goes on the charger now.
       a.onDeviceState(charging: true, chargingTs: tsAged(2));
       await a.settled;
       expect(sink.countOf(NotificationService.idCharging), 1);
+    });
+
+    test('a failing sink still lets the announcement persist', () async {
+      // Presentation and persistence must not take each other down: a throwing
+      // plugin used to skip the writes below it, so the session re-announced
+      // after a restart.
+      final failing = _ThrowingSink();
+      final a = DeviceAlerts(sink: failing, store: store);
+      a.onDeviceState(charging: true, chargingTs: tsAged(3));
+      await a.settled;
+      expect(failing.attempts, 1);
+      expect(store.values[DeviceAlerts.debugLastChargeWallKey], isNotNull);
+      expect(store.values[DeviceAlerts.debugLastChargeTsKey], isNotNull);
+
+      // A restart therefore knows the session was already announced.
+      final restarted = DeviceAlerts(sink: sink, store: store);
+      restarted.onDeviceState(charging: true, chargingTs: tsAged(3));
+      await restarted.settled;
+      expect(sink.countOf(NotificationService.idCharging), 0);
     });
 
     test('an untimed announce clears the identity high-water', () async {


### PR DESCRIPTION
### **User description**
Fixes #179 — repeated "Your band is on the charger" long after the charger was removed (Android, 0.9.21).

## Root cause

The charging alert fires from a band **event**, and nothing on that path checked *when* the event happened.

1. `ble_engine.dart` `_absorbState` sets `state.charging` from a decoded event and calls `onState`. The decoded event carries `ts_epoch`, and it was discarded.
2. `app_state.dart` `_onEngineState` feeds every `onState` into `DeviceAlerts`.
3. `device_alerts.dart` fired on any `charging == true && _wasCharging != true`, with `_wasCharging` held **only in RAM**.
4. `notification_service.dart` re-posts id 1002 with no `onlyAlertOnce`, so each re-post re-buzzes.

The strap buffers its event log in flash, dumps it on connect, and re-sends events it has already delivered — so step 1 hands step 3 a `chargingOn` from hours ago and it is treated as a live plug-in. And because the edge state is RAM-only, **every Android process restart re-arms it**: `EdgeApplication` pre-warms a Dart engine on every process create, and `KeepAliveWorker` + the `START_STICKY` foreground service recreate the process routinely.

### Evidence

Queried a real user export (`openstrap_export_*.db`, 6,980 events):

| Check | Result |
|---|---|
| Events delivered >10 min after they occurred | **750** |
| Events delivered >1 h after | **410** |
| Worst case | **8h 26m** stale (8-hour backlog dumped in ~90 s) |
| Duplicate `(event_id, ts)` deliveries | **140 groups, up to 4×** — different frame `seq` each time, so nothing upstream de-dupes them |

The codebase already knew both facts: `db.dart`'s `insertEvent` comments *"the band re-sends events"* (hence its `ConflictAlgorithm.ignore`), and `GestureDispatcher` carries a recency window plus a debounce for exactly this — *"older than this = a drained/historical tap"*. Double-tap got that treatment; charging never did.

## The fix

**`ChargeAlertPolicy`** (new, pure, unit-tested) — two guards, because neither is sufficient alone:

- **Recency** — a `chargingOn` describing a plug-in from hours ago is history, not news. Catches first-time delivery of a backlogged event, which has no prior identity to match against.
- **Identity**, persisted — never announce a charge session at or before the last one announced. Catches exact re-sends and restart-driven re-arming, both of which are recent enough to pass the recency check.

Supporting changes:

- **`DeviceState.chargingTs`** carries the event's own strap timestamp. The flag itself still means "latest known charging state" and the UI should keep showing it — only consumers that treat the *transition* as live gate on the age.
- **`DeviceAlerts` persists its edge state**, so "once per real event" survives a process restart. The low-battery hysteresis had the identical defect (re-armed on every restart) and is fixed with it.
- **`chargingOff` cancels the Charging card.** It is a state claim, so leaving it in the tray after the puck comes off was wrong independently of this bug.
- **`onlyAlertOnce`** on the device channel — explicitly **not** load-bearing. It only suppresses sound while a card with that id is still showing, so the user dismissing it re-arms the buzz. It just stops a redundant *update* from making noise; the real de-dupe is the policy.

## Trade-off worth flagging

A genuine plug-in whose event is first delivered **more than 15 min late** no longer notifies. Real first-delivery lags in the export were 0 s, 105 s and 226 s (the app reconnecting minutes after the puck went on), so the window clears them with room to spare. A tighter window would have silenced those real alerts and fixed nothing, since re-sends are recent by definition.

A more precise alternative — debounce the charging edge until the event burst goes quiet, then act on the *resolved* final state — would preserve even a very-late first notification while still dropping a replayed on/off pair. It needs a timer and has its own failure mode (an `off` still queued for a later connection), so I left it out of a bug fix. Noted as a possible follow-up.

## Not changed, deliberately

- **Engine `state.charging` still applies old events.** Applying the replayed log in order converges to the correct current state; gating it would make the UI go blank on a legitimate plug-in the app learned about late, since there is no live charging source to fall back on.
- **HELLO's charging bit is parsed but unwired** (`control.dart:295` sets `HelloInfo.charging`; `_absorbState` reads only `batteryPct`/`wristOn` from it). A request/response bit would be a genuinely live signal, but the HELLO battery-block offsets are heuristic and unverified on hardware — not something to wire up in a bug fix. Worth a look separately.

## Testing

`test/device_alerts_test.dart` — 23 new tests: policy table, the exact #179 loop (announce → remove → 4 re-sends → 5 process restarts ⇒ still one notification), the real measured lags still announcing, a genuinely new session after a restart still announcing, unset-RTC fallback, identity expiry so a backwards strap clock can't silence alerts forever, and low-battery hysteresis surviving a restart.

Each was checked to **fail against the old behaviour** — temporarily restoring the original rule fails 7 of them, including both #179 regression tests, and removing the restore guard fails the broken-store test.

- `flutter analyze` — clean
- `flutter test --concurrency=1` — **1127 passed** (1104 + 23)
- No `kAlgoVersion` bump: notification layer only, no analytics output change.

Not verified on hardware — the policy is fully covered by unit tests, but `onlyAlertOnce` and the card-cancel are OS behaviours that need a device check: plug in → buzz; re-post while showing → silent update; unplug → card clears; plug in again → buzzes.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes repeated "band is on the charger" notifications from replayed stale BLE events (#179)

- Adds `ChargeAlertPolicy` with recency + identity guards to filter backlog replays

- Persists charging/low-battery edge state to `SharedPreferences` so Android process restarts don't re-arm alerts

- Adds 377-line test suite covering all policy paths and restart scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BLE event\n(chargingOn + ts_epoch)"]
  B["DeviceState.chargingTs\n(strap timestamp)"]
  C["DeviceAlerts.onDeviceState\n(serialized async queue)"]
  D["ChargeAlertPolicy.evaluate\n(recency + identity guards)"]
  E["SharedPreferences\n(persisted edge state)"]
  F["NotificationService\n(idCharging / idLowBattery)"]

  A -- "ts_epoch carried" --> B
  B -- "chargingTs passed" --> C
  C -- "restore from" --> E
  C -- "evaluate verdict" --> D
  D -- "announce / stale / alreadyAnnounced / cooldown" --> C
  C -- "on announce: show/cancel" --> F
  C -- "write back" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>ble_engine.dart</strong><dd><code>Carry strap event timestamp into DeviceState.chargingTs</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/180/files#diff-6ab6bfb845fca8d59abbc4cb3d3afc4d41e6ccd63608a71bb397ba7a748c7b85">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>charge_alert_policy.dart</strong><dd><code>New pure policy: recency and identity guards for charging alerts</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/180/files#diff-c3f184b96c6ce67a2ec07375f38e6598a277cc21a05384d935cbcb28ee3d801f">+148/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>device_alerts.dart</strong><dd><code>Persist edge state, serialize async queue, apply ChargeAlertPolicy</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/180/files#diff-240becf3d6bb44d1bd155dcb567166f167cd4944c7d437242f09b5dc06da6bd6">+177/-17</a></td>

</tr>

<tr>
  <td><strong>notification_service.dart</strong><dd><code>Add onlyAlertOnce for device notification category on Android</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/180/files#diff-67af22f84b6b4b271b1b4d15a7b075f31e1c4417f556d99c0c1cd63950f9f5a7">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_state.dart</strong><dd><code>Pass chargingTs through to DeviceAlerts.onDeviceState</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/180/files#diff-d56ba858e512e18dc3962da198adee46d354aca39ff7c1b4a11d5f19b9afc1ae">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>models.dart</strong><dd><code>Add chargingTs field to DeviceState</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/180/files#diff-b0870ab2a85dc22705cb348d05a8e82e65cd2b495ce7852e9a5d317b77224d6d">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>device_alerts_test.dart</strong><dd><code>Full test suite for charging and low-battery alert de-dupe</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/180/files#diff-5dbca7b29cb8cfa11cdaf9c43b87de39e731d7e75379068bd5e75d13bd073185">+377/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Charging alerts now use event timestamps to prevent duplicate, stale, or replayed notifications.
  * Alert state persists across app restarts, including charging sessions and low-battery status.
  * Removing a device from charging cancels its active charging notification.
  * Low-battery alerts provide improved recovery and threshold handling.

* **Bug Fixes**
  * Prevented repeated notification sounds when existing device alerts are updated.
  * Improved resilience when notification or alert-state storage operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->