### PR TITLE
Log and retime completed workouts

### DIFF
--- a/lib/compute/manual_session.dart
+++ b/lib/compute/manual_session.dart
@@ -281,12 +281,25 @@ ManualSessionStats computeManualSessionStats({
   if (hrTs.isEmpty || hrTs.length != hrBpm.length) {
     return const ManualSessionStats();
   }
-  final worn = <int>[for (final v in hrBpm) if (v > 0) v];
+  // Off-skin samples are dropped ONCE, here, and every scored field below is
+  // built from the survivors. `hrSamplesInRange` already filters `hr > 0` in
+  // SQL so production never sees a zero, but the filter must not depend on
+  // that: forwarding the raw list to the calorie estimator billed each dropped
+  // second at the resting rate, so a window with lost contact scored kcal that
+  // avgHr, strain and the zone bands had all correctly ignored.
+  final wornTs = <int>[];
+  final worn = <int>[];
+  for (var i = 0; i < hrBpm.length; i++) {
+    if (hrBpm[i] > 0) {
+      wornTs.add(hrTs[i]);
+      worn.add(hrBpm[i]);
+    }
+  }
   if (worn.isEmpty) return const ManualSessionStats();
 
   final avg = worn.reduce((a, b) => a + b) / worn.length;
   final peak = worn.reduce((a, b) => a > b ? a : b);
-  final perMin = hrPerMinute(hrTs, hrBpm);
+  final perMin = hrPerMinute(wornTs, worn);
 
   final age = profile.ageYears?.toDouble();
   final weightKg = profile.weightKg;
@@ -301,8 +314,8 @@ ManualSessionStats computeManualSessionStats({
     // Real anchors only — `usedDefaultAnchors` stays false, so we are never
     // persisting a kcal figure built on a fabricated 220/60.
     final bout = ana.Calories.estimateBoutCalories(
-      hrTs,
-      [for (final v in hrBpm) v.toDouble()],
+      wornTs,
+      [for (final v in worn) v.toDouble()],
       profile: ana.WorkoutUserProfile(
         weightKg: weightKg,
         heightCm: profile.heightCm ?? 170.0,
@@ -320,7 +333,7 @@ ManualSessionStats computeManualSessionStats({
     maxHr: peak,
     strain: strain,
     calories: calories,
-    zoneMinutes: zoneMinutesFor(hrBpm, zoneMaxHr),
+    zoneMinutes: zoneMinutesFor(worn, zoneMaxHr),
     hrSampleCount: worn.length,
   );
 }

--- a/lib/compute/manual_session.dart
+++ b/lib/compute/manual_session.dart
@@ -1,0 +1,404 @@
+// manual_session.dart — pure policy for USER-ENTERED workout windows.
+//
+// Two flows let the athlete own the times on a COMPLETED session:
+//   * "Log a past workout" — an effort the band never surfaced at all.
+//   * "Edit times"         — correcting a window that is real but wrong.
+//
+// WHY THIS EXISTS. The auto-detector (`analytics/.../workout/auto_detect.dart`)
+// deliberately reports the HARD-EFFORT CORE, not wall-clock: a minute only
+// counts at >= RHR + 0.45*(HRmax-RHR) (`hrrFloorFraction`), a dip longer than
+// 90 s breaks the span (`maxDipS`), and the survivor must hold >= 12 min
+// (`minSustainedMin`). That tuning is correct for a "did you work out?" prompt
+// — it was calibrated against a sedentary week where a looser gate fired 30
+// false windows — but it means warm-up, cool-down and inter-set rest fall out.
+// An hour of mixed-intensity training routinely lands as ~25 detected minutes.
+// Nothing was broken; the athlete just needs a way to say what actually
+// happened. Until now the only session writer was `startWorkout`, which stamps
+// `DateTime.now()`, so there was no such way.
+//
+// EVERYTHING HERE IS PURE — no I/O, no DB, no clock. The caller passes
+// `nowSec`, the existing session spans and the 1 Hz HR samples it read, so all
+// of it is unit-testable (test/manual_session_test.dart).
+//
+// HONESTY CONTRACT. `strain` and `calories` are computed ONLY from real 1 Hz
+// HR inside the window, through the same published methods the day-level
+// derivation uses (Banister TRIMP -> log-squash strain; Keytel 2005 calories).
+// No HR in the window — because it predates the ~3-day `decoded_onehz`
+// retention, or the band was off — means those columns stay NULL and the UI
+// renders "—". A duration alone NEVER becomes a strain or a calorie figure.
+
+import 'dart:convert';
+
+import 'package:openstrap_analytics/onehz.dart' as ana;
+
+import 'profile.dart';
+
+/// Shortest window we accept. Below a minute the 1 Hz substrate cannot say
+/// anything useful and the entry is almost certainly a mis-tap.
+const int kMinManualWorkoutSec = 60;
+
+/// Longest window we accept. This is TYPO PROTECTION (a wrong date turning a
+/// 45-minute run into a 3-day session), not a physiological claim — 24 h still
+/// admits a 100-mile ultra or an Ironman.
+const int kMaxManualWorkoutSec = 24 * 60 * 60;
+
+/// Why a proposed window was rejected. Ordered by check sequence.
+enum ManualWindowError {
+  /// end <= start — a zero or negative-length session.
+  endNotAfterStart,
+
+  /// Shorter than [kMinManualWorkoutSec].
+  tooShort,
+
+  /// Longer than [kMaxManualWorkoutSec].
+  tooLong,
+
+  /// The window ends after "now". We never accept a session from the future.
+  inFuture,
+
+  /// The window intersects one already in the log. Overlap would double-count
+  /// the same minutes and confuse `savedSpans` auto-detect exclusion.
+  overlapsExisting,
+}
+
+extension ManualWindowErrorMessage on ManualWindowError {
+  /// User-facing copy. Plain, specific, no jargon.
+  String get message => switch (this) {
+        ManualWindowError.endNotAfterStart =>
+          'The end time has to be after the start time.',
+        ManualWindowError.tooShort => 'A workout has to be at least a minute.',
+        ManualWindowError.tooLong => "That's longer than 24 hours — check the date.",
+        ManualWindowError.inFuture => "That window hasn't happened yet.",
+        ManualWindowError.overlapsExisting =>
+          'That overlaps a workout already in your log.',
+      };
+}
+
+/// Thrown by the repo when a proposed window fails [validateManualWindow].
+///
+/// The form validates as you type, but the form is not the only caller and its
+/// overlap snapshot can be stale by the time you hit save — so the write path
+/// checks again and refuses rather than trusting the UI.
+class ManualWindowException implements Exception {
+  final ManualWindowError error;
+  const ManualWindowException(this.error);
+  @override
+  String toString() => 'ManualWindowException: ${error.message}';
+}
+
+/// A `[startSec, endSec]` span of a session already saved — used to reject an
+/// overlapping entry. `id` lets an EDIT skip its own row.
+class SessionSpan {
+  final String id;
+  final int startSec;
+  final int endSec;
+  const SessionSpan(this.id, this.startSec, this.endSec);
+}
+
+/// Validate a user-proposed window. Returns null when it is acceptable.
+///
+/// [editingId] is the row being retimed, if any — its own span is excluded
+/// from the overlap check so a session never collides with itself.
+///
+/// A saved row with a null/absent `end_ts` (a stranded `status='live'` row)
+/// cannot be overlap-checked and is skipped rather than guessed at.
+ManualWindowError? validateManualWindow({
+  required int startSec,
+  required int endSec,
+  required int nowSec,
+  List<SessionSpan> existing = const [],
+  String? editingId,
+}) {
+  if (endSec <= startSec) return ManualWindowError.endNotAfterStart;
+  final dur = endSec - startSec;
+  if (dur < kMinManualWorkoutSec) return ManualWindowError.tooShort;
+  if (dur > kMaxManualWorkoutSec) return ManualWindowError.tooLong;
+  if (endSec > nowSec) return ManualWindowError.inFuture;
+  for (final s in existing) {
+    if (s.id == editingId) continue;
+    if (s.endSec <= s.startSec) continue; // stranded/live row — nothing to test
+    // Half-open intersection: touching end-to-start is fine (back-to-back
+    // sessions are legitimate), genuine overlap is not.
+    if (startSec < s.endSec && s.startSec < endSec) {
+      return ManualWindowError.overlapsExisting;
+    }
+  }
+  return null;
+}
+
+/// Everything we could derive for a manual window from the 1 Hz substrate.
+/// Every field is nullable/empty when its input was absent — see the honesty
+/// contract in the file header.
+class ManualSessionStats {
+  /// Mean HR over the window, or null with no worn HR.
+  final int? avgHr;
+
+  /// Peak HR over the window, or null with no worn HR.
+  final int? maxHr;
+
+  /// Headline 0–21 strain (Banister TRIMP -> log squash). Null unless HR,
+  /// resting HR, HRmax and sex are ALL present — every one is a term in the
+  /// formula, so a missing one cannot be defaulted.
+  final double? strain;
+
+  /// Keytel 2005 active kcal. Null unless HR, age, weight, sex and HRmax are
+  /// all present.
+  final double? calories;
+
+  /// Minutes in Z1..Z5 (5 elements), or empty with no HR.
+  final List<double> zoneMinutes;
+
+  /// How many 1 Hz HR samples backed the numbers above. 0 means the window has
+  /// no substrate — the caller should tell the user the entry was saved but
+  /// cannot be scored.
+  final int hrSampleCount;
+
+  const ManualSessionStats({
+    this.avgHr,
+    this.maxHr,
+    this.strain,
+    this.calories,
+    this.zoneMinutes = const [],
+    this.hrSampleCount = 0,
+  });
+
+  /// True when the window had no 1 Hz HR at all — pruned, or band not worn.
+  bool get isUnscored => hrSampleCount == 0;
+}
+
+/// Mean HR per whole minute across [hrTs]/[hrBpm]. Banister weights each entry
+/// as one minute, so feeding it raw 1 Hz samples would inflate TRIMP ~60x.
+/// Samples are assumed ascending by ts (the DB returns them ordered); a minute
+/// with no sample simply produces no entry rather than a zero.
+List<double> hrPerMinute(List<int> hrTs, List<int> hrBpm) {
+  if (hrTs.length != hrBpm.length || hrTs.isEmpty) return const [];
+  final out = <double>[];
+  var bucket = hrTs.first ~/ 60;
+  var sum = 0.0;
+  var n = 0;
+  for (var i = 0; i < hrTs.length; i++) {
+    final b = hrTs[i] ~/ 60;
+    if (b != bucket) {
+      if (n > 0) out.add(sum / n);
+      bucket = b;
+      sum = 0;
+      n = 0;
+    }
+    if (hrBpm[i] > 0) {
+      sum += hrBpm[i];
+      n++;
+    }
+  }
+  if (n > 0) out.add(sum / n);
+  return out;
+}
+
+/// Minutes spent in each of Z1..Z5 (50/60/70/80/90 % of [zoneMaxHr]).
+///
+/// [zoneMaxHr] is the caller's DISPLAY HRmax convention. It is deliberately a
+/// parameter, not derived here: the workout screens band zones on 220-age
+/// (`LocalRepositoryImpl._profileMaxHr`) while the analytics anchors below use
+/// Tanaka. Persisting `zone_min` on a different HRmax from the `zone_bands`
+/// the same screen recomputes on read would put two disagreeing zone splits on
+/// one card. (That the app carries two HRmax conventions at all is
+/// pre-existing and worth converging separately — this just refuses to widen
+/// the split.)
+List<double> zoneMinutesFor(List<int> hrBpm, double zoneMaxHr) {
+  if (hrBpm.isEmpty || zoneMaxHr <= 0) return const [];
+  const loPct = [0.5, 0.6, 0.7, 0.8, 0.9];
+  final secs = List<int>.filled(5, 0);
+  for (final v in hrBpm) {
+    if (v <= 0) continue;
+    final pct = v / zoneMaxHr;
+    for (var z = 4; z >= 0; z--) {
+      if (pct >= loPct[z]) {
+        secs[z]++;
+        break;
+      }
+    }
+  }
+  return [
+    for (var z = 0; z < 5; z++)
+      double.parse((secs[z] / 60.0).toStringAsFixed(2)),
+  ];
+}
+
+/// Headline 0–21 strain from per-minute mean HR, or null when an anchor the
+/// Banister formula actually needs is missing.
+///
+/// THE ONE STRAIN METHOD. Everything that puts a number on the 0–21 dial goes
+/// through here: the day-level pipeline, a manually logged session, a retimed
+/// one, an auto-detected one, and the live gauge. They used to disagree —
+/// the live session accrued `strain += %HRR * 0.01` per second, which is
+/// uncited, uncapped, and measured 25.33 where this returns 11.62 for the same
+/// hour (2.18x, and past the top of its own scale after ~50 min); auto-detected
+/// sessions wrote no strain at all. Sharing a dial while not sharing a method
+/// made "workout strain" and "daily strain" incomparable numbers that merely
+/// looked alike.
+///
+/// [restingHr] and the profile's Tanaka HRmax and sex are all TERMS in the
+/// formula — a missing one abstains rather than substituting a default (the
+/// old live path silently used 30 y / 70 kg / 60 bpm).
+double? strainFromPerMinuteHr(
+  List<double> perMinuteHr, {
+  required Profile profile,
+  required double? restingHr,
+}) {
+  final hrMax = profile.hrMaxTanaka; // null when age is unknown
+  final sex = profile.sex?.toLowerCase();
+  if (perMinuteHr.isEmpty || hrMax == null || restingHr == null || sex == null) {
+    return null;
+  }
+  final trimp = ana.banisterTrimp(
+    perMinuteHr,
+    restingHr: restingHr,
+    maxHr: hrMax,
+    sex: sex == 'f' || sex == 'female' ? ana.Sex.female : ana.Sex.male,
+  );
+  if (!trimp.present || trimp.value == null) return null;
+  final score = ana.strainScoreMetric(trimp.value);
+  return score.present ? score.value : null;
+}
+
+/// Score a manual window from its 1 Hz HR.
+///
+/// [hrTs]/[hrBpm] are the substrate samples INSIDE the window (ascending,
+/// same length, `hr > 0` — exactly what `LocalDb.hrSamplesInRange` returns).
+/// [restingHr] is the nightly/user RHR; [profile] supplies age/weight/sex.
+///
+/// Uses the SAME published methods as the day-level derivation so a manual
+/// session and the day it sits in are on one scale: `ana.banisterTrimp` ->
+/// `ana.strainScoreMetric` for strain, `ana.Calories.estimateBoutCalories`
+/// (Keytel 2005) for kcal. Anchors come from Tanaka HRmax (`Profile`), never a
+/// 220-age default — a missing anchor makes the dependent metric null.
+ManualSessionStats computeManualSessionStats({
+  required List<int> hrTs,
+  required List<int> hrBpm,
+  required Profile profile,
+  required double zoneMaxHr,
+  double? restingHr,
+}) {
+  if (hrTs.isEmpty || hrTs.length != hrBpm.length) {
+    return const ManualSessionStats();
+  }
+  final worn = <int>[for (final v in hrBpm) if (v > 0) v];
+  if (worn.isEmpty) return const ManualSessionStats();
+
+  final avg = worn.reduce((a, b) => a + b) / worn.length;
+  final peak = worn.reduce((a, b) => a > b ? a : b);
+  final perMin = hrPerMinute(hrTs, hrBpm);
+
+  final age = profile.ageYears?.toDouble();
+  final weightKg = profile.weightKg;
+  final sex = profile.sex?.toLowerCase();
+  final hrMax = profile.hrMaxTanaka; // null when age is unknown
+
+  final strain =
+      strainFromPerMinuteHr(perMin, profile: profile, restingHr: restingHr);
+
+  double? calories;
+  if (hrMax != null && age != null && weightKg != null && sex != null) {
+    // Real anchors only — `usedDefaultAnchors` stays false, so we are never
+    // persisting a kcal figure built on a fabricated 220/60.
+    final bout = ana.Calories.estimateBoutCalories(
+      hrTs,
+      [for (final v in hrBpm) v.toDouble()],
+      profile: ana.WorkoutUserProfile(
+        weightKg: weightKg,
+        heightCm: profile.heightCm ?? 170.0,
+        age: age,
+        sex: sex == 'f' || sex == 'female' ? 'female' : 'male',
+      ),
+      hrmax: hrMax,
+      restingHr: restingHr,
+    );
+    if (!bout.usedDefaultAnchors && bout.kcal > 0) calories = bout.kcal;
+  }
+
+  return ManualSessionStats(
+    avgHr: avg.round(),
+    maxHr: peak,
+    strain: strain,
+    calories: calories,
+    zoneMinutes: zoneMinutesFor(hrBpm, zoneMaxHr),
+    hrSampleCount: worn.length,
+  );
+}
+
+/// Stable id for a manually logged session. Keyed on the START SECOND so
+/// re-logging the same window is idempotent under `putSession`'s
+/// INSERT-OR-REPLACE rather than piling up near-duplicates.
+String manualSessionId(int startSec) => 'manual:$startSec';
+
+/// Build the `sessions` row for a manual entry or a retimed session.
+///
+/// [existing] is the current row when EDITING — its `id`, `source` and
+/// `created_at` are preserved so a retimed live session stays attributed to
+/// how it was originally captured (the detail screen's AUTO tag depends on
+/// this) and does not jump to the top of any created-at ordering.
+///
+/// Absent stats are written as explicit nulls, NOT omitted: `putSession` is
+/// INSERT-OR-REPLACE, so an omitted key on an edit would silently retain the
+/// stale value computed for the OLD window.
+/// [sessionId] and [source] override the defaults for a session that is not
+/// hand-entered — an auto-detected bout confirmed by the athlete keeps its
+/// `auto:` id and `auto` attribution while still being scored through this one
+/// path. Ignored when [existing] is given (an edit keeps what it already had).
+Map<String, dynamic> buildManualSessionRow({
+  required int startSec,
+  required int endSec,
+  required String type,
+  required ManualSessionStats stats,
+  required int createdAtMs,
+  Map<String, dynamic>? existing,
+  String? sessionId,
+  String source = 'manual',
+}) {
+  final id =
+      (existing?['id'] as String?) ?? sessionId ?? manualSessionId(startSec);
+  final zone = stats.zoneMinutes;
+  return {
+    'id': id,
+    'start_ts': startSec,
+    'end_ts': endSec,
+    'type': type,
+    'status': 'done',
+    'calories': stats.calories,
+    'strain': stats.strain,
+    'max_hr': stats.maxHr,
+    'duration_min': (endSec - startSec) ~/ 60,
+    'zone_min_json': jsonEncode(zone.any((v) => v > 0) ? zone : const <num>[]),
+    // Steps and HRR belong to the window, not the entry: `steps` came from the
+    // live pedometer we never ran, and `hrr_bpm` is refilled retrospectively
+    // by the derivation engine from the substrate around `end_ts`. Clearing
+    // them on an edit is correct — the old values described the old window.
+    'steps': null,
+    'hrr_bpm': null,
+    'source': (existing?['source'] as String?) ?? source,
+    'created_at':
+        (existing?['created_at'] as num?)?.toInt() ?? createdAtMs,
+  };
+}
+
+/// Ids of active suggestions whose window intersects a just-saved session.
+///
+/// A manual entry that covers the detector's fragment must retire that
+/// fragment, or the athlete is left staring at a "did you work out?" card for
+/// the workout they just logged. Same half-open intersection as the overlap
+/// check. [suggestions] are `workout_suggestions` rows.
+List<String> supersededSuggestionIds(
+  List<Map<String, dynamic>> suggestions, {
+  required int startSec,
+  required int endSec,
+}) {
+  final out = <String>[];
+  for (final s in suggestions) {
+    final id = s['id'];
+    final sStart = (s['start_ts'] as num?)?.toInt();
+    final sEnd = (s['end_ts'] as num?)?.toInt();
+    if (id is! String || sStart == null || sEnd == null) continue;
+    if (sEnd <= sStart) continue;
+    if (startSec < sEnd && sStart < endSec) out.add(id);
+  }
+  return out;
+}

--- a/lib/data/local_repository.dart
+++ b/lib/data/local_repository.dart
@@ -118,7 +118,7 @@ abstract class LocalRepository {
   /// Log a COMPLETED workout the athlete times themselves — one the band never
   /// detected, or detected too narrowly. Scored from the 1 Hz substrate over
   /// [startTs, endTs] (epoch SECONDS); a window with no substrate is still
-  /// saved, just unscored. Returns `{workout_id, unscored}`.
+  /// saved, just unscored. Returns `{workout_id, unscored, hr_samples}`.
   Future<Map<String, dynamic>> logManualWorkout({
     required int startTs,
     required int endTs,
@@ -130,6 +130,7 @@ abstract class LocalRepository {
   /// [logManualWorkout], but keeps the `auto:` id and `auto` attribution.
   /// Before this existed the confirm flow wrote no `strain` or `calories` at
   /// all, so every accepted suggestion showed blanks where the numbers go.
+  /// Returns `{workout_id, unscored, hr_samples}`.
   Future<Map<String, dynamic>> logDetectedWorkout({
     required int startTs,
     required int endTs,
@@ -139,7 +140,9 @@ abstract class LocalRepository {
 
   /// Retime an existing session and re-score it over the new window. Used to
   /// widen an auto-detected fragment to the real session. Returns
-  /// `{workout_id, unscored}`.
+  /// `{workout_id, unscored, hr_samples}`. Throws [StateError] when the id is
+  /// unknown or the session is still live, and [ManualWindowException] when
+  /// the proposed window is rejected.
   Future<Map<String, dynamic>> setWorkoutWindow(
     String id, {
     required int startTs,

--- a/lib/data/local_repository.dart
+++ b/lib/data/local_repository.dart
@@ -12,6 +12,7 @@
 // run server-side. The screen DATA layer is therefore a clean, localized seam:
 // nothing above this file references HTTP, JWT, or a backend URL anymore.
 
+import '../compute/manual_session.dart' show SessionSpan;
 import '../gps/route_models.dart';
 
 /// The single source of truth for "no step goal configured yet" (8k/day is
@@ -113,6 +114,43 @@ abstract class LocalRepository {
       throw UnimplementedError('re-layer: endWorkout');
   Future<Map<String, dynamic>> setWorkoutType(String id, String type) =>
       throw UnimplementedError('re-layer: setWorkoutType');
+
+  /// Log a COMPLETED workout the athlete times themselves — one the band never
+  /// detected, or detected too narrowly. Scored from the 1 Hz substrate over
+  /// [startTs, endTs] (epoch SECONDS); a window with no substrate is still
+  /// saved, just unscored. Returns `{workout_id, unscored}`.
+  Future<Map<String, dynamic>> logManualWorkout({
+    required int startTs,
+    required int endTs,
+    required String type,
+  }) =>
+      throw UnimplementedError('re-layer: logManualWorkout');
+
+  /// Log a confirmed auto-detected bout. Same scoring path as
+  /// [logManualWorkout], but keeps the `auto:` id and `auto` attribution.
+  /// Before this existed the confirm flow wrote no `strain` or `calories` at
+  /// all, so every accepted suggestion showed blanks where the numbers go.
+  Future<Map<String, dynamic>> logDetectedWorkout({
+    required int startTs,
+    required int endTs,
+    required String type,
+  }) =>
+      throw UnimplementedError('re-layer: logDetectedWorkout');
+
+  /// Retime an existing session and re-score it over the new window. Used to
+  /// widen an auto-detected fragment to the real session. Returns
+  /// `{workout_id, unscored}`.
+  Future<Map<String, dynamic>> setWorkoutWindow(
+    String id, {
+    required int startTs,
+    required int endTs,
+  }) =>
+      throw UnimplementedError('re-layer: setWorkoutWindow');
+
+  /// Saved session spans (excluding stranded live rows), for the manual-entry
+  /// form's overlap check.
+  Future<List<SessionSpan>> savedSessionSpans() =>
+      throw UnimplementedError('re-layer: savedSessionSpans');
   // GPS route for a run/ride/walk (on-device only). Null when none recorded.
   Future<WorkoutRoute?> getWorkoutRoute(String id) =>
       throw UnimplementedError('re-layer: getWorkoutRoute');

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -19,6 +19,8 @@ import 'dart:math' as math;
 
 import '../compute/derivation_engine.dart';
 import '../compute/hr_max.dart';
+import '../compute/manual_session.dart';
+import '../compute/profile.dart';
 import 'package:openstrap_protocol/openstrap_protocol.dart' as proto;
 import 'package:openstrap_analytics/onehz.dart' as ana;
 
@@ -2027,10 +2029,204 @@ class LocalRepositoryImpl extends LocalRepository {
   }
 
   @override
+  Future<List<SessionSpan>> savedSessionSpans() async {
+    // Everything ever logged — the overlap check has to see a session from any
+    // date the athlete might be back-filling into, not just a recent window.
+    final rows = await LocalDb.sessionsInRange(0, 1 << 40);
+    return [
+      for (final r in rows)
+        if (r['id'] is String && r['start_ts'] is int && r['end_ts'] is int)
+          SessionSpan(
+            r['id'] as String,
+            (r['start_ts'] as num).toInt(),
+            (r['end_ts'] as num).toInt(),
+          ),
+    ];
+  }
+
+  @override
+  Future<Map<String, dynamic>> logManualWorkout({
+    required int startTs,
+    required int endTs,
+    required String type,
+  }) =>
+      _writeManualSession(
+        startTs: startTs,
+        endTs: endTs,
+        type: type,
+        // A manual row's id is derived from its start second, so re-logging the
+        // same window is an UPDATE of that row, not a collision with it. Pass
+        // the id we are about to write as the one to skip in the overlap check.
+        validateAgainstId: manualSessionId(startTs),
+      );
+
+  @override
+  Future<Map<String, dynamic>> logDetectedWorkout({
+    required int startTs,
+    required int endTs,
+    required String type,
+  }) =>
+      _writeManualSession(
+        startTs: startTs,
+        endTs: endTs,
+        type: type,
+        sessionId: 'auto:$startTs',
+        source: 'auto',
+        validateAgainstId: 'auto:$startTs',
+      );
+
+  @override
+  Future<Map<String, dynamic>> setWorkoutWindow(
+    String id, {
+    required int startTs,
+    required int endTs,
+  }) async {
+    final existing = await LocalDb.session(id);
+    if (existing == null) {
+      throw StateError('setWorkoutWindow: no session $id');
+    }
+    // A retimed session keeps its id, so the OLD row is replaced rather than
+    // orphaned — including its GPS route, which still belongs to it.
+    return _writeManualSession(
+      startTs: startTs,
+      endTs: endTs,
+      type: (existing['type'] as String?) ?? 'other',
+      existing: existing,
+      validateAgainstId: id,
+    );
+  }
+
+  /// Shared writer for both user-timed paths: score the window from the 1 Hz
+  /// substrate, persist, and retire any auto-detect suggestion it covers.
+  ///
+  /// Deliberately does NOT force a day re-derive. Sessions do not feed
+  /// `day_result` — the derivation engine reads them only as `savedSpans`
+  /// (auto-detect exclusion) and to back-fill `hrr_bpm`, while day strain and
+  /// calories come from the whole-day substrate independently. So there is no
+  /// analytics output to invalidate here and no `kAlgoVersion` bump to make;
+  /// the next ordinary derive picks up the exclusion on its own.
+  Future<Map<String, dynamic>> _writeManualSession({
+    required int startTs,
+    required int endTs,
+    required String type,
+    required String validateAgainstId,
+    Map<String, dynamic>? existing,
+    String? sessionId,
+    String source = 'manual',
+  }) async {
+    // Re-check at the write seam. The form validates live, but its snapshot of
+    // saved spans can be stale by the time save is tapped (a background derive
+    // can log an auto-detected session mid-edit), and the form is not the only
+    // possible caller. Throwing beats silently writing an overlapping row.
+    final invalid = validateManualWindow(
+      startSec: startTs,
+      endSec: endTs,
+      nowSec: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      existing: await savedSessionSpans(),
+      editingId: validateAgainstId,
+    );
+    if (invalid != null) throw ManualWindowException(invalid);
+
+    final hrRows = await LocalDb.hrSamplesInRange(startTs, endTs);
+    final hrTs = [for (final e in hrRows) (e['rec_ts'] as num).toInt()];
+    final hrBpm = [for (final e in hrRows) (e['hr'] as num).toInt()];
+
+    final profile = Profile.fromMap(getProfileMap());
+    // Prefer the measured nightly RHR; fall back to the user-supplied one.
+    // Both are real inputs — absent both, strain stays null rather than
+    // leaning on a 60 bpm stand-in.
+    final restingHr = await _recentRestingHr() ??
+        profile.restingHrManual?.toDouble();
+
+    final stats = computeManualSessionStats(
+      hrTs: hrTs,
+      hrBpm: hrBpm,
+      profile: profile,
+      zoneMaxHr: _profileMaxHr().toDouble(),
+      restingHr: restingHr,
+    );
+
+    final row = buildManualSessionRow(
+      startSec: startTs,
+      endSec: endTs,
+      type: type,
+      stats: stats,
+      createdAtMs: DateTime.now().millisecondsSinceEpoch,
+      existing: existing,
+      sessionId: sessionId,
+      source: source,
+    );
+    await LocalDb.putSession(row);
+
+    // Retire the fragment(s) this window supersedes, so the athlete isn't
+    // asked "did you work out?" about the session they just logged.
+    try {
+      final sug = await LocalDb.activeWorkoutSuggestions();
+      for (final id in supersededSuggestionIds(sug,
+          startSec: startTs, endSec: endTs)) {
+        await LocalDb.dismissWorkoutSuggestion(id);
+      }
+    } catch (_) {
+      /* suggestion cleanup is best-effort — the session is already saved */
+    }
+
+    return {
+      'workout_id': row['id'],
+      'unscored': stats.isUnscored,
+      'hr_samples': stats.hrSampleCount,
+    };
+  }
+
+  /// Most recent nightly resting HR from `metric_series`, or null. Bounded to
+  /// the last week so a stale figure from a long gap can't anchor TRIMP.
+  Future<double?> _recentRestingHr() async {
+    try {
+      // 'rhr' is the `metric_series` key the derivation engine writes nightly
+      // resting HR under (see _BaselineHistoryCache.keys).
+      final vals = await LocalDb.trailingSeriesValues('rhr', 7);
+      if (vals.isEmpty) return null;
+      return vals.last;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Tolerance when clipping route points to their session's window. GPS
+  /// timestamps are millisecond-stamped while the session window is whole
+  /// seconds, so the very first and last fix can land a hair outside it.
+  static const int _routeClipPadSec = 5;
+
+  @override
   Future<WorkoutRoute?> getWorkoutRoute(String id) async {
     final rows = await LocalDb.routePoints(id);
     if (rows.length < 2) return null;
-    final points = [for (final r in rows) RoutePoint.fromRow(r)];
+    var points = [for (final r in rows) RoutePoint.fromRow(r)];
+
+    // Clip to the session's CURRENT window. A route point outside its
+    // session's window is not part of that session — which only became
+    // reachable once workouts could be retimed: narrowing a live run that was
+    // stopped late (say 90 min down to the 60 you actually ran) otherwise left
+    // the map, distance, moving time and splits describing the full original
+    // 90 minutes while the hero above them read "1h 00m". Two contradictory
+    // accounts of the same session on one card.
+    //
+    // Widening cannot conjure GPS that was never recorded, so the route simply
+    // stays as long as it is — correct, and honest about it.
+    final session = await LocalDb.session(id);
+    final startTs = (session?['start_ts'] as num?)?.toInt();
+    final endTs = (session?['end_ts'] as num?)?.toInt();
+    if (startTs != null && endTs != null && endTs > startTs) {
+      final lo = (startTs - _routeClipPadSec) * 1000;
+      final hi = (endTs + _routeClipPadSec) * 1000;
+      final clipped = [
+        for (final p in points)
+          if (p.tsMs >= lo && p.tsMs <= hi) p,
+      ];
+      // Fewer than two points is not a route — better no map than a single
+      // orphaned pin and a zero-length "distance".
+      if (clipped.length < 2) return null;
+      points = clipped;
+    }
 
     // 1 Hz HR over the route's own time window (± a small pad), for zone
     // colouring and per-split average HR.

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -2035,7 +2035,7 @@ class LocalRepositoryImpl extends LocalRepository {
     final rows = await LocalDb.sessionsInRange(0, 1 << 40);
     return [
       for (final r in rows)
-        if (r['id'] is String && r['start_ts'] is int && r['end_ts'] is int)
+        if (r['id'] is String && r['start_ts'] is num && r['end_ts'] is num)
           SessionSpan(
             r['id'] as String,
             (r['start_ts'] as num).toInt(),
@@ -2084,6 +2084,14 @@ class LocalRepositoryImpl extends LocalRepository {
     final existing = await LocalDb.session(id);
     if (existing == null) {
       throw StateError('setWorkoutWindow: no session $id');
+    }
+    // A running session has no end to correct yet, and buildManualSessionRow
+    // always writes status 'done' — retiming one here would silently end it.
+    // The detail screen already passes onEditTimes:null for a live row, but
+    // the window is re-validated at this seam precisely because the form is
+    // not the only caller; the status deserves the same treatment.
+    if (existing['status'] == 'live') {
+      throw StateError('setWorkoutWindow: session $id is still live');
     }
     // A retimed session keeps its id, so the OLD row is replaced rather than
     // orphaned — including its GPS route, which still belongs to it.

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -36,6 +36,7 @@ import '../ble/ios_ble_restore.dart';
 import '../cloud/companion_client.dart';
 import '../compute/derivation_engine.dart';
 import '../compute/derive_scheduler.dart';
+import '../compute/manual_session.dart' show strainFromPerMinuteHr;
 import '../compute/hr_max.dart';
 import '../compute/profile.dart';
 import '../data/day_label.dart';
@@ -1421,6 +1422,7 @@ class AppState extends ChangeNotifier {
   Future<void> _init() async {
     paired = await PairedDevice.load();
     await _loadProfile();
+    await _refreshNightlyRhr();
     await _deriveScheduler.init();
     lastSynced = await LocalDb.latestSample();
     // The true data-edge frontier is the `rec_ts_hw` sync cursor, NOT
@@ -3511,6 +3513,30 @@ class AppState extends ChangeNotifier {
 
   int get _restingHr => (user?['resting_hr'] as num?)?.round() ?? 60;
 
+  /// Latest MEASURED nightly resting HR (`metric_series` key 'rhr'), or null
+  /// before the first night has been derived. Refreshed on init and whenever a
+  /// workout starts, since RHR moves on the scale of weeks.
+  double? _nightlyRhr;
+
+  /// The resting-HR anchor for SCORING a live session: the measured nightly
+  /// value, else a user-supplied one, else nothing.
+  ///
+  /// Deliberately not [_restingHr], which falls back to 60 bpm. That default is
+  /// fine for display copy, but as a term inside the Banister formula it would
+  /// turn an absent input into a confident-looking strain number — exactly the
+  /// fabrication the honesty contract forbids. No anchor, no score.
+  double? get _liveRestingHr =>
+      _nightlyRhr ?? (user?['resting_hr'] as num?)?.toDouble();
+
+  Future<void> _refreshNightlyRhr() async {
+    try {
+      final vals = await LocalDb.trailingSeriesValues('rhr', 7);
+      if (vals.isNotEmpty) _nightlyRhr = vals.last;
+    } catch (_) {
+      /* best effort — falls back to the user-supplied RHR, or abstains */
+    }
+  }
+
   /// HR → zone 0..5 (% of max HR), matching the app's zone bands.
   int _zoneFor(int hr) {
     if (hr <= 0 || _maxHr <= 0) return 0;
@@ -3546,6 +3572,9 @@ class AppState extends ChangeNotifier {
       unawaited(engine.retryFullLiveStreams());
     }
     _workoutRawBase = _liveRaw;
+    // A first night may have been derived since init, so pick up a measured
+    // RHR before this session is scored against it.
+    unawaited(_refreshNightlyRhr());
     // Hold heavy derivation for the session — an isolate spawn mid-ride
     // competes with GPS, the live map and the BLE drain (see
     // DeriveScheduler.setWorkoutActive).
@@ -3561,6 +3590,9 @@ class AppState extends ChangeNotifier {
       workoutId: id,
       type: type,
       age: (user?['age'] as num?)?.round(),
+      // Score against the profile the session is performed under.
+      profile: Profile.fromMap(user),
+      restingHr: _liveRestingHr,
     );
     // Persist the live session (INSERT OR REPLACE — idempotent if repo already
     // inserted this id). Final stats are written on stop.
@@ -3735,6 +3767,8 @@ class AppState extends ChangeNotifier {
             workoutId: id,
             type: (row['type'] as String?) ?? 'other',
             age: (user?['age'] as num?)?.round(),
+            profile: Profile.fromMap(user),
+            restingHr: _liveRestingHr,
           );
           // Without this, `workoutSteps` (gated on _workoutRawBase != null)
           // stays 0 for the rest of this resumed session, and stopWorkout()
@@ -3743,6 +3777,9 @@ class AppState extends ChangeNotifier {
           // snapshot: steps count from zero going forward, same as
           // calories/strain/zone-minutes already (honestly) do here.
           _workoutRawBase = _liveRaw;
+    // A first night may have been derived since init, so pick up a measured
+    // RHR before this session is scored against it.
+    unawaited(_refreshNightlyRhr());
           // Never overwrite a live timer reference without cancelling it.
           _workoutTimer?.cancel();
           _workoutTimer = Timer.periodic(
@@ -3992,14 +4029,10 @@ class AppState extends ChangeNotifier {
       // Add per-second slice (kcal/min / 60). Clamp to 0 in case of low HR.
       w.calories += (kcalMin.clamp(0.0, 30.0) / 60.0);
 
-      // Rough strain accumulation (experimental): HRR% (HR Reserve) → strain/sec.
-      final maxHr = 220.0 - age;
-      final rhr = (u['resting_hr'] as num?)?.toDouble() ?? 60.0;
-      final hrr = (w.currentHr - rhr) / (maxHr - rhr).clamp(1.0, 200.0);
-      if (hrr > 0) {
-        w.strain +=
-            (hrr * 0.01); // scales to ~15-20 strain over an hour of hard work
-      }
+      // Strain is NOT accrued here. `accrueHr` (called above) recomputes it
+      // from the session's per-minute HR through the one shared Banister ->
+      // log-squash path, so the live gauge, a manually logged session and the
+      // day's own strain all mean the same thing on the same 0–21 scale.
     }
     // Push to the Live Activity at most ~every 4s (ActivityKit throttles; saves battery).
     if (DateTime.now().difference(_lastLaPush).inSeconds >= 4) {
@@ -4007,7 +4040,9 @@ class AppState extends ChangeNotifier {
       LiveActivity.update(
         hr: w.currentHr,
         zone: _zoneFor(w.currentHr),
-        strain: w.strain,
+        // The Live Activity widget has no absent state; the in-app gauge
+        // shows "—" when strain is null, this pushes 0.
+        strain: w.strain ?? 0,
         calories: w.calories.round(),
         maxHr: _maxHr,
         rhr: _restingHr,
@@ -4025,7 +4060,14 @@ class LiveWorkoutState {
   final String type; // exercise type label
   Duration elapsed = Duration.zero;
   double calories = 0.0;
-  double strain = 0.0;
+
+  /// Headline 0–21 strain, or null when the profile lacks an anchor the
+  /// Banister formula needs. Recomputed on every HR sample by [accrueHr] — it
+  /// is NOT accrued incrementally any more. The old `strain += %HRR * 0.01`
+  /// per second was uncited and uncapped: it read 25.33 where the canonical
+  /// method reads 11.62 for the same hour, and passed the top of its own 0–21
+  /// scale after ~50 minutes of hard work, which the gauge silently clamped.
+  double? strain;
   int currentHr = 0;
   int maxHrSeen = 0; // spike-suppressed peak live HR this session (issue #127)
 
@@ -4054,18 +4096,63 @@ class LiveWorkoutState {
           double.parse((zoneSeconds[z] / 60.0).toStringAsFixed(2)),
       ];
 
+  /// Anchors for the live strain score. Held on the session because a workout
+  /// must be scored against the profile it was performed under, not whatever
+  /// the profile happens to say when the session ends.
+  final Profile profile;
+  final double? restingHr;
+
+  /// Per-minute mean HR, the unit Banister TRIMP weights. Live HR arrives at
+  /// 1 Hz, so it is folded into the current minute here rather than kept as
+  /// thousands of raw samples.
+  final List<double> _perMinuteHr = [];
+  int _minuteBucket = -1;
+  double _minuteSum = 0;
+  int _minuteCount = 0;
+
+  /// Per-minute means INCLUDING the minute still in progress, so the live
+  /// gauge moves within the first minute instead of sitting at zero for 60 s.
+  List<double> perMinuteHr() => [
+        ..._perMinuteHr,
+        if (_minuteCount > 0) _minuteSum / _minuteCount,
+      ];
+
   LiveWorkoutState({
     required this.startTime,
     required this.targetKcal,
     this.workoutId,
     this.type = 'other',
     int? age,
+    this.profile = const Profile(),
+    this.restingHr,
   }) : _hrPeak = RollingMaxHr(age: age);
 
-  /// Feed a live 1 Hz HR sample; updates the spike-suppressed [maxHrSeen].
+  /// Feed a live 1 Hz HR sample; updates the spike-suppressed [maxHrSeen], the
+  /// per-minute accumulator, and the Banister strain derived from it.
   void accrueHr(int hr) {
     if (hr <= 0) return;
     _hrPeak.add(hr);
     if (_hrPeak.max > maxHrSeen) maxHrSeen = _hrPeak.max;
+
+    // Fold into the current minute, measured from the session start so the
+    // buckets are the session's own minutes rather than wall-clock ones.
+    final minute = elapsed.inMinutes;
+    if (minute != _minuteBucket) {
+      if (_minuteCount > 0) _perMinuteHr.add(_minuteSum / _minuteCount);
+      _minuteBucket = minute;
+      _minuteSum = 0;
+      _minuteCount = 0;
+    }
+    _minuteSum += hr;
+    _minuteCount++;
+
+    // ONE strain method across the app (see strainFromPerMinuteHr). Null when
+    // an anchor is missing — the gauge shows "—" rather than a number built on
+    // an invented HRmax or resting HR.
+    strain = strainFromPerMinuteHr(
+      perMinuteHr(),
+      profile: profile,
+      restingHr: restingHr,
+    );
   }
 }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -3531,7 +3531,16 @@ class AppState extends ChangeNotifier {
   Future<void> _refreshNightlyRhr() async {
     try {
       final vals = await LocalDb.trailingSeriesValues('rhr', 7);
-      if (vals.isNotEmpty) _nightlyRhr = vals.last;
+      if (vals.isEmpty) return;
+      _nightlyRhr = vals.last;
+      // Adopt it into a session that started before this read completed, but
+      // only to FILL A GAP — overwriting an anchor a running session was
+      // already scored against would move its number mid-workout.
+      final w = activeWorkout;
+      if (w != null && w.restingHr == null) {
+        w.restingHr = _liveRestingHr;
+        notifyListeners();
+      }
     } catch (_) {
       /* best effort — falls back to the user-supplied RHR, or abstains */
     }
@@ -3572,8 +3581,9 @@ class AppState extends ChangeNotifier {
       unawaited(engine.retryFullLiveStreams());
     }
     _workoutRawBase = _liveRaw;
-    // A first night may have been derived since init, so pick up a measured
-    // RHR before this session is scored against it.
+    // A first night may have been derived since init. This read finishes
+    // after the session below is constructed, so it back-fills the anchor on
+    // `activeWorkout` when it lands rather than blocking the start.
     unawaited(_refreshNightlyRhr());
     // Hold heavy derivation for the session — an isolate spawn mid-ride
     // competes with GPS, the live map and the BLE drain (see
@@ -3777,8 +3787,9 @@ class AppState extends ChangeNotifier {
           // snapshot: steps count from zero going forward, same as
           // calories/strain/zone-minutes already (honestly) do here.
           _workoutRawBase = _liveRaw;
-    // A first night may have been derived since init, so pick up a measured
-    // RHR before this session is scored against it.
+    // A first night may have been derived since init. This read finishes
+    // after the session below is constructed, so it back-fills the anchor on
+    // `activeWorkout` when it lands rather than blocking the start.
     unawaited(_refreshNightlyRhr());
           // Never overwrite a live timer reference without cancelling it.
           _workoutTimer?.cancel();
@@ -4100,7 +4111,14 @@ class LiveWorkoutState {
   /// must be scored against the profile it was performed under, not whatever
   /// the profile happens to say when the session ends.
   final Profile profile;
-  final double? restingHr;
+
+  /// Resting-HR anchor for the strain score. NOT final: the measured nightly
+  /// value is loaded asynchronously, so a session can begin before it lands.
+  /// [AppState._refreshNightlyRhr] back-fills it here when it arrives, and the
+  /// next HR sample re-scores through it — otherwise the session would be
+  /// stuck unscored for its whole duration over a read that finished a
+  /// fraction of a second after it started.
+  double? restingHr;
 
   /// Per-minute mean HR, the unit Banister TRIMP weights. Live HR arrives at
   /// 1 Hz, so it is folded into the current minute here rather than kept as

--- a/lib/ui/activity/live_session_screen.dart
+++ b/lib/ui/activity/live_session_screen.dart
@@ -309,7 +309,7 @@ class _LiveSessionScreenState extends State<LiveSessionScreen>
       duration: w?.elapsed ?? Duration.zero,
       peakHr: w?.maxHrSeen ?? 0,
       calories: w?.calories ?? 0,
-      strain: w?.strain ?? 0,
+      strain: w?.strain,
       steps: app.workoutSteps,
     );
     // AWAIT: stopWorkout flushes the GPS route tail; navigating before it
@@ -702,7 +702,11 @@ class WorkoutFinishSnapshot {
   final Duration duration;
   final int peakHr;
   final double calories;
-  final double strain;
+
+  /// Null when the profile lacked an anchor the Banister score needs. Kept
+  /// nullable all the way to the finish card: a `?? 0` here would print a
+  /// confident "0.0" for a session that was simply never scored.
+  final double? strain;
   final int steps;
   const WorkoutFinishSnapshot({
     required this.type,
@@ -832,8 +836,10 @@ class _WorkoutFinishScreenState extends State<WorkoutFinishScreen>
           final s = widget.snapshot;
           final strain = (d['strain'] as num?)?.toDouble() ?? s.strain;
           final tw = recs.record('top_workout');
-          _prWorkout =
-              tw != null && strain > 0 && (strain - tw.value).abs() < 0.15;
+          _prWorkout = tw != null &&
+              strain != null &&
+              strain > 0 &&
+              (strain - tw.value).abs() < 0.15;
           final ms = recs.record('most_steps');
           _prSteps = ms != null &&
               s.steps > 0 &&
@@ -1028,9 +1034,12 @@ class _WorkoutFinishScreenState extends State<WorkoutFinishScreen>
     );
   }
 
-  Widget _strainGauge(double strain) => Center(
+  /// The 0–21 strain dial. [strain] is null for a session the profile could
+  /// not anchor — the arc sits empty and the readout is a dash, rather than a
+  /// full-looking gauge over a fabricated number.
+  Widget _strainGauge(double? strain) => Center(
         child: ArcGauge(
-          value: (strain / 21).clamp(0.0, 1.0),
+          value: strain == null ? 0.0 : (strain / 21).clamp(0.0, 1.0),
           color: AppColors.accent,
           size: 176,
           stroke: 15,
@@ -1042,7 +1051,10 @@ class _WorkoutFinishScreenState extends State<WorkoutFinishScreen>
             builder: (context, _) => Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text((strain * _seg(0.0, 0.5)).toStringAsFixed(1),
+                Text(
+                    strain == null
+                        ? '—'
+                        : (strain * _seg(0.0, 0.5)).toStringAsFixed(1),
                     style: AppText.display),
                 Text('STRAIN', style: AppText.overline),
               ],
@@ -1376,7 +1388,7 @@ class _WorkoutFinishScreenState extends State<WorkoutFinishScreen>
       duration: s.duration,
       when: DateTime.now(),
       maxHr: _maxHr,
-      strain: (d?['strain'] as num?)?.toDouble() ?? s.strain,
+      strain: (d?['strain'] as num?)?.toDouble() ?? s.strain ?? 0,
       calories: (d?['calories'] as num?)?.toInt() ?? s.calories.round(),
       route: _route,
       avgHr: (d?['avg_hr'] as num?)?.toInt(),
@@ -2489,7 +2501,11 @@ class _SessionSheet extends StatelessWidget {
                   ),
                   Expanded(
                     child: _SheetStat(
-                      isRoute ? (pace ?? '—') : workout.strain.toStringAsFixed(1),
+                      isRoute
+                          ? (pace ?? '—')
+                          // Null until the profile carries the anchors
+                          // Banister needs — a dash, never a 0.0.
+                          : (workout.strain?.toStringAsFixed(1) ?? '—'),
                       isRoute ? 'PACE' : 'STRAIN',
                     ),
                   ),

--- a/lib/ui/workouts/manual_workout_screen.dart
+++ b/lib/ui/workouts/manual_workout_screen.dart
@@ -15,6 +15,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../compute/manual_session.dart';
+import '../../data/day_label.dart';
 import '../../state/app_state.dart';
 import '../../theme/theme_switcher.dart';
 import '../design/design.dart';
@@ -115,12 +116,18 @@ class _ManualWorkoutScreenState extends State<ManualWorkoutScreen> {
 
   Future<void> _pickDate() async {
     final now = DateTime.now();
+    // Back to the start of last year is plenty for back-filling; forward is
+    // pointless — a future session is rejected anyway. But an EDIT can carry a
+    // session older than that floor (sessions are never pruned, and an import
+    // can bring in years of history), and showDatePicker asserts that
+    // initialDate is on or after firstDate. Widen the floor to admit whatever
+    // we are about to show rather than opening a picker that throws.
+    final floor = DateTime(now.year - 1, 1, 1);
+    final firstDate = _start.isBefore(floor) ? DateTime(_start.year, 1, 1) : floor;
     final picked = await showDatePicker(
       context: context,
       initialDate: _start,
-      // Back to the start of last year is plenty for back-filling; forward is
-      // pointless — a future session is rejected anyway.
-      firstDate: DateTime(now.year - 1, 1, 1),
+      firstDate: firstDate,
       lastDate: now,
       helpText: 'Which day?',
     );
@@ -336,17 +343,24 @@ class _ManualWorkoutScreenState extends State<ManualWorkoutScreen> {
   }
 }
 
+/// Local calendar-day label for the date row.
+///
+/// Compares day LABELS, not elapsed seconds. `today.difference(that).inDays`
+/// measures the gap between two local midnights, and a spring-forward day is
+/// 23 h — which truncates to 0, so yesterday renders as "Today"; a fall-back
+/// day is 25 h and pushes the label the other way. Day identity is calendar
+/// identity, which is what `dayLabelOf` encodes.
 String _dateLabel(DateTime d) {
   const mon = [
     'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
     'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
   ];
+  final label = dayLabelOf(d);
+  if (label == todayLabel()) return 'Today';
   final now = DateTime.now();
-  final today = DateTime(now.year, now.month, now.day);
-  final that = DateTime(d.year, d.month, d.day);
-  final diff = today.difference(that).inDays;
-  if (diff == 0) return 'Today';
-  if (diff == 1) return 'Yesterday';
+  if (label == dayLabelOf(DateTime(now.year, now.month, now.day - 1))) {
+    return 'Yesterday';
+  }
   return '${mon[d.month - 1]} ${d.day}';
 }
 

--- a/lib/ui/workouts/manual_workout_screen.dart
+++ b/lib/ui/workouts/manual_workout_screen.dart
@@ -1,0 +1,445 @@
+// Manual workout entry / retime — the form behind "Log a past workout" and
+// the detail screen's "Edit times".
+//
+// The band's auto-detector reports the HARD-EFFORT CORE of a session, not its
+// wall-clock (see `compute/manual_session.dart` for the gate constants). An
+// hour of mixed-intensity training routinely surfaces as ~25 minutes, and
+// until now the only session writer stamped `DateTime.now()` — so there was no
+// way to say what actually happened. This screen is that way.
+//
+// It owns NO policy: validation is `validateManualWindow`, scoring is
+// `computeManualSessionStats`, and the row shape is `buildManualSessionRow`,
+// all pure and unit-tested. This file picks times and renders the verdict.
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../compute/manual_session.dart';
+import '../../state/app_state.dart';
+import '../../theme/theme_switcher.dart';
+import '../design/design.dart';
+import 'workout_types.dart';
+
+/// Push the manual-entry form. Returns true when a session was written.
+///
+/// [editing] is an existing session row (from `getWorkout`) when retiming;
+/// null starts a blank entry.
+Future<bool> showManualWorkoutScreen(
+  BuildContext context, {
+  Map<String, dynamic>? editing,
+}) async {
+  final saved = await Navigator.of(context).push<bool>(
+    themedRoute<bool>(
+      (_) => ManualWorkoutScreen(editing: editing),
+      fullscreenDialog: true,
+      name: 'ManualWorkoutScreen',
+    ),
+  );
+  return saved == true;
+}
+
+class ManualWorkoutScreen extends StatefulWidget {
+  /// The session being retimed, or null for a fresh entry.
+  final Map<String, dynamic>? editing;
+  const ManualWorkoutScreen({super.key, this.editing});
+
+  @override
+  State<ManualWorkoutScreen> createState() => _ManualWorkoutScreenState();
+}
+
+class _ManualWorkoutScreenState extends State<ManualWorkoutScreen> {
+  late DateTime _start;
+  late DateTime _end;
+  late String _type;
+
+  /// Every saved span, for the overlap check. Loaded once; until it arrives the
+  /// overlap rule simply cannot fire here — the repo re-validates at the write
+  /// seam and throws [ManualWindowException], so a stale snapshot cannot slip
+  /// an overlapping session through.
+  List<SessionSpan> _spans = const [];
+
+  bool _saving = false;
+
+  /// Message under the form. [_savedUnscored] says which KIND it is: a write
+  /// that succeeded but could not be scored, versus one that was refused.
+  /// Keeping these apart matters — the button turns into "Done" only for the
+  /// former; conflating them would let a REFUSED save close the form as though
+  /// it had worked.
+  String? _notice;
+  bool _savedUnscored = false;
+
+  bool get _isEdit => widget.editing != null;
+
+  @override
+  void initState() {
+    super.initState();
+    final e = widget.editing;
+    final startTs = (e?['start_ts'] as num?)?.toInt();
+    final endTs = (e?['end_ts'] as num?)?.toInt();
+    if (startTs != null && endTs != null && endTs > startTs) {
+      _start = DateTime.fromMillisecondsSinceEpoch(startTs * 1000).toLocal();
+      _end = DateTime.fromMillisecondsSinceEpoch(endTs * 1000).toLocal();
+    } else {
+      // A blank entry defaults to "an hour, ending an hour ago" — near enough
+      // to a just-finished session that most edits are one or two taps.
+      final now = DateTime.now();
+      _end = DateTime(now.year, now.month, now.day, now.hour, now.minute)
+          .subtract(const Duration(hours: 1));
+      _start = _end.subtract(const Duration(hours: 1));
+    }
+    _type = (e?['type'] as String?) ?? 'run';
+    _loadSpans();
+  }
+
+  Future<void> _loadSpans() async {
+    final api = context.read<AppState>().repo;
+    if (api == null) return;
+    try {
+      final s = await api.savedSessionSpans();
+      if (mounted) setState(() => _spans = s);
+    } catch (_) {
+      /* overlap check degrades to "not enforced here"; save still validates */
+    }
+  }
+
+  int get _startSec => _start.millisecondsSinceEpoch ~/ 1000;
+  int get _endSec => _end.millisecondsSinceEpoch ~/ 1000;
+
+  ManualWindowError? get _error => validateManualWindow(
+        startSec: _startSec,
+        endSec: _endSec,
+        nowSec: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        existing: _spans,
+        editingId: widget.editing?['id'] as String?,
+      );
+
+  Future<void> _pickDate() async {
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _start,
+      // Back to the start of last year is plenty for back-filling; forward is
+      // pointless — a future session is rejected anyway.
+      firstDate: DateTime(now.year - 1, 1, 1),
+      lastDate: now,
+      helpText: 'Which day?',
+    );
+    if (picked == null || !mounted) return;
+    setState(() {
+      // Move BOTH ends by the same number of days so the duration survives the
+      // date change — otherwise picking a date silently rewrites the length.
+      final delta = _end.difference(_start);
+      _start = DateTime(picked.year, picked.month, picked.day, _start.hour,
+          _start.minute);
+      _end = _start.add(delta);
+      _notice = null;
+      _savedUnscored = false;
+    });
+  }
+
+  Future<void> _pickTime({required bool isStart}) async {
+    final base = isStart ? _start : _end;
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(base),
+      helpText: isStart ? 'When did you start?' : 'When did you finish?',
+    );
+    if (picked == null || !mounted) return;
+    setState(() {
+      if (isStart) {
+        final delta = _end.difference(_start);
+        _start = DateTime(
+            _start.year, _start.month, _start.day, picked.hour, picked.minute);
+        // Keep the duration when the start moves — the athlete is placing the
+        // session, not resizing it.
+        _end = _start.add(delta);
+      } else {
+        var e = DateTime(
+            _start.year, _start.month, _start.day, picked.hour, picked.minute);
+        // A finish time earlier in the clock than the start means the session
+        // ran past midnight.
+        if (!e.isAfter(_start)) e = e.add(const Duration(days: 1));
+        _end = e;
+      }
+      _notice = null;
+      _savedUnscored = false;
+    });
+  }
+
+  Future<void> _pickType() async {
+    final t = await pickWorkoutType(context, title: 'Workout type');
+    if (t == null || !mounted) return;
+    setState(() => _type = t);
+  }
+
+  Future<void> _save() async {
+    if (_error != null || _saving) return;
+    final api = context.read<AppState>().repo;
+    if (api == null) return;
+    setState(() {
+      _saving = true;
+      _notice = null;
+      _savedUnscored = false;
+    });
+    try {
+      final editingId = widget.editing?['id'] as String?;
+      final res = editingId != null
+          ? await api.setWorkoutWindow(editingId,
+              startTs: _startSec, endTs: _endSec)
+          : await api.logManualWorkout(
+              startTs: _startSec, endTs: _endSec, type: _type);
+      if (!mounted) return;
+      if (res['unscored'] == true) {
+        // Saved, but we cannot score it — say so plainly rather than showing a
+        // workout with silent blanks where strain and calories should be.
+        setState(() {
+          _saving = false;
+          _savedUnscored = true;
+          _notice =
+              'Saved. There is no heart-rate data left for that window, so '
+              'strain and calories will stay blank — the band only keeps '
+              'about three days of second-by-second data on the phone.';
+        });
+        return;
+      }
+      Navigator.of(context).pop(true);
+    } on ManualWindowException catch (e) {
+      // The write seam re-validated and refused — most likely the saved-span
+      // snapshot went stale mid-edit. Show the real reason, not "try again".
+      if (mounted) {
+        setState(() {
+          _saving = false;
+          _notice = e.error.message;
+        });
+        _loadSpans(); // refresh the snapshot so live validation agrees
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() {
+          _saving = false;
+          _notice = "Couldn't save that workout. Please try again.";
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tone = ToneScope.of(context);
+    final err = _error;
+    final dur = _endSec > _startSec
+        ? Duration(seconds: _endSec - _startSec)
+        : Duration.zero;
+
+    return AppScaffold(
+      title: _isEdit ? 'Edit times' : 'Log a workout',
+      subtitle: _isEdit
+          ? 'Set the window this session actually covered'
+          : 'For a session your strap missed',
+      bottomBar: Padding(
+        padding: const EdgeInsets.fromLTRB(Sp.screen, 0, Sp.screen, Sp.x5),
+        child: _SaveButton(
+          label: _savedUnscored
+              ? 'Done'
+              : (_isEdit ? 'Save times' : 'Log workout'),
+          enabled: (_savedUnscored || err == null) && !_saving,
+          busy: _saving,
+          onTap: () {
+            // Once the unscored notice is showing the write already happened —
+            // a second tap must close, not save the same window twice. A
+            // REFUSED save also leaves a notice, so key this on the flag, never
+            // on "a notice exists": popping there would report a success that
+            // never occurred.
+            if (_savedUnscored) {
+              Navigator.of(context).pop(true);
+            } else {
+              _save();
+            }
+          },
+        ),
+      ),
+      children: [
+        SurfaceCard(
+          child: Column(
+            children: [
+              if (!_isEdit)
+                ListRow(
+                  icon: workoutTypeIcon(_type),
+                  title: 'Type',
+                  value: workoutTypeLabel(_type),
+                  onTap: _pickType,
+                  divider: true,
+                ),
+              ListRow(
+                icon: OsIcon.calendar,
+                title: 'Date',
+                value: _dateLabel(_start),
+                onTap: _pickDate,
+                divider: true,
+              ),
+              ListRow(
+                icon: OsIcon.history,
+                title: 'Start',
+                value: _timeLabel(context, _start),
+                onTap: () => _pickTime(isStart: true),
+                divider: true,
+              ),
+              ListRow(
+                icon: OsIcon.history,
+                title: 'Finish',
+                value: _timeLabel(context, _end) +
+                    (_end.day != _start.day ? ' (next day)' : ''),
+                onTap: () => _pickTime(isStart: false),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: Sp.x4),
+        SurfaceCard(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: Sp.x2),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('DURATION',
+                    style: AppText.overline.copyWith(color: tone.fgFaint)),
+                const SizedBox(height: Sp.x1),
+                Text(
+                  _durationLabel(dur),
+                  style: AppText.hero.copyWith(fontSize: 40, color: tone.fg),
+                ),
+              ],
+            ),
+          ),
+        ),
+        if (err != null) ...[
+          const SizedBox(height: Sp.x3),
+          _Note(err.message, tone: _NoteTone.error),
+        ],
+        if (_notice != null) ...[
+          const SizedBox(height: Sp.x3),
+          _Note(_notice!, tone: _NoteTone.info),
+        ],
+        const SizedBox(height: Sp.x4),
+        Text(
+          _isEdit
+              ? 'Strain, calories and heart rate are recomputed from the '
+                  'second-by-second data inside the new window.'
+              : 'Strain, calories and heart rate are read from the '
+                  'second-by-second data your strap already recorded for that '
+                  'window — nothing is estimated from the duration alone.',
+          style: AppText.captionMuted.copyWith(color: tone.fgMuted),
+        ),
+        const SizedBox(height: Sp.x6),
+      ],
+    );
+  }
+}
+
+String _dateLabel(DateTime d) {
+  const mon = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  final that = DateTime(d.year, d.month, d.day);
+  final diff = today.difference(that).inDays;
+  if (diff == 0) return 'Today';
+  if (diff == 1) return 'Yesterday';
+  return '${mon[d.month - 1]} ${d.day}';
+}
+
+String _timeLabel(BuildContext context, DateTime d) =>
+    TimeOfDay.fromDateTime(d).format(context);
+
+String _durationLabel(Duration d) {
+  if (d <= Duration.zero) return '—';
+  final h = d.inHours;
+  final m = d.inMinutes % 60;
+  if (h == 0) return '${m}m';
+  return m == 0 ? '${h}h' : '${h}h ${m}m';
+}
+
+enum _NoteTone { error, info }
+
+class _Note extends StatelessWidget {
+  final String text;
+  final _NoteTone tone;
+  const _Note(this.text, {required this.tone});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = tone == _NoteTone.error ? AppColors.critical : AppColors.accent;
+    return Container(
+      padding: const EdgeInsets.all(Sp.x3),
+      decoration: BoxDecoration(
+        color: c.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(R.cardSm),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            tone == _NoteTone.error
+                ? Icons.error_outline
+                : Icons.info_outline,
+            size: 18,
+            color: c,
+          ),
+          const SizedBox(width: Sp.x2),
+          Expanded(child: Text(text, style: AppText.caption.copyWith(color: c))),
+        ],
+      ),
+    );
+  }
+}
+
+class _SaveButton extends StatelessWidget {
+  final String label;
+  final bool enabled;
+  final bool busy;
+  final VoidCallback onTap;
+  const _SaveButton({
+    required this.label,
+    required this.enabled,
+    required this.busy,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      enabled: enabled,
+      label: label,
+      child: Pressable(
+        pressedScale: enabled ? 0.97 : 1.0,
+        onTap: enabled ? onTap : null,
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(vertical: Sp.x4),
+          decoration: BoxDecoration(
+            color: enabled
+                ? AppColors.accent
+                : AppColors.accent.withValues(alpha: 0.35),
+            borderRadius: BorderRadius.circular(R.pill),
+          ),
+          child: Center(
+            child: busy
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      valueColor: AlwaysStoppedAnimation(Colors.white),
+                    ),
+                  )
+                : Text(label,
+                    style: AppText.label.copyWith(color: Colors.white)),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/workouts/workout_types.dart
+++ b/lib/ui/workouts/workout_types.dart
@@ -93,3 +93,34 @@ Widget workoutTypeGrid(BuildContext context) => Wrap(
       ),
   ],
 );
+
+/// Bottom-sheet type picker (no workout start) — used to confirm/correct an
+/// auto-detected workout's type and to set the type on a manually logged one.
+/// Returns the chosen type, or null if dismissed.
+///
+/// Lives here rather than in workouts_screen.dart so the manual-entry form can
+/// reach it without the two screen files importing each other.
+Future<String?> pickWorkoutType(
+  BuildContext context, {
+  String title = 'Set workout type',
+}) {
+  return showModalBottomSheet<String>(
+    context: context,
+    builder: (_) => SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.all(Sp.x5),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: AppText.h2),
+            const SizedBox(height: Sp.x4),
+            Builder(builder: workoutTypeGrid),
+            const SizedBox(height: Sp.x4),
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/ui/workouts/workouts_screen.dart
+++ b/lib/ui/workouts/workouts_screen.dart
@@ -15,6 +15,7 @@ import '../../state/prefs.dart';
 import '../../state/units_controller.dart';
 import '../../models/payloads.dart';
 import '../../data/day_label.dart';
+import '../../compute/manual_session.dart' show ManualWindowException;
 import '../../data/db.dart';
 import '../activity/live_session_screen.dart';
 import '../activity/workout_share_card.dart';
@@ -567,6 +568,15 @@ Future<void> _logDetectedSession(Map<String, dynamic> s,
         unawaited(appState.exportWorkoutToHealth(saved));
       }
       return;
+    } on ManualWindowException {
+      // A REFUSAL is not a failure to retry differently. The window collides
+      // with a session already in the log, so those minutes are recorded
+      // already; falling through would write a duplicate under the same
+      // `auto:` id AND strip it back to the blank strain/calories this change
+      // set out to remove — bypassing the very rule the write seam enforces.
+      // The athlete acted on the card, so retire it and stop.
+      await LocalDb.dismissWorkoutSuggestion(s['id'] as String);
+      return;
     } catch (_) {
       // Fall through to the unscored write — a suggestion the athlete has
       // explicitly accepted must land in the log either way.
@@ -622,7 +632,21 @@ class _WindowLabel extends StatelessWidget {
       style: AppText.captionMuted.copyWith(color: tone.fgMuted),
     );
     if (onTap == null) return label;
+    // NOTE: this annotation merges into an ancestor card's semantics node
+    // rather than standing on its own, so the button flag and label here are
+    // contributions to that merged node, not a node of their own. `container:
+    // true` + `excludeSemantics: true` were tried to force a standalone node
+    // and could NOT be shown to work — tester.getSemantics still resolved to
+    // the ancestor. Excluding the child's semantics on that evidence would
+    // have risked dropping the window text from the merged announcement while
+    // gaining nothing, which is the same trap as excluding semantics without
+    // re-exposing the action. Left as a plain annotation until someone can
+    // demonstrate the improvement; the key below is what tests target.
     return Semantics(
+      // Stable handle for targeting the affordance itself — the window text
+      // alone is not distinguishing, since the zone rows render "133–152 bpm"
+      // with the same en dash.
+      key: const Key('workout-window-edit'),
       button: true,
       label: 'Edit workout times. Currently $text',
       child: Pressable(

--- a/lib/ui/workouts/workouts_screen.dart
+++ b/lib/ui/workouts/workouts_screen.dart
@@ -23,6 +23,7 @@ import '../design/design.dart';
 import '../kit/route_map.dart';
 import '../screens/detail_cards.dart' show hm;
 import '../../gps/route_models.dart';
+import 'manual_workout_screen.dart';
 import 'workout_types.dart';
 
 const _ranges = ['Today', 'Week', 'Month', '3M'];
@@ -77,6 +78,15 @@ String _whenLabel(int? startTs) {
 }
 
 /// Bottom-sheet exercise picker → starts a workout → opens the live screen.
+///
+/// NOTE — do not grow this sheet. `showModalBottomSheet` defaults to
+/// `isScrollControlled: false`, which caps it at 9/16 of the screen (~475 pt on
+/// a 390x844 device). The nine type tiles already wrap to three rows (~294 pt)
+/// and, with the title and gutters, land close to that ceiling. A fourth child
+/// was added here once and was clipped clean off the bottom — invisible and
+/// untappable in release, where there are no overflow stripes to give it away.
+/// Logging a PAST workout is a header action ([_AddButton]) for exactly that
+/// reason.
 Future<void> startWorkoutFlow(BuildContext context) async {
   final type = await showModalBottomSheet<String>(
     context: context,
@@ -115,33 +125,6 @@ Future<void> startWorkoutFlow(BuildContext context) async {
   } catch (_) {
     /* surfaced as no-op; user can retry */
   }
-}
-
-/// Bottom-sheet type picker (no workout start) — used to confirm/correct an
-/// auto-detected workout's type. Returns the chosen type, or null if dismissed.
-Future<String?> pickWorkoutType(
-  BuildContext context, {
-  String title = 'Set workout type',
-}) {
-  return showModalBottomSheet<String>(
-    context: context,
-    builder: (_) => SafeArea(
-      top: false,
-      child: Padding(
-        padding: const EdgeInsets.all(Sp.x5),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(title, style: AppText.h2),
-            const SizedBox(height: Sp.x4),
-            Builder(builder: workoutTypeGrid),
-            const SizedBox(height: Sp.x4),
-          ],
-        ),
-      ),
-    ),
-  );
 }
 
 class WorkoutsScreen extends StatefulWidget {
@@ -208,6 +191,13 @@ class _WorkoutsScreenState extends State<WorkoutsScreen> {
     await _load();
   }
 
+  /// Log a session that is already over — one the strap missed, or only caught
+  /// part of (the detector reports an effort's hard-effort core, not its
+  /// wall-clock, so an hour of training routinely surfaces as ~25 minutes).
+  Future<void> _logPastWorkout() async {
+    if (await showManualWorkoutScreen(context) && mounted) await _load();
+  }
+
   // LOCAL calendar day — "today's workouts" must match the local day model
   // (a UTC comparison shifted early-morning sessions into yesterday's bucket).
   bool _isToday(int startTs) =>
@@ -226,7 +216,14 @@ class _WorkoutsScreenState extends State<WorkoutsScreen> {
 
     return AppScaffold(
       title: 'Workouts',
-      actions: [_StartButton(onTap: () => startWorkoutFlow(context).then((_) => _load()))],
+      // AppScaffold already inserts Sp.x2 before EACH action — no manual
+      // spacer between these two, or the gap comes out at three times the
+      // intended width.
+      actions: [
+        _AddButton(onTap: _logPastWorkout),
+        _StartButton(
+            onTap: () => startWorkoutFlow(context).then((_) => _load())),
+      ],
       header: SegmentedControl(
         options: _ranges,
         index: _range,
@@ -279,7 +276,8 @@ class _WorkoutsScreenState extends State<WorkoutsScreen> {
                 StateCard(
                   icon: OsIcon.run,
                   title: 'No workouts',
-                  message: 'Tap Start, or an effort will be auto-detected.',
+                  message: 'Tap Start, or an effort will be auto-detected. '
+                      'You can also log one you already finished.',
                   actionLabel: 'Start a workout',
                   onAction: () => startWorkoutFlow(context).then((_) => _load()),
                 )
@@ -471,6 +469,45 @@ class _WorkoutsScreenState extends State<WorkoutsScreen> {
   }
 }
 
+/// Tonal Add pill — logs a workout that is already finished.
+///
+/// Deliberately the QUIETER sibling of [_StartButton]: starting a live session
+/// is the primary action and keeps the solid accent fill, while back-filling
+/// one sits on a tonal fill at the same size. Same pill geometry so the pair
+/// reads as one control group rather than two unrelated buttons.
+class _AddButton extends StatelessWidget {
+  final VoidCallback onTap;
+  const _AddButton({required this.onTap});
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: 'Log a past workout',
+      child: Pressable(
+        pressedScale: 0.94,
+        onTap: onTap,
+        child: Container(
+          padding:
+              const EdgeInsets.symmetric(horizontal: Sp.x4, vertical: Sp.x3),
+          decoration: BoxDecoration(
+            color: AppColors.tonalFill(AppColors.accent),
+            borderRadius: BorderRadius.circular(R.pill),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.add_rounded, size: 18, color: AppColors.accent),
+              const SizedBox(width: Sp.x1),
+              Text('Add',
+                  style: AppText.label.copyWith(color: AppColors.accent)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 /// Solid ember Start pill — top-right of the Workouts header. Restrained:
 /// brand accent + standard elevation, no gradient/glow.
 class _StartButton extends StatelessWidget {
@@ -512,11 +549,35 @@ class _StartButton extends StatelessWidget {
 Future<void> _logDetectedSession(Map<String, dynamic> s,
     [AppState? appState]) async {
   final start = (s['start_ts'] as num?)?.toInt() ?? 0;
+  final end = (s['end_ts'] as num?)?.toInt();
+  final type = (s['sport'] as String?) ?? 'cardio';
+
+  // Score it over the bout window through the SAME path a manually logged
+  // session uses. This used to hand-build a row with no `strain` and no
+  // `calories`, so every confirmed suggestion landed in the log showing
+  // blanks — the numbers were computable from the 1 Hz substrate the whole
+  // time, nothing was ever asking for them.
+  final api = appState?.repo;
+  if (api != null && end != null && end > start) {
+    try {
+      await api.logDetectedWorkout(startTs: start, endTs: end, type: type);
+      await LocalDb.dismissWorkoutSuggestion(s['id'] as String);
+      final saved = await LocalDb.session('auto:$start');
+      if (saved != null && appState!.healthSyncEnabled) {
+        unawaited(appState.exportWorkoutToHealth(saved));
+      }
+      return;
+    } catch (_) {
+      // Fall through to the unscored write — a suggestion the athlete has
+      // explicitly accepted must land in the log either way.
+    }
+  }
+
   final row = {
     'id': 'auto:$start',
     'start_ts': start,
-    'end_ts': (s['end_ts'] as num?)?.toInt(),
-    'type': (s['sport'] as String?) ?? 'cardio',
+    'end_ts': end,
+    'type': type,
     'status': 'done',
     'duration_min': (s['duration_min'] as num?)?.toInt(),
     'max_hr': (s['peak_bpm'] as num?)?.toInt(),
@@ -532,6 +593,54 @@ Future<void> _logDetectedSession(Map<String, dynamic> s,
 
 /// An opt-in auto-detected workout the user can confirm (→ logs a session) or
 /// dismiss. We never auto-log: this is "did you work out?", not a silent write.
+/// The session's time window on the detail hero — and, when [onTap] is given,
+/// the way into the retime form.
+///
+/// Renders "Today · 6:30 PM – 7:31 PM" rather than just the start, because the
+/// window is exactly what the athlete is here to check: an effort the detector
+/// clipped to its hard-effort core reads as an hour that finished 35 minutes
+/// early, and you cannot see that from a start time alone.
+class _WindowLabel extends StatelessWidget {
+  final int? startTs;
+  final int? endTs;
+  final VoidCallback? onTap;
+  final ToneColors tone;
+  const _WindowLabel({
+    required this.startTs,
+    required this.endTs,
+    required this.onTap,
+    required this.tone,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final start = _whenLabel(startTs);
+    final end = endTs == null || endTs == 0 ? null : _clockLabel(endTs);
+    final text = end == null ? start : '$start – $end';
+    final label = Text(
+      text,
+      style: AppText.captionMuted.copyWith(color: tone.fgMuted),
+    );
+    if (onTap == null) return label;
+    return Semantics(
+      button: true,
+      label: 'Edit workout times. Currently $text',
+      child: Pressable(
+        pressedScale: 0.98,
+        onTap: onTap,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Flexible(child: label),
+            const SizedBox(width: Sp.x1),
+            AppIcon(OsIcon.edit, size: 12, color: tone.fgFaint),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _SuggestionCard extends StatelessWidget {
   final Map<String, dynamic> s;
   final VoidCallback onConfirm;
@@ -1102,6 +1211,14 @@ class _WorkoutDetailBodyState extends State<_WorkoutDetailBody> {
     } catch (_) {}
   }
 
+  /// Retime this session and re-score it over the new window.
+  Future<void> _editTimes() async {
+    final d = _d;
+    if (d == null || d['id'] == null) return;
+    final saved = await showManualWorkoutScreen(context, editing: d);
+    if (saved && mounted) await _go();
+  }
+
   @override
   Widget build(BuildContext context) {
     if (_loading) {
@@ -1130,6 +1247,11 @@ class _WorkoutDetailBodyState extends State<_WorkoutDetailBody> {
           ? units.distance(route.distanceMeters)
           : null,
       onCorrectType: d['source'] == 'auto' ? _correctType : null,
+      // Any finished session can be retimed. The common case is widening an
+      // auto-detected fragment to the real window, but a live session stopped
+      // late (or early) is just as wrong and just as fixable. A still-running
+      // workout has no end to edit yet.
+      onEditTimes: d['status'] == 'live' ? null : _editTimes,
     );
   }
 }
@@ -1149,6 +1271,9 @@ class WorkoutDetailContent extends StatelessWidget {
   /// Non-null only for auto-detected sessions (shows the "fix type" affordance).
   final VoidCallback? onCorrectType;
 
+  /// Non-null for any finished session — opens the retime form.
+  final VoidCallback? onEditTimes;
+
   const WorkoutDetailContent({
     super.key,
     required this.d,
@@ -1156,6 +1281,7 @@ class WorkoutDetailContent extends StatelessWidget {
     required this.maxHr,
     this.distanceLabel,
     this.onCorrectType,
+    this.onEditTimes,
   });
 
   num? _n(Object? v) => v is num ? v : null;
@@ -1288,9 +1414,15 @@ class WorkoutDetailContent extends StatelessWidget {
                         workoutTypeLabel(d['type'] as String?).toUpperCase(),
                         style: AppText.overline.copyWith(color: tone.fgFaint),
                       ),
-                      Text(
-                        _whenLabel(d['start_ts'] as int?),
-                        style: AppText.captionMuted.copyWith(color: tone.fgMuted),
+                      // The window doubles as the retime affordance — you tap
+                      // the times to change the times. Tapping through to a
+                      // form is what makes a too-narrow auto-detected window
+                      // fixable at all.
+                      _WindowLabel(
+                        startTs: d['start_ts'] as int?,
+                        endTs: d['end_ts'] as int?,
+                        onTap: onEditTimes,
+                        tone: tone,
                       ),
                     ],
                   ),

--- a/test/core_screens_test.dart
+++ b/test/core_screens_test.dart
@@ -464,11 +464,15 @@ void main() {
       );
       await t.pump(const Duration(milliseconds: 1200));
 
-      // A range, not just the start — "Today · 4:00 PM – 4:42 PM".
-      final window = find.textContaining('–');
-      expect(window, findsWidgets);
+      // Targeted by key, not by the en dash: the zone rows render
+      // "133–152 bpm" with the same character, so a text finder matched those
+      // too and the test had to lean on tree order to pick the right one.
+      final window = find.byKey(const Key('workout-window-edit'));
+      expect(window, findsOneWidget);
+      // The window really is rendered as a RANGE, which is the point of it.
+      expect(find.textContaining('–'), findsWidgets);
 
-      await t.tap(window.first);
+      await t.tap(window);
       await t.pump();
       expect(tapped, 1);
       expect(t.takeException(), isNull);
@@ -495,10 +499,9 @@ void main() {
       );
       await t.pump(const Duration(milliseconds: 1200));
       // The window still renders; it just isn't a button.
-      expect(
-        find.bySemanticsLabel(RegExp('Edit workout times')),
-        findsNothing,
-      );
+      expect(find.byKey(const Key('workout-window-edit')), findsNothing);
+      expect(find.textContaining('–'), findsWidgets,
+          reason: 'the window itself must still be shown');
       expect(t.takeException(), isNull);
     });
   });

--- a/test/core_screens_test.dart
+++ b/test/core_screens_test.dart
@@ -438,6 +438,69 @@ void main() {
         expect(t.takeException(), isNull);
       }
     });
+
+    // The detector reports a session's hard-effort CORE, so a real hour can
+    // land as ~25 minutes. Retiming is how that gets fixed, and the window
+    // itself is the affordance — a start time alone can't show the clipping.
+    testWidgets('the time window is shown end-to-end and opens the retime form',
+        (t) async {
+      t.view.physicalSize = const Size(390, 2400);
+      t.view.devicePixelRatio = 1.0;
+      addTearDown(t.view.reset);
+      AppColors.active = kLightPalette;
+      var tapped = 0;
+      await t.pumpWidget(
+        MaterialApp(
+          theme: buildOpenStrapTheme(kLightPalette),
+          home: Scaffold(
+            body: WorkoutDetailContent(
+              d: detail(),
+              route: null,
+              maxHr: 190,
+              onEditTimes: () => tapped++,
+            ),
+          ),
+        ),
+      );
+      await t.pump(const Duration(milliseconds: 1200));
+
+      // A range, not just the start — "Today · 4:00 PM – 4:42 PM".
+      final window = find.textContaining('–');
+      expect(window, findsWidgets);
+
+      await t.tap(window.first);
+      await t.pump();
+      expect(tapped, 1);
+      expect(t.takeException(), isNull);
+    });
+
+    testWidgets('a live session offers no retime affordance', (t) async {
+      t.view.physicalSize = const Size(390, 2400);
+      t.view.devicePixelRatio = 1.0;
+      addTearDown(t.view.reset);
+      AppColors.active = kLightPalette;
+      await t.pumpWidget(
+        MaterialApp(
+          theme: buildOpenStrapTheme(kLightPalette),
+          home: Scaffold(
+            body: WorkoutDetailContent(
+              d: detail(),
+              route: null,
+              maxHr: 190,
+              // What _WorkoutDetailBody passes for status == 'live'.
+              onEditTimes: null,
+            ),
+          ),
+        ),
+      );
+      await t.pump(const Duration(milliseconds: 1200));
+      // The window still renders; it just isn't a button.
+      expect(
+        find.bySemanticsLabel(RegExp('Edit workout times')),
+        findsNothing,
+      );
+      expect(t.takeException(), isNull);
+    });
   });
 
   group('SleepNightContent', () {

--- a/test/live_strain_convergence_test.dart
+++ b/test/live_strain_convergence_test.dart
@@ -1,0 +1,110 @@
+// Live-session strain — pinned to the one shared method.
+//
+// Until this landed, three things put a number on the same 0–21 dial and
+// disagreed with each other:
+//   * daily strain   — Banister TRIMP -> min(21, ln(trimp+1)/ln(1.5))
+//   * a live session — `strain += %HRR * 0.01` per second: uncited, uncapped,
+//                      and measured 25.33 where the canonical method reads
+//                      11.62 for the same hour (2.18x, and past the top of its
+//                      own scale after ~50 min, which the gauge silently
+//                      clamped to full)
+//   * an auto-detected session — no strain written at all
+//
+// The live path is the one with real state, so it gets its own file: the
+// per-minute folding has to be right or the gauge and the value written to
+// `sessions.strain` on stop will drift apart from everything else.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:openstrap_edge/compute/profile.dart';
+import 'package:openstrap_edge/state/app_state.dart';
+
+/// A full profile — every anchor the Banister score needs.
+const _profile = Profile(
+  ageYears: 30,
+  weightKg: 75,
+  heightCm: 180,
+  sex: 'm',
+  restingHrManual: 55,
+);
+
+// The live session's own accumulator. It is the piece with real state — the
+// per-minute folding has to be right or the live gauge and the number written
+// to `sessions.strain` on stop will disagree with everything else.
+void main() {
+  group('LiveWorkoutState — live strain rides the same method', () {
+    LiveWorkoutState make() => LiveWorkoutState(
+          startTime: DateTime(2026, 1, 1, 9),
+          targetKcal: 300,
+          type: 'run',
+          age: 30,
+          profile: _profile,
+          restingHr: 55,
+        );
+
+    test('starts absent, not zero', () {
+      expect(make().strain, isNull);
+    });
+
+    test('folds 1 Hz samples into per-minute means', () {
+      final w = make();
+      // 30 s at 100 then 30 s at 200, all inside minute 0.
+      for (var i = 0; i < 60; i++) {
+        w.elapsed = Duration(seconds: i);
+        w.accrueHr(i < 30 ? 100 : 200);
+      }
+      expect(w.perMinuteHr(), hasLength(1));
+      expect(w.perMinuteHr().first, closeTo(150, 0.001));
+    });
+
+    test('the in-progress minute counts, so the gauge moves before 60 s', () {
+      final w = make();
+      for (var i = 0; i < 10; i++) {
+        w.elapsed = Duration(seconds: i);
+        w.accrueHr(150);
+      }
+      expect(w.perMinuteHr(), hasLength(1));
+      expect(w.strain, isNotNull);
+      expect(w.strain, greaterThan(0));
+    });
+
+    test('an hour at 150 bpm lands on the canonical figure, not 25', () {
+      final w = make();
+      for (var i = 0; i < 3600; i++) {
+        w.elapsed = Duration(seconds: i);
+        w.accrueHr(150);
+      }
+      expect(w.perMinuteHr(), hasLength(60));
+      expect(w.strain, closeTo(11.62, 0.05));
+      expect(w.strain, lessThanOrEqualTo(21.0));
+    });
+
+    test('abstains when the profile carries no anchors', () {
+      final w = LiveWorkoutState(
+        startTime: DateTime(2026, 1, 1, 9),
+        targetKcal: 300,
+        type: 'run',
+      );
+      for (var i = 0; i < 600; i++) {
+        w.elapsed = Duration(seconds: i);
+        w.accrueHr(150);
+      }
+      // No fabricated 30 y / 60 bpm stand-ins — the gauge shows "—".
+      expect(w.strain, isNull);
+    });
+
+    test('off-skin zeros neither pollute a minute nor reset the score', () {
+      final w = make();
+      for (var i = 0; i < 600; i++) {
+        w.elapsed = Duration(seconds: i);
+        w.accrueHr(150);
+      }
+      final before = w.strain;
+      for (var i = 600; i < 660; i++) {
+        w.elapsed = Duration(seconds: i);
+        w.accrueHr(0); // dropped contact
+      }
+      expect(w.strain, before, reason: 'a zero sample must be ignored outright');
+    });
+  });
+}

--- a/test/manual_session_test.dart
+++ b/test/manual_session_test.dart
@@ -354,6 +354,22 @@ void main() {
       );
       expect(s.avgHr, 150);
       expect(s.hrSampleCount, 60);
+
+      // ...and neither may they dilute kcal. The estimator bills every sample
+      // below the active threshold at the RESTING rate, so a forwarded zero
+      // silently bought a second of basal burn that avgHr, strain and the zone
+      // bands had all correctly discarded. An identical window containing only
+      // the worn minute must score the same.
+      final wornOnly = computeManualSessionStats(
+        hrTs: [for (var i = 60; i < 120; i++) i],
+        hrBpm: List<int>.filled(60, 150),
+        profile: _profile,
+        zoneMaxHr: 190,
+        restingHr: 55,
+      );
+      expect(s.calories, wornOnly.calories);
+      expect(s.strain, wornOnly.strain);
+      expect(s.zoneMinutes, wornOnly.zoneMinutes);
     });
   });
 

--- a/test/manual_session_test.dart
+++ b/test/manual_session_test.dart
@@ -1,0 +1,601 @@
+// Manual / retimed workout logging — the pure policy layer.
+//
+// Context: the auto-detector reports the HARD-EFFORT CORE (>=0.45*HRR held
+// >=12 min, dips >90 s break the span), so an hour of mixed-intensity training
+// commonly lands as ~25 detected minutes. `manual_session.dart` is what lets
+// the athlete state the real window; these tests pin the parts that decide
+// what gets written, without a DB or a clock in the way.
+//
+// The load-bearing guarantee is the honesty contract: a window with no 1 Hz HR
+// behind it (pruned past the ~3-day `decoded_onehz` retention, or band off)
+// must produce NULL strain/calories — never a figure inferred from duration.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:openstrap_edge/compute/manual_session.dart';
+import 'package:openstrap_edge/compute/profile.dart';
+
+/// A full profile — every anchor the scored metrics need.
+const _profile = Profile(
+  ageYears: 30,
+  weightKg: 75,
+  heightCm: 180,
+  sex: 'm',
+  restingHrManual: 55,
+);
+
+/// 1 Hz samples at a flat [bpm] for [minutes], starting at [start].
+({List<int> ts, List<int> bpm}) _flat(int start, int minutes, int bpm) {
+  final ts = <int>[];
+  final hr = <int>[];
+  for (var i = 0; i < minutes * 60; i++) {
+    ts.add(start + i);
+    hr.add(bpm);
+  }
+  return (ts: ts, bpm: hr);
+}
+
+void main() {
+  group('validateManualWindow', () {
+    const now = 1_700_000_000;
+
+    test('accepts an ordinary past window', () {
+      expect(
+        validateManualWindow(
+          startSec: now - 3600,
+          endSec: now - 1800,
+          nowSec: now,
+        ),
+        isNull,
+      );
+    });
+
+    test('rejects end <= start', () {
+      expect(
+        validateManualWindow(startSec: now - 60, endSec: now - 60, nowSec: now),
+        ManualWindowError.endNotAfterStart,
+      );
+      expect(
+        validateManualWindow(startSec: now - 60, endSec: now - 120, nowSec: now),
+        ManualWindowError.endNotAfterStart,
+      );
+    });
+
+    test('rejects a sub-minute window but accepts exactly a minute', () {
+      expect(
+        validateManualWindow(startSec: now - 59, endSec: now, nowSec: now),
+        ManualWindowError.tooShort,
+      );
+      expect(
+        validateManualWindow(startSec: now - 60, endSec: now, nowSec: now),
+        isNull,
+      );
+    });
+
+    test('rejects beyond the 24 h typo guard, accepts exactly 24 h', () {
+      expect(
+        validateManualWindow(
+          startSec: now - kMaxManualWorkoutSec - 1,
+          endSec: now,
+          nowSec: now,
+        ),
+        ManualWindowError.tooLong,
+      );
+      expect(
+        validateManualWindow(
+          startSec: now - kMaxManualWorkoutSec,
+          endSec: now,
+          nowSec: now,
+        ),
+        isNull,
+      );
+    });
+
+    test('rejects a window ending in the future', () {
+      expect(
+        validateManualWindow(
+          startSec: now - 1800,
+          endSec: now + 1,
+          nowSec: now,
+        ),
+        ManualWindowError.inFuture,
+      );
+    });
+
+    test('rejects overlap but allows back-to-back sessions', () {
+      final existing = [SessionSpan('a', now - 7200, now - 3600)];
+      // Overlapping by a single second.
+      expect(
+        validateManualWindow(
+          startSec: now - 3601,
+          endSec: now - 1800,
+          nowSec: now,
+          existing: existing,
+        ),
+        ManualWindowError.overlapsExisting,
+      );
+      // Touching end-to-start is legitimate (a brick session, back-to-back).
+      expect(
+        validateManualWindow(
+          startSec: now - 3600,
+          endSec: now - 1800,
+          nowSec: now,
+          existing: existing,
+        ),
+        isNull,
+      );
+    });
+
+    test('fully-contained and fully-containing windows both count as overlap', () {
+      final existing = [SessionSpan('a', now - 7200, now - 3600)];
+      // New window swallows the existing one — the widen-a-fragment case, which
+      // must be an EDIT, not a second row.
+      expect(
+        validateManualWindow(
+          startSec: now - 7800,
+          endSec: now - 3000,
+          nowSec: now,
+          existing: existing,
+        ),
+        ManualWindowError.overlapsExisting,
+      );
+      // New window sits inside the existing one.
+      expect(
+        validateManualWindow(
+          startSec: now - 6000,
+          endSec: now - 5000,
+          nowSec: now,
+          existing: existing,
+        ),
+        ManualWindowError.overlapsExisting,
+      );
+    });
+
+    test('editingId excludes the row being retimed from its own overlap check', () {
+      final existing = [SessionSpan('a', now - 7200, now - 3600)];
+      // Widening 'a' overlaps 'a' — without the exclusion this is unfixable.
+      expect(
+        validateManualWindow(
+          startSec: now - 7800,
+          endSec: now - 3000,
+          nowSec: now,
+          existing: existing,
+          editingId: 'a',
+        ),
+        isNull,
+      );
+    });
+
+    test('a stranded live row (no usable end) is skipped, not guessed at', () {
+      final existing = [SessionSpan('live', now - 3600, 0)];
+      expect(
+        validateManualWindow(
+          startSec: now - 3600,
+          endSec: now - 1800,
+          nowSec: now,
+          existing: existing,
+        ),
+        isNull,
+      );
+    });
+
+    test('every error carries user-facing copy', () {
+      for (final e in ManualWindowError.values) {
+        expect(e.message, isNotEmpty);
+      }
+    });
+  });
+
+  group('hrPerMinute', () {
+    test('collapses 1 Hz samples to one entry per minute', () {
+      final s = _flat(0, 10, 140);
+      final perMin = hrPerMinute(s.ts, s.bpm);
+      expect(perMin.length, 10);
+      expect(perMin.every((v) => v == 140.0), isTrue);
+    });
+
+    test('averages within a minute', () {
+      // 30 s at 100, 30 s at 200 inside one minute bucket.
+      final ts = [for (var i = 0; i < 60; i++) i];
+      final bpm = [for (var i = 0; i < 60; i++) i < 30 ? 100 : 200];
+      expect(hrPerMinute(ts, bpm), [150.0]);
+    });
+
+    test('a gap produces no entry rather than a zero minute', () {
+      // Minute 0 present, minute 1 absent, minute 2 present.
+      final ts = <int>[0, 1, 2, 120, 121, 122];
+      final bpm = <int>[120, 120, 120, 130, 130, 130];
+      expect(hrPerMinute(ts, bpm), [120.0, 130.0]);
+    });
+
+    test('empty and mismatched inputs yield nothing', () {
+      expect(hrPerMinute(const [], const []), isEmpty);
+      expect(hrPerMinute(const [1, 2], const [100]), isEmpty);
+    });
+  });
+
+  group('zoneMinutesFor', () {
+    test('bands on the supplied display HRmax', () {
+      // maxHr 190 → Z3 is 70–80% = 133–152 bpm. 120 s at 140 bpm = 2.0 min Z3.
+      final z = zoneMinutesFor(List<int>.filled(120, 140), 190);
+      expect(z.length, 5);
+      expect(z[2], 2.0);
+      expect(z[0], 0.0);
+      expect(z[4], 0.0);
+    });
+
+    test('below Z1 counts nowhere', () {
+      // 50 bpm at maxHr 190 is under the 50% floor.
+      expect(zoneMinutesFor(List<int>.filled(60, 50), 190).every((v) => v == 0),
+          isTrue);
+    });
+
+    test('empty HR or a degenerate HRmax yields no bands', () {
+      expect(zoneMinutesFor(const [], 190), isEmpty);
+      expect(zoneMinutesFor(const [140], 0), isEmpty);
+    });
+  });
+
+  group('computeManualSessionStats — honesty contract', () {
+    test('no HR in the window → every scored field is null', () {
+      final s = computeManualSessionStats(
+        hrTs: const [],
+        hrBpm: const [],
+        profile: _profile,
+        zoneMaxHr: 190,
+        restingHr: 55,
+      );
+      expect(s.isUnscored, isTrue);
+      expect(s.hrSampleCount, 0);
+      expect(s.strain, isNull);
+      expect(s.calories, isNull);
+      expect(s.avgHr, isNull);
+      expect(s.maxHr, isNull);
+      expect(s.zoneMinutes, isEmpty);
+    });
+
+    test('no resting HR → neither strain nor calories', () {
+      final w = _flat(0, 30, 150);
+      final s = computeManualSessionStats(
+        hrTs: w.ts,
+        hrBpm: w.bpm,
+        profile: _profile,
+        zoneMaxHr: 190,
+        restingHr: null,
+      );
+      // Banister carries RHR as a term in the formula — absent it, abstain.
+      expect(s.strain, isNull);
+      // Keytel's own kJ/min formula takes no RHR, so it is tempting to score
+      // calories anyway. But `estimateBoutCalories` uses RHR to place the
+      // active/resting threshold that decides which seconds burn at the active
+      // rate, and reports `usedDefaultAnchors` when it had to invent one. We
+      // honour that flag rather than banking a figure built on a 60 bpm guess.
+      expect(s.calories, isNull);
+      // Raw HR observations are real regardless, and still reported.
+      expect(s.avgHr, 150);
+      expect(s.hrSampleCount, 30 * 60);
+    });
+
+    test('no age → no HRmax anchor → neither strain nor calories', () {
+      final w = _flat(0, 30, 150);
+      final s = computeManualSessionStats(
+        hrTs: w.ts,
+        hrBpm: w.bpm,
+        profile: const Profile(weightKg: 75, heightCm: 180, sex: 'm'),
+        zoneMaxHr: 190,
+        restingHr: 55,
+      );
+      expect(s.strain, isNull);
+      expect(s.calories, isNull);
+      // Raw HR observations are still real and still reported.
+      expect(s.avgHr, 150);
+      expect(s.maxHr, 150);
+      expect(s.hrSampleCount, 30 * 60);
+    });
+
+    test('no weight → no Keytel calories, strain unaffected', () {
+      final w = _flat(0, 30, 150);
+      final s = computeManualSessionStats(
+        hrTs: w.ts,
+        hrBpm: w.bpm,
+        profile: const Profile(ageYears: 30, heightCm: 180, sex: 'm'),
+        zoneMaxHr: 190,
+        restingHr: 55,
+      );
+      expect(s.calories, isNull);
+      expect(s.strain, isNotNull);
+    });
+
+    test('a full profile over real HR scores both', () {
+      final w = _flat(0, 45, 150);
+      final s = computeManualSessionStats(
+        hrTs: w.ts,
+        hrBpm: w.bpm,
+        profile: _profile,
+        zoneMaxHr: 190,
+        restingHr: 55,
+      );
+      expect(s.isUnscored, isFalse);
+      expect(s.avgHr, 150);
+      expect(s.maxHr, 150);
+      expect(s.strain, isNotNull);
+      // 0–21 headline scale.
+      expect(s.strain, inInclusiveRange(0.0, 21.0));
+      expect(s.calories, greaterThan(0));
+      expect(s.zoneMinutes.length, 5);
+    });
+
+    test('a longer window at the same intensity scores higher strain', () {
+      ManualSessionStats run(int minutes) => computeManualSessionStats(
+            hrTs: _flat(0, minutes, 150).ts,
+            hrBpm: _flat(0, minutes, 150).bpm,
+            profile: _profile,
+            zoneMaxHr: 190,
+            restingHr: 55,
+          );
+      // THE WHOLE POINT of the feature: correcting 25 min → 60 min must
+      // actually move the number the athlete came here to fix.
+      expect(run(60).strain!, greaterThan(run(25).strain!));
+      expect(run(60).calories!, greaterThan(run(25).calories!));
+    });
+
+    test('off-skin zero samples never drag the average down', () {
+      // hrSamplesInRange filters hr>0, but the policy must not depend on that.
+      final ts = [for (var i = 0; i < 120; i++) i];
+      final bpm = [for (var i = 0; i < 120; i++) i < 60 ? 0 : 150];
+      final s = computeManualSessionStats(
+        hrTs: ts,
+        hrBpm: bpm,
+        profile: _profile,
+        zoneMaxHr: 190,
+        restingHr: 55,
+      );
+      expect(s.avgHr, 150);
+      expect(s.hrSampleCount, 60);
+    });
+  });
+
+  // ONE strain method across the app. Before this, three things put a number
+  // on the same 0–21 dial and disagreed: daily strain used Banister -> log
+  // squash, a live session accrued `%HRR * 0.01` per second (uncited,
+  // uncapped, 2.18x higher, past 21 after ~50 min at 150 bpm), and an
+  // auto-detected session wrote no strain at all.
+  group('strainFromPerMinuteHr — the single strain method', () {
+    test('a hard hour scores on-scale, nowhere near the old accrual', () {
+      final perMin = List<double>.filled(60, 150);
+      final s = strainFromPerMinuteHr(perMin,
+          profile: _profile, restingHr: 55)!;
+
+      // The canonical figure for this effort.
+      expect(s, closeTo(11.62, 0.05));
+      expect(s, lessThanOrEqualTo(21.0));
+
+      // What the retired live accrual produced for the identical hour, so the
+      // gap is on the record rather than in a commit message.
+      final hrrLive = (150 - 55) / (220 - 30 - 55);
+      final legacy = hrrLive * 0.01 * 60 * 60;
+      expect(legacy, greaterThan(21.0),
+          reason: 'the old live formula left its own scale');
+      expect(legacy / s, greaterThan(2.0));
+    });
+
+    test('never exceeds 21, even for an absurdly long maximal effort', () {
+      // 12 h pinned at 190 bpm — the old accrual would read into the hundreds.
+      final s = strainFromPerMinuteHr(List<double>.filled(720, 190),
+          profile: _profile, restingHr: 55)!;
+      expect(s, lessThanOrEqualTo(21.0));
+    });
+
+    test('monotonic in both duration and intensity', () {
+      double at(int minutes, double bpm) => strainFromPerMinuteHr(
+          List<double>.filled(minutes, bpm),
+          profile: _profile,
+          restingHr: 55)!;
+      expect(at(60, 150), greaterThan(at(30, 150)));
+      expect(at(60, 165), greaterThan(at(60, 150)));
+    });
+
+    test('abstains rather than inventing an anchor', () {
+      final perMin = List<double>.filled(60, 150);
+      // No resting HR.
+      expect(
+          strainFromPerMinuteHr(perMin, profile: _profile, restingHr: null),
+          isNull);
+      // No age → no Tanaka HRmax.
+      expect(
+          strainFromPerMinuteHr(perMin,
+              profile: const Profile(sex: 'm'), restingHr: 55),
+          isNull);
+      // No sex → no Banister weighting constant.
+      expect(
+          strainFromPerMinuteHr(perMin,
+              profile: const Profile(ageYears: 30), restingHr: 55),
+          isNull);
+      // No HR at all.
+      expect(
+          strainFromPerMinuteHr(const [], profile: _profile, restingHr: 55),
+          isNull);
+    });
+
+    test('is exactly what computeManualSessionStats reports', () {
+      // The session scorer must not fork its own copy of the method.
+      final w = _flat(0, 45, 150);
+      final viaStats = computeManualSessionStats(
+        hrTs: w.ts,
+        hrBpm: w.bpm,
+        profile: _profile,
+        zoneMaxHr: 190,
+        restingHr: 55,
+      ).strain;
+      final direct = strainFromPerMinuteHr(hrPerMinute(w.ts, w.bpm),
+          profile: _profile, restingHr: 55);
+      expect(viaStats, direct);
+    });
+  });
+
+  group('buildManualSessionRow', () {
+    final scored = computeManualSessionStats(
+      hrTs: _flat(1000, 60, 150).ts,
+      hrBpm: _flat(1000, 60, 150).bpm,
+      profile: _profile,
+      zoneMaxHr: 190,
+      restingHr: 55,
+    );
+
+    test('a new entry is done/manual with a start-keyed id', () {
+      final row = buildManualSessionRow(
+        startSec: 1000,
+        endSec: 1000 + 3600,
+        type: 'run',
+        stats: scored,
+        createdAtMs: 5_000_000,
+      );
+      expect(row['id'], 'manual:1000');
+      expect(row['status'], 'done');
+      expect(row['source'], 'manual');
+      expect(row['type'], 'run');
+      expect(row['duration_min'], 60);
+      expect(row['created_at'], 5_000_000);
+      expect(row['strain'], isNotNull);
+      expect(row['calories'], isNotNull);
+    });
+
+    test('re-logging the same window is idempotent on id', () {
+      expect(manualSessionId(1000), manualSessionId(1000));
+      expect(manualSessionId(1000), isNot(manualSessionId(1001)));
+    });
+
+    test('an edit preserves id, source and created_at', () {
+      final row = buildManualSessionRow(
+        startSec: 2000,
+        endSec: 2000 + 3600,
+        type: 'run',
+        stats: scored,
+        createdAtMs: 9_999_999,
+        existing: const {
+          'id': 'auto:1234',
+          'source': 'auto',
+          'created_at': 111,
+        },
+      );
+      // Retiming must not re-attribute how the session was captured — the
+      // detail screen's AUTO tag reads `source`.
+      expect(row['id'], 'auto:1234');
+      expect(row['source'], 'auto');
+      expect(row['created_at'], 111);
+      // ...but the window itself is the new one.
+      expect(row['start_ts'], 2000);
+      expect(row['duration_min'], 60);
+    });
+
+    test('absent stats are written as explicit nulls, not omitted', () {
+      // putSession is INSERT-OR-REPLACE: an omitted key on an edit would let a
+      // stale value computed for the OLD window survive into the new one.
+      final row = buildManualSessionRow(
+        startSec: 3000,
+        endSec: 3000 + 3600,
+        type: 'other',
+        stats: const ManualSessionStats(),
+        createdAtMs: 1,
+      );
+      for (final k in ['calories', 'strain', 'max_hr', 'steps', 'hrr_bpm']) {
+        expect(row.containsKey(k), isTrue, reason: '$k must be present');
+        expect(row[k], isNull, reason: '$k must be explicitly null');
+      }
+      // An unscored session still records the window the athlete asserted.
+      expect(row['duration_min'], 60);
+      expect(row['status'], 'done');
+    });
+
+    test('steps and hrr are cleared on a retime', () {
+      final row = buildManualSessionRow(
+        startSec: 4000,
+        endSec: 4000 + 3600,
+        type: 'run',
+        stats: scored,
+        createdAtMs: 1,
+        existing: const {
+          'id': 'w1',
+          'source': 'manual',
+          'created_at': 2,
+          'steps': 4321,
+          'hrr_bpm': 22.5,
+        },
+      );
+      // Both described the OLD window; hrr_bpm is refilled by derivation.
+      expect(row['steps'], isNull);
+      expect(row['hrr_bpm'], isNull);
+    });
+
+    test('zone_min_json is a JSON list, empty when there are no zones', () {
+      final unscored = buildManualSessionRow(
+        startSec: 5000,
+        endSec: 5000 + 3600,
+        type: 'other',
+        stats: const ManualSessionStats(),
+        createdAtMs: 1,
+      );
+      expect(jsonDecode(unscored['zone_min_json'] as String), isEmpty);
+
+      final withZones = buildManualSessionRow(
+        startSec: 5000,
+        endSec: 5000 + 3600,
+        type: 'run',
+        stats: scored,
+        createdAtMs: 1,
+      );
+      final decoded = jsonDecode(withZones['zone_min_json'] as String) as List;
+      expect(decoded.length, 5);
+      expect(decoded.cast<num>().any((v) => v > 0), isTrue);
+    });
+  });
+
+  group('supersededSuggestionIds', () {
+    Map<String, dynamic> sug(String id, int start, int end) =>
+        {'id': id, 'start_ts': start, 'end_ts': end};
+
+    test('retires the fragment a wider manual entry covers', () {
+      // The reported case: the detector found 25 min inside a 60 min session.
+      final ids = supersededSuggestionIds(
+        [sug('s1', 1500, 3000)],
+        startSec: 0,
+        endSec: 3600,
+      );
+      expect(ids, ['s1']);
+    });
+
+    test('leaves an unrelated suggestion alone', () {
+      final ids = supersededSuggestionIds(
+        [sug('s1', 10000, 12000)],
+        startSec: 0,
+        endSec: 3600,
+      );
+      expect(ids, isEmpty);
+    });
+
+    test('a merely adjacent suggestion is not superseded', () {
+      final ids = supersededSuggestionIds(
+        [sug('s1', 3600, 5000)],
+        startSec: 0,
+        endSec: 3600,
+      );
+      expect(ids, isEmpty);
+    });
+
+    test('malformed rows are skipped, not crashed on', () {
+      final ids = supersededSuggestionIds(
+        [
+          {'id': null, 'start_ts': 0, 'end_ts': 100},
+          {'id': 's2', 'start_ts': null, 'end_ts': 100},
+          {'id': 's3', 'start_ts': 200, 'end_ts': 100}, // inverted
+          sug('s4', 100, 200),
+        ],
+        startSec: 0,
+        endSec: 3600,
+      );
+      expect(ids, ['s4']);
+    });
+  });
+}

--- a/test/manual_workout_repo_test.dart
+++ b/test/manual_workout_repo_test.dart
@@ -334,9 +334,28 @@ void main() {
 
     test('retiming preserves the route rows themselves (id is stable)',
         () async {
+      // Self-contained: this used to read the rows the narrowing test above
+      // happened to leave behind, so it failed the moment it ran alone.
+      final start = sessionStart - 46 * 86400;
+      await LocalDb.putSession({
+        'id': 'w-route-keep',
+        'start_ts': start,
+        'end_ts': start + 5400,
+        'type': 'run',
+        'status': 'done',
+        'duration_min': 90,
+        'source': 'manual',
+        'created_at': start * 1000,
+      });
+      await seedRoute('w-route-keep', start, 5400);
+      final before = (await LocalDb.routePoints('w-route-keep')).length;
+      await repo.setWorkoutWindow('w-route-keep',
+          startTs: start, endTs: start + 3600);
+
       // The cascade delete lives on deleteSession; putSession must not touch
       // workout_route, or widening back would silently lose the map forever.
-      final rows = await LocalDb.routePoints('w-route');
+      final rows = await LocalDb.routePoints('w-route-keep');
+      expect(rows.length, before);
       expect(rows.length, greaterThan(2),
           reason: 'the full route must survive a narrowing retime, so the '
               'athlete can widen the window back again');
@@ -345,8 +364,14 @@ void main() {
 
   test('savedSessionSpans surfaces saved windows for the overlap check',
       () async {
+    // Seed our own row rather than leaning on whatever earlier tests left.
+    final start = sessionStart - 50 * 86400;
+    await repo.logManualWorkout(
+        startTs: start, endTs: start + 1800, type: 'walk');
+
     final spans = await repo.savedSessionSpans();
     expect(spans, isNotEmpty);
+    expect(spans.map((e) => e.id), contains(manualSessionId(start)));
     // Every span is a real, ordered window.
     for (final s in spans) {
       expect(s.endSec, greaterThan(s.startSec));
@@ -361,7 +386,9 @@ void main() {
           startTs: start, endTs: start + 3600, type: 'run');
 
       // A second session landing in the middle of the first.
-      expect(
+      // await: expect() on an async callback returns before the future
+      // settles, so the "nothing was written" query below would race it.
+      await expectLater(
         () => repo.logManualWorkout(
             startTs: start + 1800, endTs: start + 5400, type: 'cycle'),
         throwsA(isA<ManualWindowException>().having(
@@ -375,7 +402,7 @@ void main() {
 
     test('a future window is refused', () async {
       final future = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 7200;
-      expect(
+      await expectLater(
         () => repo.logManualWorkout(
             startTs: future, endTs: future + 3600, type: 'run'),
         throwsA(isA<ManualWindowException>()
@@ -385,7 +412,7 @@ void main() {
 
     test('a sub-minute window is refused', () async {
       final start = sessionStart - 25 * 86400;
-      expect(
+      await expectLater(
         () => repo.logManualWorkout(
             startTs: start, endTs: start + 30, type: 'run'),
         throwsA(isA<ManualWindowException>()
@@ -393,15 +420,47 @@ void main() {
       );
     });
 
-    test('retiming a session never collides with its own existing span', () {
+    test('retiming a session never collides with its own existing span',
+        () async {
       // Regression: without editingId, widening ANY saved session overlaps
       // itself and would be permanently unfixable.
-      final start = sessionStart - 5 * 86400;
-      expect(
-        repo.setWorkoutWindow('auto:$start',
+      final start = sessionStart - 40 * 86400;
+      await LocalDb.putSession({
+        'id': 'w-self-overlap',
+        'start_ts': start,
+        'end_ts': start + 600,
+        'type': 'run',
+        'status': 'done',
+        'duration_min': 10,
+        'source': 'manual',
+        'created_at': start * 1000,
+      });
+      await expectLater(
+        repo.setWorkoutWindow('w-self-overlap',
             startTs: start, endTs: start + 7200),
         completes,
       );
+    });
+
+    test('a still-live session cannot be retimed', () async {
+      // buildManualSessionRow always writes status 'done', so retiming a
+      // running session would silently end it.
+      final start = sessionStart - 43 * 86400;
+      await LocalDb.putSession({
+        'id': 'w-live',
+        'start_ts': start,
+        'end_ts': null,
+        'type': 'run',
+        'status': 'live',
+        'source': 'manual',
+        'created_at': start * 1000,
+      });
+      await expectLater(
+        repo.setWorkoutWindow('w-live', startTs: start, endTs: start + 3600),
+        throwsA(isA<StateError>()),
+      );
+      final row = await LocalDb.session('w-live');
+      expect(row!['status'], 'live', reason: 'must not have been ended');
     });
   });
 

--- a/test/manual_workout_repo_test.dart
+++ b/test/manual_workout_repo_test.dart
@@ -1,0 +1,422 @@
+// Manual / retimed workout logging — the REPO path, against a real database.
+//
+// `manual_session_test.dart` pins the pure policy. This pins the wiring: that
+// `logManualWorkout` / `setWorkoutWindow` actually read the 1 Hz substrate over
+// the window they were given, persist a row the workout screens can render,
+// retire the auto-detect suggestion they supersede, and — the reported bug —
+// that widening a clipped window really does raise the numbers.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:openstrap_edge/data/db.dart';
+import 'package:openstrap_edge/data/local_repository_impl.dart';
+import 'package:openstrap_edge/compute/manual_session.dart';
+import 'package:openstrap_edge/data/models.dart';
+import 'package:openstrap_edge/gps/route_models.dart';
+
+/// A profile with every anchor the scored metrics need.
+Map<String, dynamic> _profile() => {
+      'age': 30,
+      'weight_kg': 75.0,
+      'height_cm': 180.0,
+      'sex': 'm',
+      'resting_hr': 55,
+    };
+
+Sample _sample(int ts, int counter, int hr) => Sample(
+      tsEpoch: ts,
+      counter: counter,
+      hr: hr,
+      rrIntervalsMs: const [],
+      ax: 0,
+      ay: 0,
+      az: 0,
+      spo2RedRaw: 0,
+      spo2IrRaw: 0,
+      skinTempRaw: 0,
+    );
+
+RawRecord _raw(int ts, int counter) => RawRecord(
+      counter: counter,
+      packetType: 47,
+      hex: 'manual$counter',
+      capturedAt: ts * 1000,
+      recTs: ts,
+    );
+
+/// Lay down 1 Hz HR at [hr] bpm for [seconds] starting at [start].
+/// One row per 10 s keeps the fixture small; the estimators weight each sample
+/// by the elapsed gap, so the window is still covered end to end.
+Future<void> _seedHr(int start, int seconds, int hr) async {
+  for (var i = 0; i < seconds; i += 10) {
+    final ts = start + i;
+    await LocalDb.insertRecord(_raw(ts, ts), _sample(ts, ts, hr));
+  }
+}
+
+void main() {
+  // A fixed, comfortably-past window so nothing here depends on wall clock
+  // beyond "this is in the past", which it always is.
+  final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+  final sessionStart = nowSec - 6 * 3600;
+
+  setUpAll(() async {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+    LocalDb.dbName = 'openstrap_manual_workout_test.db';
+    final dir = await databaseFactory.getDatabasesPath();
+    await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+  });
+
+  tearDownAll(() async {
+    await LocalDb.close();
+    final dir = await databaseFactory.getDatabasesPath();
+    await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+  });
+
+  final repo = LocalRepositoryImpl(getProfileMap: _profile);
+
+  test(
+    'logManualWorkout scores a past window from the 1 Hz substrate',
+    () async {
+      // An hour at 150 bpm.
+      await _seedHr(sessionStart, 3600, 150);
+
+      final res = await repo.logManualWorkout(
+        startTs: sessionStart,
+        endTs: sessionStart + 3600,
+        type: 'run',
+      );
+      expect(res['unscored'], isFalse);
+      expect(res['hr_samples'], greaterThan(0));
+
+      final w = await repo.getWorkout(res['workout_id'] as String);
+      expect(w['status'], 'done');
+      expect(w['source'], 'manual');
+      expect(w['type'], 'run');
+      expect(w['duration_min'], 60);
+      // Scored from real HR — not inferred from the duration.
+      expect(w['strain'], isNotNull);
+      expect(w['calories'], isNotNull);
+      expect(w['avg_hr'], 150);
+      // getWorkout's on-read enrichment fills the detail screen's chart.
+      expect((w['hr'] as List?) ?? const [], isNotEmpty);
+      expect((w['zone_bands'] as List?) ?? const [], isNotEmpty);
+    },
+  );
+
+  test(
+    'a window with no substrate is still saved, just honestly unscored',
+    () async {
+      // Two days before anything we seeded — no decoded_onehz rows at all.
+      final start = sessionStart - 2 * 86400;
+      final res = await repo.logManualWorkout(
+        startTs: start,
+        endTs: start + 1800,
+        type: 'strength',
+      );
+      expect(res['unscored'], isTrue);
+      expect(res['hr_samples'], 0);
+
+      final w = await repo.getWorkout(res['workout_id'] as String);
+      // The athlete's assertion about the window is kept...
+      expect(w['duration_min'], 30);
+      expect(w['type'], 'strength');
+      // ...but nothing is invented to fill the gaps.
+      expect(w['strain'], isNull);
+      expect(w['calories'], isNull);
+      expect(w['max_hr'], isNull);
+    },
+  );
+
+  test(
+    'setWorkoutWindow widening a clipped detection raises the numbers — '
+    'the whole point of the feature',
+    () async {
+      // A 2 h block of real training at 150 bpm.
+      final start = sessionStart - 5 * 86400;
+      await _seedHr(start, 7200, 150);
+
+      // What the detector reported: the hard-effort CORE only, 25 minutes of a
+      // two-hour session, written the way _logDetectedSession writes one.
+      const detectedMin = 25;
+      await LocalDb.putSession({
+        'id': 'auto:$start',
+        'start_ts': start,
+        'end_ts': start + detectedMin * 60,
+        'type': 'cardio',
+        'status': 'done',
+        'duration_min': detectedMin,
+        'source': 'auto',
+        'created_at': start * 1000,
+      });
+
+      // Score it over the detected window first, for a like-for-like baseline.
+      final narrow = await repo.setWorkoutWindow(
+        'auto:$start',
+        startTs: start,
+        endTs: start + detectedMin * 60,
+      );
+      final before = await repo.getWorkout(narrow['workout_id'] as String);
+
+      // Now say what actually happened: the full two hours.
+      final wide = await repo.setWorkoutWindow(
+        'auto:$start',
+        startTs: start,
+        endTs: start + 7200,
+      );
+      final after = await repo.getWorkout(wide['workout_id'] as String);
+
+      expect(after['duration_min'], 120);
+      expect(
+        (after['strain'] as num).toDouble(),
+        greaterThan((before['strain'] as num).toDouble()),
+        reason: 'a longer window at the same intensity must score more strain',
+      );
+      expect(
+        (after['calories'] as num).toDouble(),
+        greaterThan((before['calories'] as num).toDouble()),
+      );
+      // Retiming must not re-attribute how the session was captured, and must
+      // not fork a second row.
+      expect(after['id'], 'auto:$start');
+      expect(after['source'], 'auto');
+    },
+  );
+
+  test(
+    'retiming does not leave the old row behind as a duplicate',
+    () async {
+      final start = sessionStart - 9 * 86400;
+      await LocalDb.putSession({
+        'id': 'w-retime',
+        'start_ts': start,
+        'end_ts': start + 600,
+        'type': 'run',
+        'status': 'done',
+        'duration_min': 10,
+        'source': 'manual',
+        'created_at': start * 1000,
+      });
+      await repo.setWorkoutWindow('w-retime',
+          startTs: start, endTs: start + 3600);
+
+      final rows = await LocalDb.sessionsInRange(start - 60, start + 7200);
+      expect(rows.where((r) => r['id'] == 'w-retime').length, 1);
+      expect(rows.firstWhere((r) => r['id'] == 'w-retime')['duration_min'], 60);
+    },
+  );
+
+  test(
+    'logging a session retires the auto-detect suggestion it covers',
+    () async {
+      final start = sessionStart - 12 * 86400;
+      await LocalDb.putWorkoutSuggestion({
+        'id': 'sug-covered',
+        'date': '2026-01-01',
+        'start_ts': start + 900, // the fragment, inside the real session
+        'end_ts': start + 2400,
+        'duration_min': 25,
+        'sport': 'cardio',
+        'created_at': start * 1000,
+      });
+      await LocalDb.putWorkoutSuggestion({
+        'id': 'sug-elsewhere',
+        'date': '2026-01-01',
+        'start_ts': start + 40000, // an unrelated effort later that day
+        'end_ts': start + 42000,
+        'duration_min': 33,
+        'sport': 'run',
+        'created_at': start * 1000,
+      });
+
+      await repo.logManualWorkout(
+        startTs: start,
+        endTs: start + 3600,
+        type: 'cardio',
+      );
+
+      final active = await LocalDb.activeWorkoutSuggestions();
+      final ids = [for (final s in active) s['id']];
+      expect(ids, isNot(contains('sug-covered')),
+          reason: 'the fragment the athlete just superseded must not keep '
+              'asking "did you work out?"');
+      expect(ids, contains('sug-elsewhere'),
+          reason: 'an unrelated suggestion must survive');
+    },
+  );
+
+  group('GPS routes follow the session window', () {
+    // A run tracked for 90 min, one fix every 30 s heading due east.
+    Future<void> seedRoute(String id, int start, int seconds) async {
+      final rows = <Map<String, Object?>>[];
+      for (var i = 0, seq = 0; i < seconds; i += 30, seq++) {
+        rows.add(RoutePoint(
+          seq: seq,
+          tsMs: (start + i) * 1000,
+          lat: 51.5,
+          lng: -0.12 + seq * 0.0005, // ~35 m per step
+        ).toRow(id));
+      }
+      await LocalDb.appendRoutePoints(id, rows);
+    }
+
+    test(
+      'narrowing a session clips its route — no 90 minutes of GPS under a '
+      '60 minute hero',
+      () async {
+        final start = sessionStart - 30 * 86400;
+        await _seedHr(start, 5400, 140);
+        await LocalDb.putSession({
+          'id': 'w-route',
+          'start_ts': start,
+          'end_ts': start + 5400, // 90 min as recorded
+          'type': 'run',
+          'status': 'done',
+          'duration_min': 90,
+          'source': 'manual',
+          'created_at': start * 1000,
+        });
+        await seedRoute('w-route', start, 5400);
+
+        final full = await repo.getWorkoutRoute('w-route');
+        expect(full, isNotNull);
+        final fullPoints = full!.points.length;
+        final fullDistance = full.distanceMeters;
+
+        // You actually ran an hour and forgot to stop the watch.
+        await repo.setWorkoutWindow('w-route',
+            startTs: start, endTs: start + 3600);
+        final clipped = await repo.getWorkoutRoute('w-route');
+
+        expect(clipped, isNotNull);
+        expect(clipped!.points.length, lessThan(fullPoints));
+        expect(clipped.distanceMeters, lessThan(fullDistance));
+        // Every surviving fix sits inside the corrected window.
+        for (final p in clipped.points) {
+          expect(p.tsMs, greaterThanOrEqualTo((start - 5) * 1000));
+          expect(p.tsMs, lessThanOrEqualTo((start + 3600 + 5) * 1000));
+        }
+      },
+    );
+
+    test(
+      'clipping to a window with under two fixes yields no map at all',
+      () async {
+        final start = sessionStart - 33 * 86400;
+        await LocalDb.putSession({
+          'id': 'w-route-tiny',
+          'start_ts': start,
+          'end_ts': start + 3600,
+          'type': 'run',
+          'status': 'done',
+          'duration_min': 60,
+          'source': 'manual',
+          'created_at': start * 1000,
+        });
+        // All the GPS sits in the SECOND hour.
+        await seedRoute('w-route-tiny', start + 3600, 1800);
+
+        // A single orphaned pin and a zero-length distance is worse than
+        // honestly showing no route.
+        expect(await repo.getWorkoutRoute('w-route-tiny'), isNull);
+      },
+    );
+
+    test('a manually logged workout simply has no route', () async {
+      final start = sessionStart - 36 * 86400;
+      final res = await repo.logManualWorkout(
+          startTs: start, endTs: start + 1800, type: 'run');
+      expect(await repo.getWorkoutRoute(res['workout_id'] as String), isNull);
+    });
+
+    test('retiming preserves the route rows themselves (id is stable)',
+        () async {
+      // The cascade delete lives on deleteSession; putSession must not touch
+      // workout_route, or widening back would silently lose the map forever.
+      final rows = await LocalDb.routePoints('w-route');
+      expect(rows.length, greaterThan(2),
+          reason: 'the full route must survive a narrowing retime, so the '
+              'athlete can widen the window back again');
+    });
+  });
+
+  test('savedSessionSpans surfaces saved windows for the overlap check',
+      () async {
+    final spans = await repo.savedSessionSpans();
+    expect(spans, isNotEmpty);
+    // Every span is a real, ordered window.
+    for (final s in spans) {
+      expect(s.endSec, greaterThan(s.startSec));
+      expect(s.id, isNotEmpty);
+    }
+  });
+
+  group('the write seam re-validates — the form is not the only guard', () {
+    test('an overlapping window is refused, not silently written', () async {
+      final start = sessionStart - 20 * 86400;
+      await repo.logManualWorkout(
+          startTs: start, endTs: start + 3600, type: 'run');
+
+      // A second session landing in the middle of the first.
+      expect(
+        () => repo.logManualWorkout(
+            startTs: start + 1800, endTs: start + 5400, type: 'cycle'),
+        throwsA(isA<ManualWindowException>().having(
+            (e) => e.error, 'error', ManualWindowError.overlapsExisting)),
+      );
+
+      // Nothing was written.
+      final rows = await LocalDb.sessionsInRange(start + 1800, start + 1800);
+      expect(rows.where((r) => r['start_ts'] == start + 1800), isEmpty);
+    });
+
+    test('a future window is refused', () async {
+      final future = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 7200;
+      expect(
+        () => repo.logManualWorkout(
+            startTs: future, endTs: future + 3600, type: 'run'),
+        throwsA(isA<ManualWindowException>()
+            .having((e) => e.error, 'error', ManualWindowError.inFuture)),
+      );
+    });
+
+    test('a sub-minute window is refused', () async {
+      final start = sessionStart - 25 * 86400;
+      expect(
+        () => repo.logManualWorkout(
+            startTs: start, endTs: start + 30, type: 'run'),
+        throwsA(isA<ManualWindowException>()
+            .having((e) => e.error, 'error', ManualWindowError.tooShort)),
+      );
+    });
+
+    test('retiming a session never collides with its own existing span', () {
+      // Regression: without editingId, widening ANY saved session overlaps
+      // itself and would be permanently unfixable.
+      final start = sessionStart - 5 * 86400;
+      expect(
+        repo.setWorkoutWindow('auto:$start',
+            startTs: start, endTs: start + 7200),
+        completes,
+      );
+    });
+  });
+
+  test(
+    're-logging the identical window replaces rather than duplicates',
+    () async {
+      final start = sessionStart - 15 * 86400;
+      final a = await repo.logManualWorkout(
+          startTs: start, endTs: start + 1800, type: 'yoga');
+      final b = await repo.logManualWorkout(
+          startTs: start, endTs: start + 1800, type: 'yoga');
+      expect(a['workout_id'], b['workout_id']);
+
+      final rows = await LocalDb.sessionsInRange(start - 60, start + 3600);
+      expect(rows.where((r) => r['id'] == a['workout_id']).length, 1);
+    },
+  );
+}

--- a/test/workouts_header_actions_test.dart
+++ b/test/workouts_header_actions_test.dart
@@ -1,0 +1,152 @@
+// Workouts header actions — the ⊕ Add / ▶ Start pair, and the layout budget
+// they have to live inside.
+//
+// WHY THIS FILE EXISTS. "Log a past workout" first shipped as a fourth child
+// of the start bottom sheet, where it was invisible and untappable: the sheet
+// defaults to `isScrollControlled: false`, capping it at 9/16 of the screen
+// (~475 pt at 390x844), and the nine type tiles already wrap to three rows.
+// The row fell off the bottom edge. In release there are no overflow stripes,
+// so nothing announced it — it just silently did not work.
+//
+// Two lessons, both pinned here:
+//   1. Two pills plus the title must fit the header row at real phone widths.
+//   2. A layout overflow must FAIL a test rather than ship as dead pixels.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:openstrap_edge/ui/design/design.dart';
+import 'package:openstrap_edge/ui/workouts/workout_types.dart';
+
+/// The narrowest phone we target, and the one the header budget is tightest on.
+const Size _iphoneSe = Size(375, 667);
+const Size _iphone14 = Size(390, 844);
+
+Widget _harness(Widget child, ThemeData theme) =>
+    MaterialApp(theme: theme, home: child);
+
+void main() {
+  for (final palette in [kLightPalette, kDarkPalette]) {
+    final mode = palette == kLightPalette ? 'light' : 'dark';
+
+    testWidgets('header fits title + Add + Start without overflow ($mode)',
+        (t) async {
+      for (final size in [_iphoneSe, _iphone14]) {
+        t.view.physicalSize = size;
+        t.view.devicePixelRatio = 1.0;
+        addTearDown(t.view.reset);
+        AppColors.active = palette;
+
+        await t.pumpWidget(_harness(
+          AppScaffold(
+            title: 'Workouts',
+            actions: [
+              // Stand-ins with the exact geometry of the real pills — the
+              // private widgets can't be imported, and what is under test is
+              // the header's width budget, not their internals.
+              _pill(Icons.add_rounded, 'Add'),
+              _pill(Icons.play_arrow_rounded, 'Start'),
+            ],
+            children: const [SizedBox(height: 200)],
+          ),
+          buildOpenStrapTheme(palette),
+        ));
+        await t.pump();
+
+        expect(t.takeException(), isNull,
+            reason: 'header overflowed at ${size.width}x${size.height}');
+        expect(find.text('Add'), findsOneWidget);
+        expect(find.text('Start'), findsOneWidget);
+        // The title must survive intact — if the actions eat the row, the
+        // Expanded title ellipsizes to "Workout…" instead of failing loudly.
+        final title = t.widget<Text>(find.text('Workouts'));
+        expect(title.overflow, TextOverflow.ellipsis);
+        final titleBox = t.getSize(find.text('Workouts'));
+        expect(titleBox.width, greaterThan(0));
+      }
+    });
+  }
+
+  testWidgets(
+    'the start sheet content fits the default 9/16 bottom-sheet cap — '
+    'the regression that made "Log a past workout" untappable',
+    (t) async {
+      t.view.physicalSize = _iphone14;
+      t.view.devicePixelRatio = 1.0;
+      addTearDown(t.view.reset);
+      AppColors.active = kLightPalette;
+
+      // The sheet body exactly as startWorkoutFlow builds it.
+      await t.pumpWidget(_harness(
+        Scaffold(
+          body: Align(
+            alignment: Alignment.bottomCenter,
+            child: ConstrainedBox(
+              // What showModalBottomSheet imposes with isScrollControlled:false.
+              constraints: BoxConstraints(maxHeight: _iphone14.height * 9 / 16),
+              child: SafeArea(
+                top: false,
+                child: Padding(
+                  padding: const EdgeInsets.all(Sp.x5),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Start a workout', style: AppText.h2),
+                      const SizedBox(height: Sp.x4),
+                      Builder(builder: workoutTypeGrid),
+                      const SizedBox(height: Sp.x4),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+        buildOpenStrapTheme(kLightPalette),
+      ));
+      await t.pump();
+
+      expect(t.takeException(), isNull,
+          reason: 'the start sheet must not overflow its 9/16 cap — anything '
+              'past the edge is silently unhittable in release');
+
+      // Every type tile is inside the visible sheet, not clipped past it.
+      final ceiling = _iphone14.height * 9 / 16;
+      for (final e in kWorkoutTypes) {
+        final tile = find.text(e.$2);
+        expect(tile, findsOneWidget, reason: '${e.$2} tile missing');
+        final r = t.getRect(tile);
+        expect(r.bottom, lessThanOrEqualTo(_iphone14.height),
+            reason: '${e.$2} is clipped off the bottom of the screen');
+        expect(r.height, greaterThan(0), reason: '${e.$2} collapsed to zero');
+      }
+
+      // And the sheet genuinely is close to its ceiling — this is the fact
+      // that makes adding a fourth child unsafe. If this ever goes slack
+      // (fewer types, a tighter grid), the note in startWorkoutFlow can be
+      // revisited; until then it stands.
+      final used = t.getSize(find.byType(SafeArea).last).height;
+      expect(used, greaterThan(ceiling * 0.6),
+          reason: 'sheet is nowhere near its cap — re-check the guidance in '
+              'startWorkoutFlow before trusting it');
+    },
+  );
+}
+
+/// A pill with the same padding/icon/label geometry as _AddButton/_StartButton.
+Widget _pill(IconData icon, String label) => Container(
+      padding: const EdgeInsets.symmetric(horizontal: Sp.x4, vertical: Sp.x3),
+      decoration: BoxDecoration(
+        color: AppColors.accent,
+        borderRadius: BorderRadius.circular(R.pill),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 18, color: Colors.white),
+          const SizedBox(width: Sp.x1),
+          Text(label, style: AppText.label.copyWith(color: Colors.white)),
+        ],
+      ),
+    );

--- a/test/workouts_header_actions_test.dart
+++ b/test/workouts_header_actions_test.dart
@@ -85,6 +85,7 @@ void main() {
               // What showModalBottomSheet imposes with isScrollControlled:false.
               constraints: BoxConstraints(maxHeight: _iphone14.height * 9 / 16),
               child: SafeArea(
+                key: const Key('sheet-body'),
                 top: false,
                 child: Padding(
                   padding: const EdgeInsets.all(Sp.x5),
@@ -126,7 +127,9 @@ void main() {
       // that makes adding a fourth child unsafe. If this ever goes slack
       // (fewer types, a tighter grid), the note in startWorkoutFlow can be
       // revisited; until then it stands.
-      final used = t.getSize(find.byType(SafeArea).last).height;
+      // By key: `find.byType(SafeArea).last` depended on how many SafeAreas
+      // the harness happened to nest, which is not what this asserts.
+      final used = t.getSize(find.byKey(const Key('sheet-body'))).height;
       expect(used, greaterThan(ceiling * 0.6),
           reason: 'sheet is nowhere near its cap — re-check the guidance in '
               'startWorkoutFlow before trusting it');


### PR DESCRIPTION
### **User description**
## Why

A user reported an hour of training logging as ~25 minutes. Nothing was broken — the auto-detector reports an effort's **hard-effort core**, not its wall-clock. A minute only counts at `>= RHR + 0.45*(HRmax-RHR)` (`hrrFloorFraction`), a dip over 90 s breaks the span (`maxDipS`), and the survivor must hold >= 12 min (`minSustainedMin`). That tuning is correct for a "did you work out?" prompt — the comments record it being calibrated against a sedentary week where a looser gate fired 30 false windows — but warm-up, cool-down and inter-set rest fall out of it.

There was no way to say otherwise. The only session writer was `startWorkout`, which stamps `DateTime.now()`; the only edit on a saved session was its type.

## What

**Two ways in.** An **Add** pill in the Workouts header, and the session's time window on the detail hero — now rendered as a range (`Today · 4:00 PM – 4:42 PM`) that taps through to the same form. A start time alone can't show that a window was clipped.

**Scoring reuses what was already there.** `getWorkout` already enriches from the 1 Hz substrate over `[start_ts, end_ts]`, so a corrected window gets its HR curve, avg/min/max, zone bands, drift and recovery curve for free. Only `strain` and `calories` lacked a producer, and they go through the published methods the day pipeline already uses.

**No `kAlgoVersion` bump.** Sessions don't feed `day_result` — derivation reads them only as `savedSpans` (auto-detect exclusion) and to backfill `hrr_bpm` — so no analytics output moved. Verified the pinned analytics SHA `f0d1153` actually contains every symbol used (`banisterTrimp`, `estimateBoutCalories`, `Sex`, `WorkoutUserProfile`) with matching signatures, per the v43 drift lesson.

## The strain convergence (second commit)

Three things put a number on the 0–21 dial and only one used the documented method:

| | method | 60 min @ 150 bpm |
|---|---|---|
| daily strain | Banister → `min(21, ln(trimp+1)/ln(1.5))` | 11.62 |
| live session | `strain += %HRR * 0.01`/sec | **25.33** |
| auto-detected | *nothing written* | blank |

2.18x apart, and the live figure is **off the top of its own scale** — it passes 21 after ~50 min, after which the gauge clamps to full while the number keeps climbing. Pre-existing, but manual logging puts both in one list side by side, so it needed settling rather than documenting.

Live strain is no longer accrued: `accrueHr` folds 1 Hz samples into per-minute means (the unit Banister weights) and recomputes through the shared `strainFromPerMinuteHr`. The in-progress minute counts, so the gauge moves inside the first 60 s.

Anchors are honest now. The old path substituted 30 y / 70 kg / 60 bpm on an empty profile, turning an absent input into a confident-looking score. Each is a term in the formula, so a missing one abstains — `LiveWorkoutState.strain` is nullable, the arc sits empty, the readout is a dash. `_liveRestingHr` prefers the *measured* nightly `rhr` and never falls back to 60.

> Note for anyone who has read the bot answer circulating on this: `StrainScorer.strain()` / `WorkoutDetector` (the 0–100 Edwards map) are **not** what the app uses — edge never calls them. The only analytics workout symbol edge imports is `AutoWorkoutDetector.motionPoints`.

## Also fixed

**GPS routes now follow their session's window.** `routePoints` had no window filter, so a retimed session kept its original map, distance, moving time and splits — narrow a 90-minute run to the 60 you actually ran and the card claimed 60 minutes over 90 minutes of GPS. Clipped to the window (±5 s, since GPS is ms-stamped and the window is whole seconds); under two surviving fixes yields no map rather than an orphaned pin. Route rows survive, so widening back restores it.

**Confirming an auto-detected suggestion now scores it.** That path hand-built a row with no `strain` and no `calories`, so every accepted suggestion landed showing blanks.

**The write seam re-validates** and throws `ManualWindowException` — the form validates live, but its snapshot of saved spans can go stale mid-edit and it isn't the only possible caller.

## A bug worth recording

"Log a past workout" first went in as a fourth child of the start bottom sheet, where it was **invisible and untappable**. `showModalBottomSheet` defaults to `isScrollControlled: false`, capping it at 9/16 of the screen; the nine type tiles already wrap to three rows. It overflowed by 11 px and the row fell off the bottom edge — in release there are no overflow stripes, so nothing announced it. Hence the header pill, a note on `startWorkoutFlow`, and a test that fails if the sheet is grown again (verified by reintroducing the bug and watching it fail).

## Testing

`flutter analyze` clean; **1200 tests green** (was 1156 on this base), run against the pinned sibling SHAs with `pubspec_overrides.yaml` removed so it matches CI. Both commits verified to compile and pass standalone.

- `manual_session_test.dart` — validation, per-minute folding, zone bands, the honesty contract, row building
- `manual_workout_repo_test.dart` — the write path against a real DB, including that widening a clipped window actually raises the numbers, and the route clipping
- `live_strain_convergence_test.dart` — the live accumulator; one test records the retired formula's 25.33 and asserts the >2x gap
- `workouts_header_actions_test.dart` — header fits at 375/390 pt in both palettes; the sheet stays under its cap

## Not in scope

Live **calories** have the same shape of problem — an inline Keytel copy falling back to 30 y / 70 kg / male where the offline scorer abstains. Left deliberately; separate user-visible change.

Retiming is realistically a **within-3-days** feature (`rawRetentionDays = 3`). Older windows save with null strain/calories and the form says so plainly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Add "Log a past workout" and "Edit times" flows so athletes can correct auto-detected session windows

- Unify all strain scoring onto one Banister TRIMP → log-squash method, retiring the uncited `%HRR × 0.01/s` live accrual that exceeded 21 after ~50 min

- Enforce honesty contract: absent HR, RHR, age, weight, or sex yields null strain/calories, never a fabricated figure

- Add 4 new test files covering pure policy, repo wiring, live strain convergence, and header action smoke tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workouts header\n_AddButton / _StartButton"]
  B["ManualWorkoutScreen\n(date + time pickers)"]
  C["manual_session.dart\n(pure policy)"]
  D["LocalRepositoryImpl\nlogManualWorkout / setWorkoutWindow"]
  E["LocalDb.putSession\n(INSERT-OR-REPLACE)"]
  F["strainFromPerMinuteHr\n(Banister TRIMP → log-squash)"]
  G["LiveWorkoutState.accrueHr\n(per-minute accumulator)"]
  H["_logDetectedSession\n(confirmed suggestion)"]
  I["WorkoutDetailContent\n_WindowLabel tap → retime"]

  A -- "Log past" --> B
  B -- "validateManualWindow\ncomputeManualSessionStats" --> C
  C -- "buildManualSessionRow" --> D
  D -- "putSession" --> E
  C -- "strainFromPerMinuteHr" --> F
  G -- "recomputes on each HR sample" --> F
  H -- "logDetectedWorkout via repo" --> D
  I -- "showManualWorkoutScreen(editing:d)" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>manual_session.dart</strong><dd><code>New pure policy module for manual/retimed workout windows</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/189/files#diff-4c14c9e94dd086da44e897bce8da931cac7c7096b23884f616ae76b95c14465a">+404/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>workouts_screen.dart</strong><dd><code>Add Add pill, retime affordance, and scored detected-session logging</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/189/files#diff-d90667f8b853f130ad9d0e1bf052b328a038e5a551b36e3b78a622d895e44cf7">+166/-34</a></td>

</tr>

<tr>
  <td><strong>manual_workout_screen.dart</strong><dd><code>New full-screen form for logging and retiming completed workouts</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/189/files#diff-d4acc8d682d1e98febc97f6ed8d96662e2bd87480a66192e7a42071918a4b04c">+445/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>app_state.dart</strong><dd><code>Replace live strain accrual with Banister TRIMP; add nightly RHR </code><br><code>refresh</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/189/files#diff-d56ba858e512e18dc3962da198adee46d354aca39ff7c1b4a11d5f19b9afc1ae">+98/-11</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>manual_session_test.dart</strong><dd><code>Pure-policy unit tests for validation, scoring, and honesty contract</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/189/files#diff-f3e540869f34e26361f94f3d9faf215beb3467457edd38a0fc2d09c72140a7df">+601/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>manual_workout_repo_test.dart</strong><dd><code>Repo-level integration tests against real sqflite for log/retime flows</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/189/files#diff-3fc738fc057b2bf3fa30781f25ddc02fc0192d0c0d0d8994332a74de259ef050">+422/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>local_repository.dart</strong></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/189/files#diff-70aa0116cfafcd1abf63bb03cc54770c240453edb7ef0fb009d07769aa6075d4">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>local_repository_impl.dart</strong></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/189/files#diff-da6b8e6c3188825ab7c7d364093ccefbd9e40a284244154fdbffd372214f6352">+197/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>live_session_screen.dart</strong></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/189/files#diff-a1806a05926c11f526d297b01e0d2448c4db55d6b57cfabc57d26e7e36c7081a">+25/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>workout_types.dart</strong></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/189/files#diff-6304f71690f750cd6a55b8b5a60021cbf9ea41db5c94e4c5572ee93dc31eb11b">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>core_screens_test.dart</strong></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/189/files#diff-23ffc0774b77fcc7744561457ff159deffc138ea90a7c9336c55436a6e61c7e7">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>live_strain_convergence_test.dart</strong></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/189/files#diff-a6a1fdc75878e05bf1d4644adec4762ae243374c8268b3554f59d6819db2d507">+110/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>workouts_header_actions_test.dart</strong></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/189/files#diff-709b6535fbafe54e6c660e122b41e79f17246cc9ffd53876e2e0082c5a241e36">+152/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

