### PR TITLE
Make a detected nap visible on the Sleep screen

### DIFF
--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -643,21 +643,18 @@ class LocalRepositoryImpl extends LocalRepository {
       // position PROXY, NOT supine/side/prone body position.
       'wrist_orientation': b['wrist_orientation'],
     };
-    // Sleep periods (main + naps) for the periods screen, mapped onto the key
-    // names that screen actually reads. The day total is the sum of what the
-    // cards show, so the hero can't disagree with them.
-    final periods = sleepPeriodsForScreen(
-      (b['sleep_periods'] as Map?)?['periods'],
-      night: night,
-    );
-    final bundleTotal = (b['sleep_periods'] as Map?)?['total_asleep_min'];
-    night['periods'] = periods;
-    night['total_asleep_min'] = periods.isEmpty
-        ? bundleTotal
-        : periods.fold<int>(
-            0,
-            (a, p) => a + ((p['duration_min'] as num?)?.toInt() ?? 0),
-          );
+    // NOTE: this used to re-map the periods here through
+    // `sleepPeriodsForScreen` and overwrite `night['periods']`. That translator
+    // read `start`/`end`/`asleep_min` -- the vocabulary the producer emitted
+    // when this branch was written. Since #204 the producer emits
+    // `onset_ts`/`wake_ts`/`duration_min` directly, and `_periodsWithMainStages`
+    // (above) already attaches the hypnogram, stage minutes and the main
+    // period's confidence, translating any legacy payload on read.
+    //
+    // Keeping the overwrite after that rebase would have read every period
+    // under keys that no longer exist, produced an EMPTY list, and blanked the
+    // whole screen -- main sleep included -- while the hero still showed a
+    // total. One source per concern: the writer-side seam owns this now.
     return night;
   }
 
@@ -683,15 +680,16 @@ class LocalRepositoryImpl extends LocalRepository {
     };
     return [
       for (final p in raw.whereType<Map>())
-        if (p['is_main'] != true)
-          _canonicalPeriod(p)
-        else
-          {
-            ..._canonicalPeriod(p),
-            if (hypno.isNotEmpty) 'hypnogram': hypno,
-            if (stages.isNotEmpty) 'stages': stages,
-            'confidence': ?mainConfidence,
-          },
+        if (_boundedPeriod(_canonicalPeriod(p)) case final bp?)
+          if (bp['is_main'] != true)
+            bp
+          else
+            {
+              ...bp,
+              if (hypno.isNotEmpty) 'hypnogram': hypno,
+              if (stages.isNotEmpty) 'stages': stages,
+              'confidence': ?mainConfidence,
+            },
     ];
   }
 
@@ -727,6 +725,31 @@ class LocalRepositoryImpl extends LocalRepository {
       if (!m.containsKey('duration_min') && m['asleep_min'] != null)
         'duration_min': m['asleep_min'],
     };
+  }
+
+  /// A period's reported asleep minutes can never exceed its own window.
+  ///
+  /// Ported from #205, which added it at the (now-removed) screen-side
+  /// translator. It is a real invariant and belongs here, at the one seam the
+  /// screen reads: `duration_min` and the window come from different producers
+  /// (staging TST vs the detected bounds), so nothing else stops a card
+  /// claiming more sleep than the period it sits in. Clamped, not dropped —
+  /// the window is the trustworthy half.
+  ///
+  /// Returns null for a period with no usable window at all, so the caller can
+  /// drop it rather than render a zero-length card.
+  Map<String, dynamic>? _boundedPeriod(Map<String, dynamic> m) {
+    final onset = (m['onset_ts'] as num?)?.toInt();
+    final wake = (m['wake_ts'] as num?)?.toInt();
+    if (onset == null || wake == null || wake <= onset) {
+      // Keep it only if it carries no window claim at all; a period whose
+      // window is present but degenerate is junk.
+      return (onset == null && wake == null) ? m : null;
+    }
+    final windowMin = ((wake - onset) / 60).round();
+    final dur = (m['duration_min'] as num?)?.toInt();
+    if (dur == null || dur <= windowMin) return m;
+    return {...m, 'duration_min': windowMin};
   }
 
   /// Mean completed-cycle length (min), or null when no cycles.
@@ -2753,69 +2776,6 @@ class LocalRepositoryImpl extends LocalRepository {
     }
     return mx == 0 ? null : mx;
   }
-}
-
-/// The `periods` list the Sleep-periods screen reads, mapped from the engine's
-/// `sleep_periods` block. The engine writes `is_main` / `start` / `end` /
-/// `asleep_min`; the screen reads `onset_ts` / `wake_ts` / `duration_min`, so
-/// every card used to render as `0m` with no time range under it.
-///
-/// The main period carries the night's own numbers (TST, efficiency, stage
-/// minutes, hypnogram) so the two sleep screens can't print different totals
-/// for the same night. A nap carries only what we actually have for it: start,
-/// end, length. No stages, no efficiency, and no confidence — a nap detected by
-/// stillness has no confidence value, and 0 would read as "we're sure it's bad".
-/// Pure + public so the mapping is unit-testable without a database.
-List<Map<String, dynamic>> sleepPeriodsForScreen(
-  Object? rawPeriods, {
-  Map<String, dynamic> night = const {},
-}) {
-  if (rawPeriods is! List) return const [];
-  num? asNum(Object? v) =>
-      v is num ? v : (v is String ? num.tryParse(v) : null);
-  final out = <Map<String, dynamic>>[];
-  for (final raw in rawPeriods) {
-    if (raw is! Map) continue;
-    final p = raw.cast<String, dynamic>();
-    final start = asNum(p['start'])?.toInt();
-    final end = asNum(p['end'])?.toInt();
-    if (start == null || end == null || end <= start) continue;
-    final isMain = p['is_main'] == true;
-    // A length outside the window it came from is malformed: it would print a
-    // negative duration on the card and skew the day total. Fall back to the
-    // window, which the period's own start/end already vouch for.
-    final windowMin = ((end - start) / 60).round();
-    final reported = asNum(p['asleep_min'])?.toInt();
-    final asleepMin = (reported != null && reported >= 0 && reported <= windowMin)
-        ? reported
-        : windowMin;
-    // The main card shows TST (what the Sleep screen shows). A nap has no
-    // asleep/awake accounting of its own, so its window IS its length. TST gets
-    // the same bound: nobody sleeps longer than the window they slept in.
-    final tstMin = asNum(night['duration_min'])?.toInt();
-    final durationMin =
-        isMain && tstMin != null && tstMin >= 0 && tstMin <= windowMin
-            ? tstMin
-            : asleepMin;
-    final stages = <String, dynamic>{
-      if (isMain)
-        for (final k in const ['light_min', 'deep_min', 'rem_min', 'nrem_min'])
-          if (night[k] != null) k: night[k],
-    };
-    out.add({
-      'is_main': isMain,
-      'onset_ts': start,
-      'wake_ts': end,
-      'duration_min': durationMin,
-      if (isMain && night['efficiency'] != null)
-        'efficiency': night['efficiency'],
-      if (isMain && night['stages_confidence'] != null)
-        'confidence': night['stages_confidence'],
-      if (isMain && night['hypnogram'] is List) 'hypnogram': night['hypnogram'],
-      if (stages.isNotEmpty) 'stages': stages,
-    });
-  }
-  return out;
 }
 
 /// The /today `stress` block from a day bundle — the pipeline's Baevsky block,

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -2781,8 +2781,14 @@ List<Map<String, dynamic>> sleepPeriodsForScreen(
     final end = asNum(p['end'])?.toInt();
     if (start == null || end == null || end <= start) continue;
     final isMain = p['is_main'] == true;
-    final asleepMin =
-        asNum(p['asleep_min'])?.toInt() ?? ((end - start) / 60).round();
+    // A length outside the window it came from is malformed: it would print a
+    // negative duration on the card and skew the day total. Fall back to the
+    // window, which the period's own start/end already vouch for.
+    final windowMin = ((end - start) / 60).round();
+    final reported = asNum(p['asleep_min'])?.toInt();
+    final asleepMin = (reported != null && reported >= 0 && reported <= windowMin)
+        ? reported
+        : windowMin;
     // The main card shows TST (what the Sleep screen shows). A nap has no
     // asleep/awake accounting of its own, so its window IS its length.
     final durationMin = isMain

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -558,7 +558,29 @@ class LocalRepositoryImpl extends LocalRepository {
     // confirmed / none — drives the Sleep screen's confirm prompt + edit affordance.
     final sleepSource = (b['sleep_source'] as String?) ?? 'auto';
     if (tst == null) {
-      return {'has_sleep': false, 'sleep_source': sleepSource};
+      // NO NIGHT SLEEP — but that is not the same as no sleep at all.
+      //
+      // A nap-only or night-shift day still has detected daytime periods, and
+      // this early return used to drop them on the floor: the screen showed
+      // "No sleep recorded for this night" while the very same nap was stored,
+      // credited against sleep need, and drawn as a band on the Timeline.
+      // Three surfaces, two answers.
+      //
+      // `has_sleep` stays FALSE — it means what it says, that there is no
+      // NIGHT to render a hypnogram, stages or efficiency for, and inventing
+      // one from a nap would be exactly the conflation this file avoids
+      // elsewhere. The periods ride along so the screen can show what it does
+      // know instead of claiming nothing happened.
+      final napPeriods = _periodsWithMainStages(b, const {});
+      if (napPeriods.isEmpty) {
+        return {'has_sleep': false, 'sleep_source': sleepSource};
+      }
+      return {
+        'has_sleep': false,
+        'sleep_source': sleepSource,
+        'periods': napPeriods,
+        'total_asleep_min': _totalAsleepMin(b, napPeriods),
+      };
     }
     final spt = (win?['spt_sec'] as num?);
     final waso = (acct?['waso_sec'] as num?);

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -573,6 +573,27 @@ class LocalRepositoryImpl extends LocalRepository {
     }
 
     final sleepConf = _sub(b, 'sleep.accounting')?['confidence'] as num?;
+    // Sleep periods (main + naps) for the periods screen. The main period is
+    // enriched HERE with the hypnogram + stage minutes: derivation builds the
+    // periods in a second isolate that never receives `series.hypnogram`, so
+    // this is the first point where the whole bundle is in hand. Naps carry
+    // neither by design — no stage claim is made for them.
+    //
+    // Naps carry their own confidence and the screen draws a ConfDot for any
+    // period that has one, so omitting the main period's left the main card as
+    // the ONLY one with no dot — reading as "unknown" for the best-evidenced
+    // period on the screen. Stays null when accounting had no confidence,
+    // which correctly draws nothing.
+    final periods = _periodsWithMainStages(
+      b,
+      {
+        'light_min': min('light_sec'),
+        'deep_min': min('deep_sec'),
+        'rem_min': min('rem_sec'),
+        'nrem_min': min('nrem_sec'),
+      },
+      mainConfidence: sleepConf,
+    );
     final night = <String, dynamic>{
       // Shape matches sleep_detail_screen's contract exactly.
       'has_sleep': true,
@@ -612,22 +633,14 @@ class LocalRepositoryImpl extends LocalRepository {
       // periods in a second isolate that never receives `series.hypnogram`, so
       // this is the first point where the whole bundle is in hand. Naps carry
       // neither by design — no stage claim is made for them.
-      'periods': _periodsWithMainStages(
-        b,
-        {
-          'light_min': min('light_sec'),
-          'deep_min': min('deep_sec'),
-          'rem_min': min('rem_sec'),
-          'nrem_min': min('nrem_sec'),
-        },
-        // Naps carry their own confidence and the screen draws a ConfDot for
-        // any period that has one, so omitting the main period's left the main
-        // card as the ONLY one with no dot — reading as "unknown" for the
-        // best-evidenced period on the screen. Stays null when accounting had
-        // no confidence, which correctly draws nothing.
-        mainConfidence: sleepConf,
-      ),
-      'total_asleep_min': (b['sleep_periods'] as Map?)?['total_asleep_min'],
+      'periods': periods,
+      // The hero total must equal the sum of the cards under it — a user can
+      // add them up. `_boundedPeriod` can CORRECT a period on read (clamping a
+      // duration to its own window, dropping a degenerate one), which makes the
+      // stored total stale, so it is recomputed from what is actually
+      // rendered. See [_totalAsleepMin] for why an absent stored total stays
+      // absent rather than being recomputed into a confident number.
+      'total_asleep_min': _totalAsleepMin(b, periods),
       // Sleep cycles — Rosenblum 2024 "fractal cycles" (HRV-adapted): peak-to-
       // peak of the smoothed per-minute RMSSD series (REM peaks / NREM troughs).
       'cycles': _sub(b, 'sleep')?['cycles'] ?? const [],
@@ -750,6 +763,35 @@ class LocalRepositoryImpl extends LocalRepository {
     final dur = (m['duration_min'] as num?)?.toInt();
     if (dur == null || dur <= windowMin) return m;
     return {...m, 'duration_min': windowMin};
+  }
+
+  /// The day's total asleep minutes, consistent with the cards on screen.
+  ///
+  /// ABSENT STAYS ABSENT. A null stored total means the producer could not
+  /// state one — most often because nap detection abstained, so the day holds
+  /// an unknown NUMBER of unmeasured naps (see `_sleepPeriods`). Recomputing a
+  /// sum from the periods we happen to have would turn that honest "—" into a
+  /// confident figure that silently omits them, which is the exact claim the
+  /// producer refused to make.
+  ///
+  /// Otherwise the total is recomputed from the RENDERED periods rather than
+  /// trusted verbatim, because `_boundedPeriod` may have corrected one on read
+  /// and the stored sum would then be stale — leaving the hero disagreeing with
+  /// the cards a user can add up. A period whose own duration is unknown makes
+  /// the sum unknown again, for the same reason it does at the writer.
+  num? _totalAsleepMin(
+    Map<String, dynamic> b,
+    List<Map<String, dynamic>> periods,
+  ) {
+    final stored = (b['sleep_periods'] as Map?)?['total_asleep_min'];
+    if (stored == null) return null;
+    var sum = 0;
+    for (final p in periods) {
+      final d = (p['duration_min'] as num?)?.toInt();
+      if (d == null) return null;
+      sum += d;
+    }
+    return sum;
   }
 
   /// Mean completed-cycle length (min), or null when no cycles.

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -2790,10 +2790,13 @@ List<Map<String, dynamic>> sleepPeriodsForScreen(
         ? reported
         : windowMin;
     // The main card shows TST (what the Sleep screen shows). A nap has no
-    // asleep/awake accounting of its own, so its window IS its length.
-    final durationMin = isMain
-        ? (asNum(night['duration_min'])?.toInt() ?? asleepMin)
-        : asleepMin;
+    // asleep/awake accounting of its own, so its window IS its length. TST gets
+    // the same bound: nobody sleeps longer than the window they slept in.
+    final tstMin = asNum(night['duration_min'])?.toInt();
+    final durationMin =
+        isMain && tstMin != null && tstMin >= 0 && tstMin <= windowMin
+            ? tstMin
+            : asleepMin;
     final stages = <String, dynamic>{
       if (isMain)
         for (final k in const ['light_min', 'deep_min', 'rem_min', 'nrem_min'])

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -783,7 +783,15 @@ class LocalRepositoryImpl extends LocalRepository {
     }
     final windowMin = ((wake - onset) / 60).round();
     final dur = (m['duration_min'] as num?)?.toInt();
-    if (dur == null || dur <= windowMin) return m;
+    if (dur == null || (dur >= 0 && dur <= windowMin)) return m;
+    // NEGATIVE is not "too small", it is CORRUPT — there is no such thing as
+    // minus fifty minutes of sleep. It is dropped to unknown rather than
+    // clamped to either end: clamping UP to the window would invent a full
+    // night out of garbage, and clamping DOWN to 0 would state "you did not
+    // sleep", which is a measurement we do not have. Unknown then propagates
+    // through `_totalAsleepMin`, so the hero reads "—" instead of a total
+    // built on a value we know is nonsense.
+    if (dur < 0) return {...m, 'duration_min': null};
     return {...m, 'duration_min': windowMin};
   }
 

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -573,7 +573,7 @@ class LocalRepositoryImpl extends LocalRepository {
     }
 
     final sleepConf = _sub(b, 'sleep.accounting')?['confidence'] as num?;
-    return {
+    final night = <String, dynamic>{
       // Shape matches sleep_detail_screen's contract exactly.
       'has_sleep': true,
       'sleep_source': sleepSource,
@@ -643,6 +643,22 @@ class LocalRepositoryImpl extends LocalRepository {
       // position PROXY, NOT supine/side/prone body position.
       'wrist_orientation': b['wrist_orientation'],
     };
+    // Sleep periods (main + naps) for the periods screen, mapped onto the key
+    // names that screen actually reads. The day total is the sum of what the
+    // cards show, so the hero can't disagree with them.
+    final periods = sleepPeriodsForScreen(
+      (b['sleep_periods'] as Map?)?['periods'],
+      night: night,
+    );
+    final bundleTotal = (b['sleep_periods'] as Map?)?['total_asleep_min'];
+    night['periods'] = periods;
+    night['total_asleep_min'] = periods.isEmpty
+        ? bundleTotal
+        : periods.fold<int>(
+            0,
+            (a, p) => a + ((p['duration_min'] as num?)?.toInt() ?? 0),
+          );
+    return night;
   }
 
   /// The persisted sleep periods with the MAIN period's hypnogram and stage
@@ -2737,6 +2753,60 @@ class LocalRepositoryImpl extends LocalRepository {
     }
     return mx == 0 ? null : mx;
   }
+}
+
+/// The `periods` list the Sleep-periods screen reads, mapped from the engine's
+/// `sleep_periods` block. The engine writes `is_main` / `start` / `end` /
+/// `asleep_min`; the screen reads `onset_ts` / `wake_ts` / `duration_min`, so
+/// every card used to render as `0m` with no time range under it.
+///
+/// The main period carries the night's own numbers (TST, efficiency, stage
+/// minutes, hypnogram) so the two sleep screens can't print different totals
+/// for the same night. A nap carries only what we actually have for it: start,
+/// end, length. No stages, no efficiency, and no confidence — a nap detected by
+/// stillness has no confidence value, and 0 would read as "we're sure it's bad".
+/// Pure + public so the mapping is unit-testable without a database.
+List<Map<String, dynamic>> sleepPeriodsForScreen(
+  Object? rawPeriods, {
+  Map<String, dynamic> night = const {},
+}) {
+  if (rawPeriods is! List) return const [];
+  num? asNum(Object? v) =>
+      v is num ? v : (v is String ? num.tryParse(v) : null);
+  final out = <Map<String, dynamic>>[];
+  for (final raw in rawPeriods) {
+    if (raw is! Map) continue;
+    final p = raw.cast<String, dynamic>();
+    final start = asNum(p['start'])?.toInt();
+    final end = asNum(p['end'])?.toInt();
+    if (start == null || end == null || end <= start) continue;
+    final isMain = p['is_main'] == true;
+    final asleepMin =
+        asNum(p['asleep_min'])?.toInt() ?? ((end - start) / 60).round();
+    // The main card shows TST (what the Sleep screen shows). A nap has no
+    // asleep/awake accounting of its own, so its window IS its length.
+    final durationMin = isMain
+        ? (asNum(night['duration_min'])?.toInt() ?? asleepMin)
+        : asleepMin;
+    final stages = <String, dynamic>{
+      if (isMain)
+        for (final k in const ['light_min', 'deep_min', 'rem_min', 'nrem_min'])
+          if (night[k] != null) k: night[k],
+    };
+    out.add({
+      'is_main': isMain,
+      'onset_ts': start,
+      'wake_ts': end,
+      'duration_min': durationMin,
+      if (isMain && night['efficiency'] != null)
+        'efficiency': night['efficiency'],
+      if (isMain && night['stages_confidence'] != null)
+        'confidence': night['stages_confidence'],
+      if (isMain && night['hypnogram'] is List) 'hypnogram': night['hypnogram'],
+      if (stages.isNotEmpty) 'stages': stages,
+    });
+  }
+  return out;
 }
 
 /// The /today `stress` block from a day bundle — the pipeline's Baevsky block,

--- a/lib/ui/sleep/sleep_detail_screen.dart
+++ b/lib/ui/sleep/sleep_detail_screen.dart
@@ -219,22 +219,17 @@ class _SleepDetailScreenState extends State<SleepDetailScreen> {
   }
 
   Widget _emptyStateNapsCard(List<Map<String, dynamic>> naps) {
-    var known = 0;
-    var anyUnknown = false;
-    for (final n in naps) {
-      final d = (n['duration_min'] as num?)?.toInt();
-      if (d == null) {
-        anyUnknown = true;
-      } else {
-        known += d;
-      }
-    }
-    // An unknown duration makes the TOTAL unknown — the same rule the producer
-    // and the periods screen use. A partial sum presented as the total would
-    // under-report by exactly the part we could not measure.
-    final value = anyUnknown
+    // ONE authoritative total, not a second one computed here. The repository
+    // already decides this (`_totalAsleepMin`) and deliberately returns null
+    // when the producer could not state a complete figure — most often because
+    // nap detection abstained, so the day holds an unknown NUMBER of naps.
+    // Re-summing the periods that happen to be present would present a partial
+    // figure as the day's total, which is exactly the claim the layer below
+    // refused to make.
+    final total = (_data['total_asleep_min'] as num?)?.toInt();
+    final value = total == null
         ? '—'
-        : (known >= 60 ? '${known ~/ 60}h ${known % 60}m' : '${known}m');
+        : (total >= 60 ? '${total ~/ 60}h ${total % 60}m' : '${total}m');
     return SurfaceCard(
       padding: const EdgeInsets.symmetric(horizontal: Sp.x4, vertical: Sp.x2),
       child: ListRow(
@@ -446,8 +441,21 @@ class SleepNightContent extends StatelessWidget {
         .toList();
   }
 
-  num get _napMin => _naps.fold<num>(
-      0, (a, p) => a + (_num(p['duration_min']) ?? 0));
+  /// Minutes asleep across this day's naps, or NULL if any nap's duration is
+  /// unknown.
+  ///
+  /// `?? 0` here would silently under-report by exactly the part we could not
+  /// measure, and present the remainder as the full nap total — the same
+  /// absent-is-not-zero rule the producer and the periods screen follow.
+  num? get _napMin {
+    num sum = 0;
+    for (final p in _naps) {
+      final d = _num(p['duration_min']);
+      if (d == null) return null;
+      sum += d;
+    }
+    return sum;
+  }
 
   List<MapEntry<int, double>> get _cycleSeries {
     final raw = data['cycle_series'];

--- a/lib/ui/sleep/sleep_detail_screen.dart
+++ b/lib/ui/sleep/sleep_detail_screen.dart
@@ -204,6 +204,49 @@ class _SleepDetailScreenState extends State<SleepDetailScreen> {
   /// Every sleep of this day, naps included. The Sleep tab renders this screen
   /// embedded, so the AppScaffold action below never builds there — without a
   /// second entry point the periods screen was unreachable in the shipped app.
+
+  /// Daytime periods on a day with no detected night, for the empty state.
+  ///
+  /// Read straight from the repository payload rather than through
+  /// [SleepNightContent], which is not built in this phase.
+  List<Map<String, dynamic>> _emptyStateNaps() {
+    final raw = _data['periods'];
+    if (raw is! List) return const [];
+    return [
+      for (final e in raw)
+        if (e is Map && e['is_main'] != true) e.cast<String, dynamic>(),
+    ];
+  }
+
+  Widget _emptyStateNapsCard(List<Map<String, dynamic>> naps) {
+    var known = 0;
+    var anyUnknown = false;
+    for (final n in naps) {
+      final d = (n['duration_min'] as num?)?.toInt();
+      if (d == null) {
+        anyUnknown = true;
+      } else {
+        known += d;
+      }
+    }
+    // An unknown duration makes the TOTAL unknown — the same rule the producer
+    // and the periods screen use. A partial sum presented as the total would
+    // under-report by exactly the part we could not measure.
+    final value = anyUnknown
+        ? '—'
+        : (known >= 60 ? '${known ~/ 60}h ${known % 60}m' : '${known}m');
+    return SurfaceCard(
+      padding: const EdgeInsets.symmetric(horizontal: Sp.x4, vertical: Sp.x2),
+      child: ListRow(
+        icon: OsIcon.bedtime,
+        title: naps.length == 1 ? 'Daytime nap' : '${naps.length} daytime naps',
+        subtitle: 'Tap for the full breakdown',
+        value: value,
+        onTap: _openPeriods,
+      ),
+    );
+  }
+
   void _openPeriods() {
     Navigator.of(context).push(
       themedRoute((_) => SleepPeriodsScreen(date: widget.date),
@@ -228,15 +271,30 @@ class _SleepDetailScreenState extends State<SleepDetailScreen> {
   List<Widget> _sections() {
     if (_phase == _Phase.loading) return [_loading()];
     if (_phase == _Phase.empty) {
+      // "No NIGHT" is not "no sleep". A nap-only or night-shift day has
+      // detected daytime periods, and showing the bare empty card while the
+      // same nap is credited against sleep need and drawn on the Timeline is
+      // the screen contradicting the rest of the app. The night breakdown is
+      // still genuinely absent — there is no hypnogram, no stages, no
+      // efficiency — so the card stays; the naps are shown alongside it rather
+      // than dressed up as a night.
+      final naps = _emptyStateNaps();
       return [
         StateCard(
           icon: OsIcon.sleep,
           title: 'No sleep recorded for this night',
-          message: 'Wear your strap overnight and sync — your breakdown '
-              'appears once a night has been recorded.',
+          message: naps.isEmpty
+              ? 'Wear your strap overnight and sync — your breakdown '
+                  'appears once a night has been recorded.'
+              : 'No overnight sleep was detected, so there is no stage '
+                  'breakdown for this day. Daytime sleep is listed below.',
           actionLabel: 'Add sleep times',
           onAction: _editSleepTimes,
         ),
+        if (naps.isNotEmpty) ...[
+          const SizedBox(height: Sp.x3),
+          _emptyStateNapsCard(naps),
+        ],
       ];
     }
     if (_phase == _Phase.error) {

--- a/lib/ui/sleep/sleep_detail_screen.dart
+++ b/lib/ui/sleep/sleep_detail_screen.dart
@@ -201,6 +201,16 @@ class _SleepDetailScreenState extends State<SleepDetailScreen> {
     await _runOverride(() => app.clearSleepOverride(widget.date));
   }
 
+  /// Every sleep of this day, naps included. The Sleep tab renders this screen
+  /// embedded, so the AppScaffold action below never builds there — without a
+  /// second entry point the periods screen was unreachable in the shipped app.
+  void _openPeriods() {
+    Navigator.of(context).push(
+      themedRoute((_) => SleepPeriodsScreen(date: widget.date),
+          name: 'SleepPeriodsScreen'),
+    );
+  }
+
   /// Run a sleep-override change with a busy state, then reload this night.
   Future<void> _runOverride(Future<void> Function() action) async {
     setState(() => _phase = _Phase.loading);
@@ -247,6 +257,7 @@ class _SleepDetailScreenState extends State<SleepDetailScreen> {
         onEditTimes: _editSleepTimes,
         onConfirmFallback: _confirmFallback,
         onClearOverride: _clearOverride,
+        onOpenPeriods: _openPeriods,
         showSleepCoach: widget.showSleepCoach,
       ),
     ];
@@ -266,13 +277,7 @@ class _SleepDetailScreenState extends State<SleepDetailScreen> {
       subtitle: _prettyDate(),
       actions: [
         // All sleeps of the day (naps included) — the multi-period view.
-        RoundIconButton(
-          OsIcon.bedtime,
-          onTap: () => Navigator.of(context).push(
-            themedRoute((_) => SleepPeriodsScreen(date: widget.date),
-                name: 'SleepPeriodsScreen'),
-          ),
-        ),
+        RoundIconButton(OsIcon.bedtime, onTap: _openPeriods),
       ],
       body: RefreshIndicator(
         onRefresh: _load,
@@ -310,6 +315,10 @@ class SleepNightContent extends StatelessWidget {
   final VoidCallback onConfirmFallback;
   final VoidCallback onClearOverride;
 
+  /// Open the per-period breakdown (main sleep + naps). Null in tests and
+  /// anywhere navigation isn't available; the naps row then stays hidden.
+  final VoidCallback? onOpenPeriods;
+
   /// Render the Sleep Coach card (tonight's need/bedtime/wake/alarm) inline,
   /// between the Cycles and Nocturnal-heart sections — it only makes sense
   /// for TODAY's night, so only the Today segment's caller sets this true
@@ -325,6 +334,7 @@ class SleepNightContent extends StatelessWidget {
     required this.onEditTimes,
     required this.onConfirmFallback,
     required this.onClearOverride,
+    this.onOpenPeriods,
     this.showSleepCoach = false,
   });
 
@@ -366,6 +376,20 @@ class SleepNightContent extends StatelessWidget {
   }
 
   num? get _cyclesMean => _num(data['cycles_mean_min']);
+
+  /// Naps this day: the non-main sleep periods. This screen shows the night
+  /// only, so without a row for them a daytime sleep is invisible here.
+  List<Map<String, dynamic>> get _naps {
+    final raw = data['periods'];
+    if (raw is! List) return const [];
+    return raw
+        .map((e) => _map(e))
+        .where((m) => m.isNotEmpty && m['is_main'] != true)
+        .toList();
+  }
+
+  num get _napMin => _naps.fold<num>(
+      0, (a, p) => a + (_num(p['duration_min']) ?? 0));
 
   List<MapEntry<int, double>> get _cycleSeries {
     final raw = data['cycle_series'];
@@ -450,6 +474,10 @@ class SleepNightContent extends StatelessWidget {
         _hero(context),
         const SizedBox(height: Sp.x4),
         _summaryBento(context),
+        if (onOpenPeriods != null && _naps.isNotEmpty) ...[
+          const SizedBox(height: Sp.x3),
+          _napsRow(),
+        ],
         // ── ESTIMATED STAGE BLOCK (below the trustworthy numbers) ──
         const SizedBox(height: Sp.x6),
         _stagesHeader(),
@@ -553,6 +581,24 @@ class SleepNightContent extends StatelessWidget {
         TextButton(onPressed: onEditTimes, child: const Text('Edit')),
         TextButton(onPressed: onClearOverride, child: const Text('Use auto')),
       ]),
+    );
+  }
+
+  /// Daytime sleep, on the way to the per-period breakdown. The numbers above
+  /// are the night only, so the row says so rather than implying the nap is in
+  /// them: it isn't in TST, and it doesn't move readiness. It does count toward
+  /// tonight's sleep need (nap credit, Sleep Coach).
+  Widget _napsRow() {
+    final n = _naps.length;
+    return SurfaceCard(
+      padding: const EdgeInsets.symmetric(horizontal: Sp.x4, vertical: Sp.x2),
+      child: ListRow(
+        icon: OsIcon.bedtime,
+        title: n == 1 ? 'Daytime nap' : '$n daytime naps',
+        subtitle: 'Not included in the night above',
+        value: _hm(_napMin),
+        onTap: onOpenPeriods,
+      ),
     );
   }
 

--- a/test/sleep_naps_visible_test.dart
+++ b/test/sleep_naps_visible_test.dart
@@ -126,4 +126,38 @@ void main() {
       expect(find.text('Daytime nap'), findsNothing);
     });
   });
+
+  group('an unknown nap duration is never rendered as zero', () {
+    testWidgets('the naps row shows "—" when a nap duration is unknown',
+        (t) async {
+      t.view.physicalSize = const Size(390, 3600);
+      t.view.devicePixelRatio = 1.0;
+      addTearDown(t.view.reset);
+
+      final data = _nightWithNap();
+      final periods = (data['periods'] as List).cast<Map<String, dynamic>>();
+      data['periods'] = [
+        periods.first,
+        {...periods[1], 'duration_min': null},
+      ];
+
+      await t.pumpWidget(_host(SleepNightContent(
+        data: data,
+        date: _today(),
+        onEditTimes: () {},
+        onConfirmFallback: () {},
+        onClearOverride: () {},
+        onOpenPeriods: () {},
+      )));
+      await t.pumpAndSettle();
+
+      expect(find.text('Daytime nap'), findsOneWidget);
+      expect(
+        find.text('—'),
+        findsWidgets,
+        reason: 'summing an unknown as 0 would under-report the nap total',
+      );
+      expect(find.text('0m'), findsNothing);
+    });
+  });
 }

--- a/test/sleep_naps_visible_test.dart
+++ b/test/sleep_naps_visible_test.dart
@@ -1,0 +1,153 @@
+// A two-hour afternoon nap was detected, stored, and drawn as a band on the
+// day timeline — and was still nowhere to be found on the Sleep screen. Two
+// separate reasons, both pinned here:
+//
+//   1. The engine writes each period as `is_main` / `start` / `end` /
+//      `asleep_min`; the periods screen reads `onset_ts` / `wake_ts` /
+//      `duration_min`. Every card rendered as "0m" with no time range.
+//   2. The only route into that screen was an AppScaffold action, and the Sleep
+//      tab embeds SleepNightContent (embedded: true), so the scaffold — and the
+//      action with it — never builds in the shipped app.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:openstrap_edge/data/local_repository_impl.dart'
+    show sleepPeriodsForScreen;
+import 'package:openstrap_edge/theme/theme.dart';
+import 'package:openstrap_edge/theme/tokens.dart';
+import 'package:openstrap_edge/ui/sleep/sleep_detail_screen.dart'
+    show SleepNightContent;
+
+/// Periods exactly as `_sleepPeriods` writes them into the bundle.
+const _rawPeriods = [
+  {'is_main': true, 'start': 1000000, 'end': 1024600, 'asleep_min': 410},
+  {'is_main': false, 'start': 1060000, 'end': 1066060, 'asleep_min': 101},
+];
+
+/// The night payload the mapping enriches the main period from.
+const _night = <String, dynamic>{
+  'duration_min': 400, // TST — less than the 410-minute window
+  'efficiency': 0.93,
+  'stages_confidence': 0.62,
+  'light_min': 220,
+  'deep_min': 60,
+  'rem_min': 120,
+  'hypnogram': [
+    {'t': 1000000, 'stage': 'light'},
+  ],
+};
+
+Widget _host(Widget child) {
+  AppColors.active = kDarkPalette;
+  return MaterialApp(
+    theme: buildOpenStrapTheme(kDarkPalette),
+    home: Scaffold(body: SingleChildScrollView(child: child)),
+  );
+}
+
+String _today() {
+  final d = DateTime.now();
+  return '${d.year.toString().padLeft(4, '0')}-'
+      '${d.month.toString().padLeft(2, '0')}-'
+      '${d.day.toString().padLeft(2, '0')}';
+}
+
+Map<String, dynamic> _nightWithNap() => {
+      ..._night,
+      'has_sleep': true,
+      'sleep_source': 'auto',
+      'need_min': 480,
+      'onset_ts': 1000000,
+      'wake_ts': 1024600,
+      'periods': sleepPeriodsForScreen(_rawPeriods, night: _night),
+    };
+
+void main() {
+  group('sleepPeriodsForScreen', () {
+    test('maps the engine keys onto the ones the screen reads', () {
+      final p = sleepPeriodsForScreen(_rawPeriods, night: _night);
+      expect(p, hasLength(2));
+      expect(p[0]['onset_ts'], 1000000);
+      expect(p[0]['wake_ts'], 1024600);
+      expect(p[1]['onset_ts'], 1060000);
+      expect(p[1]['duration_min'], 101);
+    });
+
+    test('main period shows TST, not the window length', () {
+      final main = sleepPeriodsForScreen(_rawPeriods, night: _night).first;
+      expect(main['duration_min'], 400);
+      expect(main['efficiency'], 0.93);
+      expect(main['confidence'], 0.62);
+      expect((main['stages'] as Map)['deep_min'], 60);
+      expect(main['hypnogram'], isA<List>());
+    });
+
+    test('a nap carries no invented stages, efficiency or confidence', () {
+      final nap = sleepPeriodsForScreen(_rawPeriods, night: _night)[1];
+      expect(nap.containsKey('stages'), isFalse);
+      expect(nap.containsKey('efficiency'), isFalse);
+      expect(nap.containsKey('confidence'), isFalse);
+    });
+
+    test('drops junk instead of rendering a zero-length card', () {
+      final p = sleepPeriodsForScreen([
+        {'is_main': false, 'start': 1060000, 'end': 1060000},
+        {'is_main': false, 'end': 1066060},
+        'not a period',
+      ]);
+      expect(p, isEmpty);
+      expect(sleepPeriodsForScreen(null), isEmpty);
+    });
+  });
+
+  group('SleepNightContent naps row', () {
+    testWidgets('a nap is visible on the night screen and opens the breakdown',
+        (t) async {
+      t.view.physicalSize = const Size(390, 3600);
+      t.view.devicePixelRatio = 1.0;
+      addTearDown(t.view.reset);
+
+      var opened = 0;
+      await t.pumpWidget(_host(SleepNightContent(
+        data: _nightWithNap(),
+        date: _today(),
+        onEditTimes: () {},
+        onConfirmFallback: () {},
+        onClearOverride: () {},
+        onOpenPeriods: () => opened++,
+      )));
+      await t.pump(const Duration(milliseconds: 1200));
+
+      expect(find.text('Daytime nap'), findsOneWidget);
+      expect(find.text('1h 41m'), findsOneWidget);
+      await t.tap(find.text('Daytime nap'));
+      await t.pump(const Duration(milliseconds: 400));
+      expect(opened, 1);
+      expect(t.takeException(), isNull);
+    });
+
+    testWidgets('no naps, no row', (t) async {
+      t.view.physicalSize = const Size(390, 3600);
+      t.view.devicePixelRatio = 1.0;
+      addTearDown(t.view.reset);
+
+      final data = _nightWithNap();
+      data['periods'] = sleepPeriodsForScreen(
+        [_rawPeriods.first],
+        night: _night,
+      );
+      await t.pumpWidget(_host(SleepNightContent(
+        data: data,
+        date: _today(),
+        onEditTimes: () {},
+        onConfirmFallback: () {},
+        onClearOverride: () {},
+        onOpenPeriods: () {},
+      )));
+      await t.pump(const Duration(milliseconds: 1200));
+
+      expect(find.text('Daytime nap'), findsNothing);
+    });
+  });
+}

--- a/test/sleep_naps_visible_test.dart
+++ b/test/sleep_naps_visible_test.dart
@@ -90,13 +90,27 @@ void main() {
       expect(nap.containsKey('confidence'), isFalse);
     });
 
-    test('a length outside its own window falls back to the window', () {
+    test('a nap length outside its own window falls back to the window', () {
       final p = sleepPeriodsForScreen([
         {'is_main': false, 'start': 1060000, 'end': 1066060, 'asleep_min': -30},
         {'is_main': false, 'start': 1060000, 'end': 1066060, 'asleep_min': 900},
         {'is_main': false, 'start': 1060000, 'end': 1066060},
       ]);
+      // hasLength first: everyElement passes vacuously on an empty list, so
+      // dropping all three inputs would look like a pass.
+      expect(p, hasLength(3));
       expect(p.map((e) => e['duration_min']), everyElement(101));
+    });
+
+    test('a TST longer than the window falls back to the window', () {
+      for (final tst in const [-30, 900]) {
+        final main = sleepPeriodsForScreen(
+          [_rawPeriods.first],
+          night: {..._night, 'duration_min': tst},
+        );
+        expect(main, hasLength(1));
+        expect(main.first['duration_min'], 410);
+      }
     });
 
     test('drops junk instead of rendering a zero-length card', () {

--- a/test/sleep_naps_visible_test.dart
+++ b/test/sleep_naps_visible_test.dart
@@ -12,18 +12,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:openstrap_edge/data/local_repository_impl.dart'
-    show sleepPeriodsForScreen;
 import 'package:openstrap_edge/theme/theme.dart';
 import 'package:openstrap_edge/theme/tokens.dart';
 import 'package:openstrap_edge/ui/sleep/sleep_detail_screen.dart'
     show SleepNightContent;
 
-/// Periods exactly as `_sleepPeriods` writes them into the bundle.
-const _rawPeriods = [
-  {'is_main': true, 'start': 1000000, 'end': 1024600, 'asleep_min': 410},
-  {'is_main': false, 'start': 1060000, 'end': 1066060, 'asleep_min': 101},
-];
 
 /// The night payload the mapping enriches the main period from.
 const _night = <String, dynamic>{
@@ -60,70 +53,31 @@ Map<String, dynamic> _nightWithNap() => {
       'need_min': 480,
       'onset_ts': 1000000,
       'wake_ts': 1024600,
-      'periods': sleepPeriodsForScreen(_rawPeriods, night: _night),
+      // The vocabulary the producer emits since #204. This used to be built by
+      // `sleepPeriodsForScreen`, which translated the old
+      // start/end/asleep_min shape; that translator is gone because the writer
+      // now emits these keys directly and `_periodsWithMainStages` enriches
+      // them on read.
+      'periods': const [
+        {
+          'is_main': true,
+          'onset_ts': 1000000,
+          'wake_ts': 1024600,
+          'duration_min': 400,
+          'efficiency': 0.93,
+          'confidence': 0.62,
+          'stages': {'light_min': 220, 'deep_min': 60, 'rem_min': 120},
+        },
+        {
+          'is_main': false,
+          'onset_ts': 1060000,
+          'wake_ts': 1066060,
+          'duration_min': 101,
+        },
+      ],
     };
 
 void main() {
-  group('sleepPeriodsForScreen', () {
-    test('maps the engine keys onto the ones the screen reads', () {
-      final p = sleepPeriodsForScreen(_rawPeriods, night: _night);
-      expect(p, hasLength(2));
-      expect(p[0]['onset_ts'], 1000000);
-      expect(p[0]['wake_ts'], 1024600);
-      expect(p[1]['onset_ts'], 1060000);
-      expect(p[1]['duration_min'], 101);
-    });
-
-    test('main period shows TST, not the window length', () {
-      final main = sleepPeriodsForScreen(_rawPeriods, night: _night).first;
-      expect(main['duration_min'], 400);
-      expect(main['efficiency'], 0.93);
-      expect(main['confidence'], 0.62);
-      expect((main['stages'] as Map)['deep_min'], 60);
-      expect(main['hypnogram'], isA<List>());
-    });
-
-    test('a nap carries no invented stages, efficiency or confidence', () {
-      final nap = sleepPeriodsForScreen(_rawPeriods, night: _night)[1];
-      expect(nap.containsKey('stages'), isFalse);
-      expect(nap.containsKey('efficiency'), isFalse);
-      expect(nap.containsKey('confidence'), isFalse);
-    });
-
-    test('a nap length outside its own window falls back to the window', () {
-      final p = sleepPeriodsForScreen([
-        {'is_main': false, 'start': 1060000, 'end': 1066060, 'asleep_min': -30},
-        {'is_main': false, 'start': 1060000, 'end': 1066060, 'asleep_min': 900},
-        {'is_main': false, 'start': 1060000, 'end': 1066060},
-      ]);
-      // hasLength first: everyElement passes vacuously on an empty list, so
-      // dropping all three inputs would look like a pass.
-      expect(p, hasLength(3));
-      expect(p.map((e) => e['duration_min']), everyElement(101));
-    });
-
-    test('a TST longer than the window falls back to the window', () {
-      for (final tst in const [-30, 900]) {
-        final main = sleepPeriodsForScreen(
-          [_rawPeriods.first],
-          night: {..._night, 'duration_min': tst},
-        );
-        expect(main, hasLength(1));
-        expect(main.first['duration_min'], 410);
-      }
-    });
-
-    test('drops junk instead of rendering a zero-length card', () {
-      final p = sleepPeriodsForScreen([
-        {'is_main': false, 'start': 1060000, 'end': 1060000},
-        {'is_main': false, 'end': 1066060},
-        'not a period',
-      ]);
-      expect(p, isEmpty);
-      expect(sleepPeriodsForScreen(null), isEmpty);
-    });
-  });
-
   group('SleepNightContent naps row', () {
     testWidgets('a nap is visible on the night screen and opens the breakdown',
         (t) async {
@@ -156,10 +110,9 @@ void main() {
       addTearDown(t.view.reset);
 
       final data = _nightWithNap();
-      data['periods'] = sleepPeriodsForScreen(
-        [_rawPeriods.first],
-        night: _night,
-      );
+      // Main sleep only — the nap row must not appear.
+      data['periods'] =
+          [(data['periods'] as List).first as Map<String, dynamic>];
       await t.pumpWidget(_host(SleepNightContent(
         data: data,
         date: _today(),

--- a/test/sleep_naps_visible_test.dart
+++ b/test/sleep_naps_visible_test.dart
@@ -90,6 +90,15 @@ void main() {
       expect(nap.containsKey('confidence'), isFalse);
     });
 
+    test('a length outside its own window falls back to the window', () {
+      final p = sleepPeriodsForScreen([
+        {'is_main': false, 'start': 1060000, 'end': 1066060, 'asleep_min': -30},
+        {'is_main': false, 'start': 1060000, 'end': 1066060, 'asleep_min': 900},
+        {'is_main': false, 'start': 1060000, 'end': 1066060},
+      ]);
+      expect(p.map((e) => e['duration_min']), everyElement(101));
+    });
+
     test('drops junk instead of rendering a zero-length card', () {
       final p = sleepPeriodsForScreen([
         {'is_main': false, 'start': 1060000, 'end': 1060000},

--- a/test/sleep_periods_legacy_keys_test.dart
+++ b/test/sleep_periods_legacy_keys_test.dart
@@ -235,4 +235,48 @@ void main() {
       expect(periods.first['wake_ts'], isNull);
     },
   );
+
+  // Ported from #205, which added these at its (now-removed) screen-side
+  // translator. They are real invariants and belong at the surviving seam.
+  test(
+    'a period cannot report more asleep minutes than its own window',
+    () async {
+      await seed({
+        'periods': [
+          {
+            'is_main': false,
+            'onset_ts': napOnset,
+            'wake_ts': napOnset + 30 * 60, // a 30-minute window
+            'duration_min': 101, // ...claiming 101 minutes of sleep
+          },
+        ],
+        'total_asleep_min': 101,
+      });
+
+      final sleep = await repo.getDaySleep('2026-06-15');
+      final periods = (sleep['periods'] as List).cast<Map<String, dynamic>>();
+      expect(
+        periods.single['duration_min'],
+        30,
+        reason: 'clamped to the window, which is the trustworthy half',
+      );
+    },
+  );
+
+  test('a degenerate window is dropped, not rendered as a zero-length card',
+      () async {
+    await seed({
+      'periods': [
+        {'is_main': true, 'onset_ts': onset, 'wake_ts': wake, 'duration_min': 420},
+        {'is_main': false, 'onset_ts': napOnset, 'wake_ts': napOnset},
+        {'is_main': false, 'onset_ts': napWake, 'wake_ts': napOnset},
+      ],
+      'total_asleep_min': 420,
+    });
+
+    final sleep = await repo.getDaySleep('2026-06-15');
+    final periods = (sleep['periods'] as List).cast<Map<String, dynamic>>();
+    expect(periods, hasLength(1), reason: 'only the real main sleep survives');
+    expect(periods.single['is_main'], isTrue);
+  });
 }

--- a/test/sleep_periods_legacy_keys_test.dart
+++ b/test/sleep_periods_legacy_keys_test.dart
@@ -279,4 +279,73 @@ void main() {
     expect(periods, hasLength(1), reason: 'only the real main sleep survives');
     expect(periods.single['is_main'], isTrue);
   });
+
+  test(
+    'the hero total equals the sum of the CARDS after a period is clamped',
+    () async {
+      await seed({
+        'periods': [
+          {'is_main': true, 'onset_ts': onset, 'wake_ts': wake, 'duration_min': 420},
+          // Claims 101 min of sleep inside a 30-minute window.
+          {
+            'is_main': false,
+            'onset_ts': napOnset,
+            'wake_ts': napOnset + 30 * 60,
+            'duration_min': 101,
+          },
+        ],
+        'total_asleep_min': 521, // what the producer summed, pre-clamp
+      });
+
+      final sleep = await repo.getDaySleep('2026-06-15');
+      final periods = (sleep['periods'] as List).cast<Map<String, dynamic>>();
+      final cardSum = periods.fold<int>(
+        0,
+        (a, p) => a + ((p['duration_min'] as num?)?.toInt() ?? 0),
+      );
+      expect(cardSum, 450);
+      expect(
+        sleep['total_asleep_min'],
+        450,
+        reason: 'a user can add the cards up; the hero must not disagree',
+      );
+    },
+  );
+
+  test(
+    'an ABSENT stored total is NOT recomputed into a confident number',
+    () async {
+      // total_asleep_min null = nap detection abstained, so the day holds an
+      // unknown NUMBER of unmeasured naps (#204). Summing the periods we do
+      // have would silently omit them.
+      await seed({
+        'periods': [
+          {'is_main': true, 'onset_ts': onset, 'wake_ts': wake, 'duration_min': 420},
+        ],
+        'total_asleep_min': null,
+      });
+
+      final sleep = await repo.getDaySleep('2026-06-15');
+      expect((sleep['periods'] as List), hasLength(1));
+      expect(
+        sleep['total_asleep_min'],
+        isNull,
+        reason: 'absent stays absent — the screen renders "—"',
+      );
+    },
+  );
+
+  test('a period with an unknown duration makes the total unknown again',
+      () async {
+    await seed({
+      'periods': [
+        {'is_main': true, 'onset_ts': onset, 'wake_ts': wake, 'duration_min': null},
+        {'is_main': false, 'onset_ts': napOnset, 'wake_ts': napWake, 'duration_min': 38},
+      ],
+      'total_asleep_min': 38,
+    });
+
+    final sleep = await repo.getDaySleep('2026-06-15');
+    expect(sleep['total_asleep_min'], isNull);
+  });
 }

--- a/test/sleep_periods_legacy_keys_test.dart
+++ b/test/sleep_periods_legacy_keys_test.dart
@@ -54,25 +54,27 @@ void main() {
   const napOnset = onset + 14 * 3600;
   const napWake = napOnset + 40 * 60;
 
-  Future<void> seed(Map<String, dynamic> sleepPeriods) async {
+  Future<void> seed(Map<String, dynamic> sleepPeriods, {bool night = true}) async {
     await LocalDb.putDayResult(
       dayId: '2026-06-15',
       algoVersion: 1, // a pre-rename generation
       payloadJson: jsonEncode({
         'scalars': {'tst_min': 420.0},
-        'sleep': {
-          'accounting': {
-            'confidence': 0.7,
-            'value': {'tst_sec': 420 * 60, 'efficiency_pct': 92.0},
-          },
-          'window': {
-            'value': {
-              'onset_ms': onset * 1000,
-              'offset_ms': wake * 1000,
-              'spt_sec': 7 * 3600,
-            },
-          },
-        },
+        'sleep': night
+            ? {
+                'accounting': {
+                  'confidence': 0.7,
+                  'value': {'tst_sec': 420 * 60, 'efficiency_pct': 92.0},
+                },
+                'window': {
+                  'value': {
+                    'onset_ms': onset * 1000,
+                    'offset_ms': wake * 1000,
+                    'spt_sec': 7 * 3600,
+                  },
+                },
+              }
+            : const <String, dynamic>{},
         'sleep_periods': sleepPeriods,
       }),
       windowJson: '{}',
@@ -347,5 +349,40 @@ void main() {
 
     final sleep = await repo.getDaySleep('2026-06-15');
     expect(sleep['total_asleep_min'], isNull);
+  });
+
+  group('nap-only day — no detected night', () {
+    test('the naps are attached instead of being dropped on the floor', () async {
+      // The `tst == null` early return used to drop these, so the screen said
+      // "No sleep recorded for this night" while the same nap was credited
+      // against sleep need and drawn on the Timeline.
+      await seed({
+        'periods': [
+          {
+            'is_main': false,
+            'onset_ts': napOnset,
+            'wake_ts': napWake,
+            'duration_min': 38,
+          },
+        ],
+        'total_asleep_min': 38,
+      }, night: false);
+
+      final sleep = await repo.getDaySleep('2026-06-15');
+      expect(
+        sleep['has_sleep'],
+        isFalse,
+        reason: 'there is genuinely no NIGHT to stage — that stays honest',
+      );
+      expect((sleep['periods'] as List), hasLength(1));
+      expect(sleep['total_asleep_min'], 38);
+    });
+
+    test('a day with neither night nor naps is unchanged', () async {
+      await seed({'periods': const [], 'total_asleep_min': null}, night: false);
+      final sleep = await repo.getDaySleep('2026-06-15');
+      expect(sleep['has_sleep'], isFalse);
+      expect(sleep['periods'], isNull, reason: 'nothing to show, nothing added');
+    });
   });
 }

--- a/test/sleep_periods_legacy_keys_test.dart
+++ b/test/sleep_periods_legacy_keys_test.dart
@@ -385,4 +385,36 @@ void main() {
       expect(sleep['periods'], isNull, reason: 'nothing to show, nothing added');
     });
   });
+
+  test(
+    'a NEGATIVE duration is corrupt, not small — it becomes unknown, and is '
+    'never clamped up into a full night',
+    () async {
+      await seed({
+        'periods': [
+          {
+            'is_main': false,
+            'onset_ts': onset,
+            'wake_ts': wake, // a 7-hour window
+            'duration_min': -50,
+          },
+        ],
+        'total_asleep_min': -50,
+      }, night: false);
+
+      final sleep = await repo.getDaySleep('2026-06-15');
+      final periods = (sleep['periods'] as List).cast<Map<String, dynamic>>();
+      expect(periods.single['duration_min'], isNull);
+      expect(
+        periods.single['duration_min'],
+        isNot(420),
+        reason: 'clamping up would invent a full night out of garbage',
+      );
+      expect(
+        sleep['total_asleep_min'],
+        isNull,
+        reason: 'unknown propagates — the hero reads "—"',
+      );
+    },
+  );
 }


### PR DESCRIPTION
I napped for ~1h40m this afternoon, synced, and the nap was nowhere in the app. It turned out the detection is fine (the nap shows as a band under Your day), but two things kept it off the Sleep screen.

**1. The periods screen is unreachable.** `SleepPeriodsScreen` is only pushed from an `AppScaffold` action in `SleepDetailScreen`, and the Sleep tab always builds that screen with `embedded: true` (`screens.dart:50,55`), which returns the bare `Column` without the scaffold. `SleepDetailScreen.today()` is never called either, so nothing in the shipped app can open it.

**2. The periods payload is keyed wrong.** The engine writes each period as `is_main` / `start` / `end` / `asleep_min` (`derivation_engine.dart:3626`), while the screen reads `onset_ts` / `wake_ts` / `duration_min`. Even if you reached the screen, every card would say "0m" with no time range.

Before: Sleep tab shows the night only, 6h40m, no sign of the nap anywhere.
After: a row under the night summary, "Daytime nap, 1h 41m, not included in the night above", which opens the per-period breakdown with real times and durations.

Also in here:

* the main period now carries the night's TST, efficiency, stage minutes and hypnogram, so the two sleep screens can't print different numbers for the same night, and the day total is the sum of what the cards show
* a nap has no confidence value, so it no longer gets a literal `0` and the confidence dot is hidden instead
* `test/sleep_naps_visible_test.dart` covers the mapping and the row (visible with a nap, absent without, tap fires)

Nothing about how a nap is computed changed, so `kAlgoVersion` stays put.

Left alone deliberately, happy to do either in a follow-up: naps still don't enter TST or readiness (they only credit tonight's need via `nap_min`), and `_daySleep` returns `has_sleep: false` when there's no night, so a nap-only day still shows nothing.

Verified on Flutter 3.41.6 (the pinned version): `flutter analyze` clean, `flutter test --concurrency=1` gives 1205 passed / 2 skipped, the two skips being the `whoop_hist.jsonl` replays that need the capture file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daytime-nap summaries to sleep details, including nap count and total duration.
  * Preserved nap-only sleep periods when no nighttime sleep is detected.
  * Enabled navigation from sleep details to the full sleep-period breakdown.

* **Bug Fixes**
  * Improved compatibility with legacy sleep-period data formats.
  * Corrected invalid period handling and capped durations to valid time windows.
  * Recalculated totals accurately while preserving unknown or unavailable values.

* **Tests**
  * Added coverage for nap display, navigation, nap-only days, duration validation, and invalid periods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->