### PR TITLE
Don't let replayed battery events overwrite the live reading

### DIFF
--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -2178,8 +2178,19 @@ class BleEngine {
       }
     }
     if (f.containsKey('battery_pct')) {
-      state.batteryPct = (f['battery_pct'] as num).toDouble();
-      onState(state);
+      // Gate on the EVENT's own strap timestamp, for the same reason the
+      // `charging` flag below carries one: the band re-serves its buffered
+      // event log on connect, so a BATTERY_LEVEL event is not evidence of the
+      // current charge. Applied blind, a first pair with a long backlog walked
+      // the live indicator through weeks of battery history before settling.
+      // A GET_BATTERY_LEVEL poll response has no `ts_epoch` and is always
+      // live — see [BatteryPolicy].
+      final batteryTs = (f['ts_epoch'] as num?)?.toInt();
+      final wallNow = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      if (BatteryPolicy.acceptsEventReading(batteryTs, wallNow)) {
+        state.batteryPct = (f['battery_pct'] as num).toDouble();
+        onState(state);
+      }
     }
     if (f.containsKey('charging')) {
       state.charging = f['charging'] as bool;

--- a/lib/sync/sync_policy.dart
+++ b/lib/sync/sync_policy.dart
@@ -205,13 +205,15 @@ class BatteryPolicy {
   static const int maxEventAgeSec = 1800;
 
   /// [tsEpoch] is the event's own strap-clock stamp, or null for a poll
-  /// response. A reading past the [kFutureMargin] ceiling comes from an unset
-  /// or corrupt RTC and is refused for the same reason [ClockPolicy] refuses
-  /// one — with no accepted event the 30-second poll still owns the value.
+  /// response. The window is symmetric on purpose: a strap RTC running ahead
+  /// stamps an event in the FUTURE, and a one-sided age check never looks at
+  /// that side — a future-dated replay would sail through and overwrite the
+  /// live value. Beyond the window in either direction is a drifting or unset
+  /// RTC, refused for the same reason [ClockPolicy] refuses one: with no
+  /// accepted event the 30-second poll still owns the value.
   static bool acceptsEventReading(int? tsEpoch, int wallNow) {
     if (tsEpoch == null) return true;
-    if (tsEpoch > wallNow + kFutureMargin) return false;
-    return wallNow - tsEpoch <= maxEventAgeSec;
+    return (wallNow - tsEpoch).abs() <= maxEventAgeSec;
   }
 }
 

--- a/lib/sync/sync_policy.dart
+++ b/lib/sync/sync_policy.dart
@@ -188,6 +188,33 @@ enum BackfillTrigger {
   autoContinue,
 }
 
+/// Whether a decoded battery reading describes the band's CURRENT charge.
+///
+/// Two sources populate the same battery field. A GET_BATTERY_LEVEL response is
+/// live by construction — it is answered on the spot and carries no timestamp.
+/// A BATTERY_LEVEL event does carry one, and cannot be trusted without it: the
+/// band re-serves its whole buffered event log on connect, so a first pair with
+/// a long backlog delivers weeks of historical readings at speed. Applied
+/// blind, they walk the live indicator through the band's entire battery
+/// history before it settles. Same hazard the `charging` flag already guards
+/// via [DeviceState.chargingTs].
+class BatteryPolicy {
+  /// How recent a BATTERY_LEVEL event must be to count as the current charge.
+  /// The band emits one roughly every 8 minutes, so a half-hour window keeps
+  /// every genuinely live event while rejecting a replayed backlog.
+  static const int maxEventAgeSec = 1800;
+
+  /// [tsEpoch] is the event's own strap-clock stamp, or null for a poll
+  /// response. A reading past the [kFutureMargin] ceiling comes from an unset
+  /// or corrupt RTC and is refused for the same reason [ClockPolicy] refuses
+  /// one — with no accepted event the 30-second poll still owns the value.
+  static bool acceptsEventReading(int? tsEpoch, int wallNow) {
+    if (tsEpoch == null) return true;
+    if (tsEpoch > wallNow + kFutureMargin) return false;
+    return wallNow - tsEpoch <= maxEventAgeSec;
+  }
+}
+
 class BackfillPolicy {
   static const double periodicFloorSeconds = 900.0;
   static const double eventFloorSeconds = 90.0;

--- a/test/sync_policy_test.dart
+++ b/test/sync_policy_test.dart
@@ -680,4 +680,35 @@ void main() {
       );
     });
   });
+
+  // The strap re-serves its whole buffered EVENT log on connect, so a
+  // BATTERY_LEVEL event is not evidence of the CURRENT charge — only its
+  // timestamp is. Without this gate a first pair with a long backlog replays
+  // weeks of battery history straight into the live indicator.
+  group('battery reading acceptance', () {
+    test('a poll response carries no event timestamp and is always live', () {
+      expect(BatteryPolicy.acceptsEventReading(null, wall), isTrue);
+    });
+
+    test('a battery event stamped just now is accepted', () {
+      expect(BatteryPolicy.acceptsEventReading(wall - 60, wall), isTrue);
+    });
+
+    test('a battery event replayed from days ago is rejected', () {
+      // The real shape of the bug: an event stamped 33 days before the
+      // session that arrived during a backlog drain.
+      expect(
+        BatteryPolicy.acceptsEventReading(wall - 33 * 86400, wall),
+        isFalse,
+      );
+    });
+
+    test('a battery event from an implausibly far-future clock is rejected',
+        () {
+      expect(
+        BatteryPolicy.acceptsEventReading(wall + kFutureMargin + 1, wall),
+        isFalse,
+      );
+    });
+  });
 }

--- a/test/sync_policy_test.dart
+++ b/test/sync_policy_test.dart
@@ -710,5 +710,24 @@ void main() {
         isFalse,
       );
     });
+
+    test('a battery event stamped beyond the window into the future is '
+        'rejected', () {
+      // A strap RTC running ahead put the stamp in the future rather than the
+      // past. "Recent" has to mean recent in both directions, or the gate lets
+      // an event through on the one side it never checked.
+      expect(
+        BatteryPolicy.acceptsEventReading(
+            wall + BatteryPolicy.maxEventAgeSec + 1, wall),
+        isFalse,
+      );
+    });
+
+    test('small clock skew ahead of the phone is still accepted', () {
+      expect(
+        BatteryPolicy.acceptsEventReading(wall + 60, wall),
+        isTrue,
+      );
+    });
   });
 }


### PR DESCRIPTION
On a first pair with about a month of history banked, the battery indicator walks through the band's whole battery history before it settles. It shows 40 percent, then 29, then 8, while the band is actually at 99. It takes about fifteen minutes to stop.

A BATTERY_LEVEL event is applied to live state without checking its timestamp, and the band re-serves its buffered event log on connect, so most of those readings are weeks old. The charging flag directly below already guards against this and keeps the event timestamp for exactly that reason. Battery never got the same treatment.

It is not only cosmetic. Each change also writes a band_battery row stamped with the current time, so a month of readings lands as though it happened in the last quarter of an hour, and that is the series the overnight forecast reads. The same value feeds the low battery notification. Replaying my own capture through that rule, it fires twice while the band is sitting at 99 percent.

The fix puts the decision in a policy class, as CONTRIBUTING asks. A GET_BATTERY_LEVEL response carries no event timestamp and is always treated as live, so the thirty second poll keeps owning the value. An event is accepted only when its own timestamp is recent. The window is thirty minutes against a roughly eight minute event cadence, so genuinely live events still update the indicator.

Checked with four unit tests written first and watched fail, plus flutter analyze clean and the full suite green at concurrency 1, 1768 passing. I also replayed the captured event stream through the new gate. Of 808 events, 807 are rejected as replay and the single accepted one is a 100 percent reading from seventeen minutes earlier, which matches what the poll returned. Nothing in this path is specific to a band generation, so any band arriving with a long backlog behaves the same way. No kAlgoVersion bump, since this is device state rather than a stored day result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved battery updates by ignoring stale, replayed, or invalid future-dated event readings.
  * Continued accepting live battery poll responses and recent valid battery events.
  * Added safeguards to ensure displayed battery percentages reflect trustworthy readings.
  * Battery readings with timestamps outside the valid 30-minute window are now excluded, preventing outdated or implausible values from replacing current battery information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->