### PR TITLE
sync: log-only burst-completeness shortfall diagnostic (correct received-total signal)

### DIFF
--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -168,10 +168,12 @@ bool burstPacketCountMatches({
 ///
 /// [droppedThisBurst] (RecordGate plausibility rejections this burst) is added
 /// back because the band counted those frames but they never entered
-/// [receivedTrafficCount] — so subtracting them isolates frames the band sent
-/// that NEVER reached us at all. A POSITIVE result is that true frame loss
-/// (would-flag); zero is complete; negative just means we tallied more than
-/// expected (retried/duplicate frames), which is not loss.
+/// [receivedTrafficCount]. A POSITIVE result is frames the band counted that we
+/// did NOT count as valid received traffic — i.e. missing OR corrupted traffic
+/// (would-flag / potential loss): CRC-failed frames also never enter
+/// [receivedTrafficCount], so a positive shortfall cannot by itself prove a
+/// frame never arrived. Zero is complete; negative just means we tallied more
+/// than expected (retried/duplicate frames), which is not loss.
 @visibleForTesting
 int burstPacketShortfall({
   required int expectedPacketCount,
@@ -2624,9 +2626,10 @@ class BleEngine {
       // Honest, LOG-ONLY completeness signal (never gates the ACK). Compares
       // num_packets against the ALL-TYPES received total (currentBurstTrafficCount),
       // not the banked R24 subset — see burstPacketShortfall. Only a POSITIVE
-      // shortfall means frames the band sent never reached us (true loss); this
-      // is the signal we want visible in telemetry BEFORE ever wiring a FAIL
-      // gate (which needs its own design + field validation to avoid re-flood).
+      // shortfall means frames the band counted that we did not count as valid
+      // received traffic (missing OR CRC-corrupted — potential loss); this is
+      // the signal we want visible in telemetry BEFORE ever wiring a FAIL gate
+      // (which needs its own design + field validation to avoid re-flood).
       final shortfall = expected == null
           ? 0
           : burstPacketShortfall(
@@ -2681,15 +2684,16 @@ class BleEngine {
       }
       // Would-flag: the correct-signal completeness diagnostic. LOG-ONLY — the
       // commit + verbatim-token ACK below are unchanged. A positive shortfall
-      // is the honest "true frame loss" telemetry we want to watch before a
-      // later, field-validated FAIL gate ever acts on it.
+      // is the honest missing/corrupted-traffic telemetry we want to watch
+      // before a later, field-validated FAIL gate ever acts on it.
       if (shortfall > 0) {
         _log(
           '[SYNC] burst completeness would-flag (LOG-ONLY, commit+ACK '
           'unchanged): expected=$expected '
           'received=${d.currentBurstTrafficCount} '
           'dropped_this_burst=$droppedThisBurst shortfall=$shortfall '
-          '(all-types received total — true frame loss; groundwork for a '
+          '(all-types received total — frames the band counted that we did '
+          'not; missing or CRC-corrupted, potential loss; groundwork for a '
           'future FAIL gate, NOT gating today)',
         );
       }

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -155,6 +155,31 @@ bool burstPacketCountMatches({
 }) =>
     expectedPacketCount == actualBurstPacketCount + droppedThisBurst;
 
+/// Honest burst-completeness signal for TELEMETRY ONLY — this NEVER gates the
+/// commit/ACK decision (see the log-only call site).
+///
+/// [receivedTrafficCount] is every frame we actually received this burst, ALL
+/// types (historical R24 data + interleaved console/event/unknown) — i.e.
+/// [BurstStats.totalTrafficPacketCount], NOT the banked historical subset. The
+/// band's [expectedPacketCount] (num_packets) likewise counts every frame it
+/// transmitted, so comparing the two all-types totals is type-agnostic and
+/// interleaving-immune: benign console/event frames riding along cannot fake a
+/// shortfall the way comparing against the R24-only subset did.
+///
+/// [droppedThisBurst] (RecordGate plausibility rejections this burst) is added
+/// back because the band counted those frames but they never entered
+/// [receivedTrafficCount] — so subtracting them isolates frames the band sent
+/// that NEVER reached us at all. A POSITIVE result is that true frame loss
+/// (would-flag); zero is complete; negative just means we tallied more than
+/// expected (retried/duplicate frames), which is not loss.
+@visibleForTesting
+int burstPacketShortfall({
+  required int expectedPacketCount,
+  required int receivedTrafficCount,
+  int droppedThisBurst = 0,
+}) =>
+    expectedPacketCount - (receivedTrafficCount + droppedThisBurst);
+
 /// Fired for every LIVE high-rate frame (0x28/0x2B/0x33). These are EPHEMERAL —
 /// they are NOT persisted to raw_records (that bloated storage ~50x and stalled
 /// derivation). The caller routes them to an in-memory sink for the live UI /
@@ -2596,6 +2621,19 @@ class BleEngine {
             expectedPacketCount: expected,
             droppedThisBurst: droppedThisBurst,
           );
+      // Honest, LOG-ONLY completeness signal (never gates the ACK). Compares
+      // num_packets against the ALL-TYPES received total (currentBurstTrafficCount),
+      // not the banked R24 subset — see burstPacketShortfall. Only a POSITIVE
+      // shortfall means frames the band sent never reached us (true loss); this
+      // is the signal we want visible in telemetry BEFORE ever wiring a FAIL
+      // gate (which needs its own design + field validation to avoid re-flood).
+      final shortfall = expected == null
+          ? 0
+          : burstPacketShortfall(
+              expectedPacketCount: expected,
+              receivedTrafficCount: d.currentBurstTrafficCount,
+              droppedThisBurst: droppedThisBurst,
+            );
       // ADVISORY ONLY, never a gate: `expectedPacketCount`'s exact semantics
       // (which transport packet types the band itself counts — command
       // responses interleaved with the burst? retried/duplicate frames?) are
@@ -2635,10 +2673,25 @@ class BleEngine {
             'traffic_burst_packets': d.currentBurstTrafficCount,
             'burst_validation_failures': d.consecutiveValidationFailures,
             'burst_breakdown': d.currentBurstBreakdown,
+            'burst_shortfall': shortfall,
           },
         ));
       } else {
         _burstMismatchStreak = 0;
+      }
+      // Would-flag: the correct-signal completeness diagnostic. LOG-ONLY — the
+      // commit + verbatim-token ACK below are unchanged. A positive shortfall
+      // is the honest "true frame loss" telemetry we want to watch before a
+      // later, field-validated FAIL gate ever acts on it.
+      if (shortfall > 0) {
+        _log(
+          '[SYNC] burst completeness would-flag (LOG-ONLY, commit+ACK '
+          'unchanged): expected=$expected '
+          'received=${d.currentBurstTrafficCount} '
+          'dropped_this_burst=$droppedThisBurst shortfall=$shortfall '
+          '(all-types received total — true frame loss; groundwork for a '
+          'future FAIL gate, NOT gating today)',
+        );
       }
       final r = d.bufferedRecTsRange;
       final droppedThisBurstForLog = droppedThisBurst;

--- a/test/ble_engine_test.dart
+++ b/test/ble_engine_test.dart
@@ -122,6 +122,101 @@ void main() {
     });
   });
 
+  group('burst completeness shortfall (log-only would-flag signal)', () {
+    test('no shortfall when all-types received total equals num_packets', () {
+      // Band sent 49 frames (30 R24 + 17 console + 2 event); we received all.
+      final received = countBurstTrafficPackets(
+        dataPacketCountsByRevision: const {24: 30},
+        consoleCount: 17,
+        eventCount: 2,
+      );
+      expect(
+        burstPacketShortfall(
+          expectedPacketCount: 49,
+          receivedTrafficCount: received,
+        ),
+        0,
+      );
+    });
+
+    test(
+      'interleaved console/event frames do NOT false-positive: comparing '
+      'against the all-types received total (not the banked R24 subset) '
+      'keeps shortfall at zero',
+      () {
+        final received = countBurstTrafficPackets(
+          dataPacketCountsByRevision: const {24: 15},
+          consoleCount: 37,
+          eventCount: 2,
+        );
+        // Banked R24 subset alone is 15 — comparing THAT to num_packets=54
+        // would fabricate a 39-frame "loss". The correct all-types total is 54.
+        expect(received, 54);
+        expect(
+          burstPacketShortfall(
+            expectedPacketCount: 54,
+            receivedTrafficCount: received,
+          ),
+          0,
+        );
+      },
+    );
+
+    test('positive shortfall flags true frame loss (band sent more than we got)',
+        () {
+      final received = countBurstTrafficPackets(
+        dataPacketCountsByRevision: const {24: 20},
+        consoleCount: 3,
+      );
+      // Band reported 30, we received 23 all-types, nothing gate-dropped → 7 lost.
+      expect(
+        burstPacketShortfall(
+          expectedPacketCount: 30,
+          receivedTrafficCount: received,
+        ),
+        7,
+      );
+    });
+
+    test('gate-dropped records are added back so they never read as loss', () {
+      // 26 all-types received, 24 legitimately gate-dropped, band expected 50 →
+      // fully explained, no true loss.
+      expect(
+        burstPacketShortfall(
+          expectedPacketCount: 50,
+          receivedTrafficCount: 26,
+          droppedThisBurst: 24,
+        ),
+        0,
+      );
+    });
+
+    test('negative shortfall (retries/dupes counted extra) is not loss', () {
+      expect(
+        burstPacketShortfall(
+          expectedPacketCount: 26,
+          receivedTrafficCount: 28,
+        ),
+        lessThan(0),
+      );
+    });
+
+    test('shortfall==0 is exactly burstPacketCountMatches', () {
+      const expected = 50, received = 26, dropped = 24;
+      final matches = burstPacketCountMatches(
+        expectedPacketCount: expected,
+        actualBurstPacketCount: received,
+        droppedThisBurst: dropped,
+      );
+      final shortfall = burstPacketShortfall(
+        expectedPacketCount: expected,
+        receivedTrafficCount: received,
+        droppedThisBurst: dropped,
+      );
+      expect(matches, (shortfall == 0));
+    });
+  });
+
   group('maintenance traffic gating', () {
     test('maintenance traffic is paused while offload is active', () {
       expect(shouldPauseMaintenanceTraffic(offloadActive: true), isTrue);

--- a/test/ble_engine_test.dart
+++ b/test/ble_engine_test.dart
@@ -162,13 +162,15 @@ void main() {
       },
     );
 
-    test('positive shortfall flags true frame loss (band sent more than we got)',
-        () {
+    test(
+        'positive shortfall flags missing-or-corrupted traffic (band counted '
+        'more than we did)', () {
       final received = countBurstTrafficPackets(
         dataPacketCountsByRevision: const {24: 20},
         consoleCount: 3,
       );
-      // Band reported 30, we received 23 all-types, nothing gate-dropped → 7 lost.
+      // Band reported 30, we counted 23 all-types, nothing gate-dropped → 7
+      // frames the band sent that we did not count (never arrived or CRC-failed).
       expect(
         burstPacketShortfall(
           expectedPacketCount: 30,


### PR DESCRIPTION
### **User description**
## What

Adds an **honest, log-only** burst frame-loss diagnostic at `HISTORY_END`. It computes the completeness signal against the **all-types received total** (`totalTrafficPacketCount`) instead of the banked R24 subset, and emits a `would-flag` line + a `burst_shortfall` ledger field — **without changing the commit/ACK decision**.

## Why

The strap's `HISTORY_END` metadata carries `num_packets` (every frame it transmitted this burst — R24 data *and* interleaved console/event/unknown). The only correct completeness comparison is against the **all-types received total**. Comparing against the banked R24 subset fabricates a shortfall whenever console/event frames ride along un-banked — which is exactly why that gate was disabled and `validateBurst` went advisory-only.

Today, on a **true** frame drop the burst is committed + ACKed OK anyway and the loss is silent. Before wiring any FAIL gate we need to **see** true loss in telemetry. This PR is that groundwork.

## The signal

New pure helper:

```dart
burstPacketShortfall = expectedPacketCount - (receivedTrafficCount + droppedThisBurst)
```

- `receivedTrafficCount` = `totalTrafficPacketCount` (all types) — type-agnostic, interleaving-immune.
- `droppedThisBurst` (RecordGate plausibility rejections) is added back so gate drops never read as radio loss.
- **Positive** shortfall = frames the band sent that never reached us (true loss → would-flag). Zero = complete. Negative = retries/dupes, not loss.

At burst end we log a clear `would-flag (LOG-ONLY, commit+ACK unchanged)` line when shortfall > 0, and stamp `burst_shortfall` into the existing mismatch ledger entry.

## Invariants (unchanged)

- Commit-before-ACK, verbatim token echo, OK/FAIL decision: untouched.
- Single `_ingestHistoricalFrame`; live streams never persisted.
- **No** hard-FAIL / re-flood path — that needs its own design + field validation to avoid eternal re-flood, and is explicitly out of scope here.

## Rejected alternative: per-revision counter-gap gate

The record counter is a **global flash-log index sliced per revision**, so gaps are the *normal* state — gating on the counter gap would false-positive constantly. `num_packets` vs received-total is the right signal.

## Tests

Pure unit tests for `burstPacketShortfall`: benign console/event interleaving does **not** false-positive, true loss is quantified, gate-dropped add-back closes the gap, negative/retry case, and `shortfall == 0` ⇔ `burstPacketCountMatches`. `flutter test` green (49 pass), `flutter analyze` clean on changed files.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds log-only `burstPacketShortfall()` helper comparing `num_packets` against all-types received total

- Emits `would-flag` log line and stamps `burst_shortfall` into mismatch ledger at HISTORY_END

- Commit-before-ACK, verbatim token echo, and OK/FAIL decision are all unchanged

- Adds five unit tests covering interleaving, true loss, gate-drop add-back, retries, and equivalence with `burstPacketCountMatches`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HISTORY_END received"] -- "compute" --> B["burstPacketShortfall()\nexpected - (receivedTrafficCount + droppedThisBurst)"]
  B -- "shortfall > 0" --> C["Log 'would-flag' (LOG-ONLY)"]
  B -- "mismatch ledger exists" --> D["Stamp burst_shortfall\ninto ledger entry"]
  A -- "unchanged" --> E["Commit + verbatim ACK\n(OK/FAIL decision untouched)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ble_engine.dart</strong><dd><code>Add log-only burst shortfall diagnostic at HISTORY_END</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/ble/ble_engine.dart

<ul><li>Adds pure <code>burstPacketShortfall()</code> helper (annotated <code>@visibleForTesting</code>) <br>computing <code>expected - (receivedTrafficCount + droppedThisBurst)</code> using <br>the all-types traffic total<br> <li> At HISTORY_END, computes <code>shortfall</code> using <code>d.currentBurstTrafficCount</code> <br>(not the banked R24 subset) and <code>droppedThisBurst</code><br> <li> Stamps <code>burst_shortfall</code> into the existing mismatch ledger <code>metaPatch</code> <br>when a mismatch is recorded<br> <li> Emits a <code>would-flag (LOG-ONLY, commit+ACK unchanged)</code> log line when <br><code>shortfall > 0</code>; commit-before-ACK and ACK decision are untouched</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/232/files#diff-6ab6bfb845fca8d59abbc4cb3d3afc4d41e6ccd63608a71bb397ba7a748c7b85">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ble_engine_test.dart</strong><dd><code>Unit tests for burstPacketShortfall helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/ble_engine_test.dart

<ul><li>Adds <code>group('burst completeness shortfall ...')</code> with five unit tests<br> <li> Tests cover: zero shortfall when all types received, no false-positive <br>from interleaved console/event frames, positive shortfall for true <br>loss, gate-dropped add-back, negative/retry case, and equivalence with <br><code>burstPacketCountMatches</code></ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/232/files#diff-deba21d2a7c95c52b8c80828c051512f6b95b3d21fb8b3ff49b7f20193009cc9">+95/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

