### PR TITLE
test: POSIX-normalise paths in link_priority_structural_test (fixes 4 Windows-only failures)

### DIFF
--- a/test/link_priority_structural_test.dart
+++ b/test/link_priority_structural_test.dart
@@ -59,7 +59,20 @@ List<MapEntry<String, List<String>>> _libSources() {
   final out = <MapEntry<String, List<String>>>[];
   for (final entity in lib.listSync(recursive: true)) {
     if (entity is! File || !entity.path.endsWith('.dart')) continue;
-    out.add(MapEntry(entity.path, codeLines(entity.readAsStringSync())));
+    // POSIX-normalise. Directory.listSync returns NATIVE separators, so on
+    // Windows every key here is `lib\ble\ble_engine.dart` while every assertion
+    // below is written `lib/ble/ble_engine.dart`. Nothing about what this file
+    // pins is platform-specific, so the paths it reasons about should not be
+    // either — normalising once here keeps the assertions readable as the
+    // single spelling they already use.
+    //
+    // Replacing Platform.pathSeparator rather than a literal backslash: on
+    // POSIX that is a no-op, whereas a blanket `\` replacement would corrupt
+    // the (legal, if perverse) filename that contains one.
+    out.add(MapEntry(
+      entity.path.replaceAll(Platform.pathSeparator, '/'),
+      codeLines(entity.readAsStringSync()),
+    ));
   }
   out.sort((a, b) => a.key.compareTo(b.key));
   return out;


### PR DESCRIPTION
## Green on CI, red on Windows

`link_priority_structural_test.dart` collects `lib/**.dart` with
`Directory('lib').listSync()`, which returns **native** path separators. Every assertion
in the file is written POSIX-style, so on Windows 4 of its 5 tests fail:

```
Expected: a string starting with 'lib/ble/ble_engine.dart:'
  Actual: 'lib\ble\ble_engine.dart:781'
```

and the helper

```dart
List<String> _engine() => _libSources()
    .firstWhere((e) => e.key.endsWith('ble/ble_engine.dart'))
    .value;
```

throws a bare **`Bad state: No element`** — which names neither the file nor the cause,
so the first guess is that something in `ble_engine.dart` actually broke.

CI runs on Linux, so `main` is green and this is invisible to the project. It just costs
every Windows contributor the same half hour, on a test that is doing its job correctly.

Same class of thing as #246 — not a bug in the repo's logic, a bug in what the repo
assumes about the machine it is built on.

## Fix

Normalise once where the paths are collected, not at each assertion:

```dart
out.add(MapEntry(
  entity.path.replaceAll(Platform.pathSeparator, '/'),
  codeLines(entity.readAsStringSync()),
));
```

Two deliberate choices:

- **At collection, not at the assertions.** Nothing this file pins is platform-specific,
  so the paths it reasons about shouldn't be either. The five assertions keep reading as
  the single spelling they already use, and a future assertion can't reintroduce the bug
  by forgetting to normalise.
- **`Platform.pathSeparator`, not a literal `\`.** On POSIX this is a no-op, whereas a
  blanket backslash replacement would corrupt a filename that legally contains one.

## Verification

- **Before:** 1 passed, 4 failed (Windows). **After:** 5 passed.
- **The test still bites.** I dropped a second `requestConnectionPriority` call into
  `lib/` and confirmed it still fails — a path fix that quietly stopped the check from
  catching anything would be worse than the bug:

  ```
  exactly one requestConnectionPriority call, and it is in the engine [E]
    a second request site can bypass the policy.
    Found: [lib/_tmp_violation.dart:4, lib/ble/ble_engine.dart:797]
  ```

  As a side benefit the diagnostic now reads in one consistent spelling instead of mixing
  separators.
- No behavioural change on Linux/macOS: `Platform.pathSeparator` is `/` there, so the
  replacement is identity.

`no_debug_only_apis_test.dart` uses the same grep approach but asserts no paths, so it is
unaffected — this is the only file with the issue.
