### PR TITLE
delete the things that were only ever measuring themselves

### DIFF
--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -2965,7 +2965,7 @@ class BleEngine {
     // just stores directly if a frame somehow arrives before setup completed.
     final d = _drain;
     if (d != null) {
-      d.onHistoricalRecord(raw, sample);
+      d.onHistoricalRecord(raw, sample, recType);
     } else {
       unawaited(_storeRecord(sample, raw));
     }
@@ -5015,11 +5015,13 @@ class DrainController {
   int get currentBurstHistoricalPacketCount => burstStats.historicalPacketCount;
   String get currentBurstBreakdown => burstStats.breakdownString;
 
-  void onHistoricalRecord(RawRecord raw, Sample? sample) {
+  /// [revision] is the record version byte the ingest path already read off
+  /// the frame (-1 when the frame was too short to have one).
+  void onHistoricalRecord(RawRecord raw, Sample? sample, int revision) {
     records++;
     recordsThisOffload++;
     _lastProgressAt = DateTime.now();
-    burstStats.onHistoricalData(raw.packetType, raw.counter, sample, raw.hex);
+    burstStats.onHistoricalData(raw.packetType, raw.counter, revision);
     if (_buffering) {
       _raws.add(raw);
       _samples.add(sample);
@@ -5364,19 +5366,16 @@ class BurstStats {
     return parts.join(', ');
   }
 
-  void onHistoricalData(
-    int packetType,
-    int counter,
-    Sample? sample,
-    String rawHex,
-  ) {
+  /// [revision] is the record version byte (inner[1]), which the caller has
+  /// already read off the frame. This used to take the record's hex and parse
+  /// the whole thing back into bytes to reach that one byte — a throwaway
+  /// buffer per record, on every record of every offload.
+  void onHistoricalData(int packetType, int counter, int revision) {
     if (packetType != PacketType.historicalData) return;
-    final inner = hexToBytes(rawHex);
-    if (inner.length < 2) {
+    if (revision < 0) {
       _unknownCount++;
       return;
     }
-    final revision = inner[1];
     if (_ordinaryHistoricalRevisions.contains(revision)) {
       _dataPacketCountsByRevision[revision] =
           (_dataPacketCountsByRevision[revision] ?? 0) + 1;

--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -3172,8 +3172,6 @@ class DerivationEngine {
       sleepHr: sleepSub.hr,
       sleepRrTsMs: sleepSub.rrTsMs,
       sleepRrMs: sleepSub.rrMs,
-      sleepSpo2Red: sleepSub.spo2Red,
-      sleepSpo2Ir: sleepSub.spo2Ir,
       sleepSkinTemp: sleepSub.skinTemp,
       sleepJson: day.sleepJson,
       hypnoStages: day.hypnoStages,
@@ -3200,7 +3198,6 @@ class DerivationEngine {
       _perDayTimeout,
       label: 'day-bundle ${day.date}',
     );
-    _logSpo2Diagnostics(day, input, bundle);
     // Readiness came back absent for TODAY specifically (not a historical
     // backfill day, which would just be noise) — log why. This ran inside
     // Isolate.run so it couldn't call Firebase itself; it just returned the
@@ -3720,86 +3717,6 @@ class DerivationEngine {
     }
     await LocalDb.setFrozenHeadline(next.day, next.value);
     _log('froze headline readiness ${next.value} for ${next.day}');
-  }
-
-  void _logSpo2Diagnostics(
-    PreparedDerivationDay day,
-    DayBundleInput input,
-    Map<String, dynamic> bundle,
-  ) {
-    final red = input.sleepSpo2Red;
-    final ir = input.sleepSpo2Ir;
-    final ts = input.sleepTsSec;
-    if (red.isEmpty || ir.isEmpty || ts.isEmpty) {
-      _log('[spo2-detect] {"day":"${day.date}","status":"no_sleep_spo2"}');
-      return;
-    }
-
-    int minInt(List<int> xs) => xs.reduce((a, b) => a < b ? a : b);
-    int maxInt(List<int> xs) => xs.reduce((a, b) => a > b ? a : b);
-    double meanInt(List<int> xs) =>
-        xs.isEmpty ? 0 : xs.reduce((a, b) => a + b) / xs.length;
-
-    final redNonZero = red.where((v) => v > 0).length;
-    final irNonZero = ir.where((v) => v > 0).length;
-    final spo2 = (bundle['spo2'] as Map?)?.cast<String, dynamic>();
-    final ratios = <double>[
-      for (var i = 0; i < red.length && i < ir.length; i++)
-        if (red[i] > 0 && ir[i] > 0) red[i] / ir[i],
-    ];
-    double? meanDouble(List<double> xs) =>
-        xs.isEmpty ? null : xs.reduce((a, b) => a + b) / xs.length;
-    double? minDouble(List<double> xs) =>
-        xs.isEmpty ? null : xs.reduce((a, b) => a < b ? a : b);
-    double? maxDouble(List<double> xs) =>
-        xs.isEmpty ? null : xs.reduce((a, b) => a > b ? a : b);
-
-    final payload = <String, dynamic>{
-      'day': day.date,
-      'sleep_samples': ts.length,
-      'sleep_span_sec': ts.last - ts.first,
-      'feature_disabled': spo2?['disabled'] == true,
-      'red': <String, dynamic>{
-        'non_zero': redNonZero,
-        'zero': red.length - redNonZero,
-        'coverage': redNonZero / red.length,
-        'unique': red.toSet().length,
-        'min': minInt(red),
-        'max': maxInt(red),
-        'mean': meanInt(red).toStringAsFixed(2),
-        'first10': red.take(10).toList(),
-      },
-      'ir': <String, dynamic>{
-        'non_zero': irNonZero,
-        'zero': ir.length - irNonZero,
-        'coverage': irNonZero / ir.length,
-        'unique': ir.toSet().length,
-        'min': minInt(ir),
-        'max': maxInt(ir),
-        'mean': meanInt(ir).toStringAsFixed(2),
-        'first10': ir.take(10).toList(),
-      },
-      'ratio': <String, dynamic>{
-        'samples': ratios.length,
-        'min': minDouble(ratios)?.toStringAsFixed(6),
-        'max': maxDouble(ratios)?.toStringAsFixed(6),
-        'mean': meanDouble(ratios)?.toStringAsFixed(6),
-        'first10': ratios.take(10).map((v) => v.toStringAsFixed(6)).toList(),
-      },
-      'odi': <String, dynamic>{
-        'disabled': spo2?['disabled'],
-        'note': spo2?['note'],
-        'value': spo2?['odi_per_hour'],
-        'dip_count': spo2?['dip_count'],
-        'signal_coverage': spo2?['signal_coverage'],
-        'trusted_coverage': spo2?['trusted_coverage'],
-        'confidence': spo2?['confidence'],
-        'reject_counts': spo2?['reject_counts'],
-        'severity_counts': spo2?['severity_counts'],
-        'debug': spo2?['debug'],
-      },
-    };
-    _log('[spo2-detect] ${jsonEncode(payload)}');
   }
 
   /// Skip reasons that describe a TRANSIENT failure of this particular pass

--- a/lib/compute/onehz_pipeline.dart
+++ b/lib/compute/onehz_pipeline.dart
@@ -22,6 +22,7 @@
 //         the curve series the UI needs + indexed scalars. Survives jsonEncode.
 
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'package:openstrap_analytics/onehz.dart';
 
@@ -126,8 +127,6 @@ class DayBundleInput {
   final List<int> sleepHr;
   final List<double> sleepRrTsMs;
   final List<double> sleepRrMs;
-  final List<int> sleepSpo2Red;
-  final List<int> sleepSpo2Ir;
   final List<int> sleepSkinTemp;
 
   // ── the SINGLE-SOURCE sleep segmentation (JSON of SleepSegmentation) ──────
@@ -192,8 +191,6 @@ class DayBundleInput {
     required this.sleepHr,
     required this.sleepRrTsMs,
     required this.sleepRrMs,
-    required this.sleepSpo2Red,
-    required this.sleepSpo2Ir,
     required this.sleepSkinTemp,
     required this.sleepJson,
     required this.hypnoStages,
@@ -222,8 +219,6 @@ class DayBundleInput {
     'sleep_hr': sleepHr,
     'sleep_rr_ts_ms': sleepRrTsMs,
     'sleep_rr_ms': sleepRrMs,
-    'sleep_spo2_red': sleepSpo2Red,
-    'sleep_spo2_ir': sleepSpo2Ir,
     'sleep_skin_temp': sleepSkinTemp,
     'sleep_json': sleepJson,
     'hypno_stages': hypnoStages,
@@ -245,9 +240,20 @@ class DayBundleInput {
   static DayBundleInput fromJson(Map<String, dynamic> m) {
     List<int> ints(String k) =>
         ((m[k] as List?) ?? const []).map((e) => (e as num).toInt()).toList();
-    List<double> dbls(String k) => ((m[k] as List?) ?? const [])
-        .map((e) => (e as num).toDouble())
-        .toList();
+    // The substrate packs these as Float64List and the isolate boundary hands
+    // them back typed; unboxing them into a plain List<double> was re-boxing
+    // every element for nothing. Always a COPY, never an alias: on the direct
+    // (synchronous, in-test) path returning the caller's list would share the
+    // substrate's arrays across two repos with nobody enforcing read-only.
+    List<double> dbls(String k) {
+      final v = (m[k] as List?) ?? const [];
+      if (v is List<double>) return Float64List.fromList(v);
+      final out = Float64List(v.length);
+      for (var i = 0; i < v.length; i++) {
+        out[i] = (v[i] as num).toDouble();
+      }
+      return out;
+    }
     List<String> strs(String k) =>
         ((m[k] as List?) ?? const []).map((e) => e.toString()).toList();
     return DayBundleInput(
@@ -260,8 +266,6 @@ class DayBundleInput {
       sleepHr: ints('sleep_hr'),
       sleepRrTsMs: dbls('sleep_rr_ts_ms'),
       sleepRrMs: dbls('sleep_rr_ms'),
-      sleepSpo2Red: ints('sleep_spo2_red'),
-      sleepSpo2Ir: ints('sleep_spo2_ir'),
       sleepSkinTemp: ints('sleep_skin_temp'),
       sleepJson: ((m['sleep_json'] as Map?) ?? const {})
           .cast<String, dynamic>(),
@@ -456,7 +460,6 @@ Map<String, dynamic> deriveDayBundle(Map<String, dynamic> inputJson) {
   const kSpo2Refusal = 'refused: the red and IR channels are one signal — '
       'ir − red is a fixed offset within a session, so any ratio built from '
       'them measures baseline drift, not oxygenation';
-  final odiTs = [for (final t in d.sleepTsSec) t.toDouble()];
   const odi = Metric<RelativeOdiResult>.absent(
     tier: Tier.relative,
     inputs_used: ['spo2_red_raw', 'spo2_ir_raw'],
@@ -1044,7 +1047,7 @@ Map<String, dynamic> deriveDayBundle(Map<String, dynamic> inputJson) {
     'inputs_used': const ['spo2_red_raw', 'spo2_ir_raw'],
     'note': kSpo2Refusal,
     'debug': <String, dynamic>{
-      'sleep_samples': odiTs.length,
+      'sleep_samples': d.sleepTsSec.length,
     },
   };
 

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1434,7 +1434,7 @@ class AppState extends ChangeNotifier {
         _log('[derive] session rescore failed: $e');
       }
       await LocalDb.refreshComputeFreshness();
-      _bumpInsightsRevision();
+      bumpInsights();
       notifyListeners(); // screens re-fetch from the derived store
       // Same signal, for the surfaces that can't listen: home/lock-screen
       // widget, Watch mirror, Siri intents (WidgetService.refresh).
@@ -1852,7 +1852,7 @@ class AppState extends ChangeNotifier {
         },
       );
       await LocalDb.refreshComputeFreshness();
-      _bumpInsightsRevision();
+      bumpInsights();
       dbCounts = await LocalDb.counts();
       return n;
     } catch (e) {
@@ -1921,6 +1921,9 @@ class AppState extends ChangeNotifier {
     try {
       await _derive.run(_profile, force: true);
       await LocalDb.refreshComputeFreshness();
+      // The day_result rows just changed — without this no RevisionReload screen
+      // re-reads, so an override/nap edit only showed up after a restart.
+      bumpInsights();
       dbCounts = await LocalDb.counts();
     } catch (e) {
       _log('[derive] sleep-override re-derive failed: $e');
@@ -1935,40 +1938,6 @@ class AppState extends ChangeNotifier {
   /// rather than a redraw, and the engine force-includes nap-edit days even
   /// when they are finalized.
   Future<void> reanalyzeForNapEdit() => _reanalyzeForOverride();
-
-  Future<int> reanalyzeDays(Set<String> days) async {
-    if (days.isEmpty || reanalyzing) return 0;
-    reanalyzing = true;
-    final ordered = days.toList()..sort();
-    reanalyzeProgress =
-        'Analyzing ${ordered.length} day${ordered.length == 1 ? '' : 's'}…';
-    notifyListeners();
-    try {
-      final n = await _derive.runDays(
-        _profile,
-        days,
-        force: true,
-        onDayDone: (day, index, total) async {
-          reanalyzeProgress = 'Analyzing $index/$total';
-          if (index == total || index == 1 || index % 3 == 0) {
-            dbCounts = await LocalDb.counts();
-            notifyListeners();
-          }
-        },
-      );
-      await LocalDb.refreshComputeFreshness();
-      _bumpInsightsRevision();
-      dbCounts = await LocalDb.counts();
-      return n;
-    } catch (e) {
-      _log('[derive] reanalyze selected failed: $e');
-      return 0;
-    } finally {
-      reanalyzing = false;
-      reanalyzeProgress = '';
-      notifyListeners();
-    }
-  }
 
   Future<List<Map<String, dynamic>>> dataHistoryDays() =>
       LocalDb.dataHistoryDays();
@@ -2387,8 +2356,6 @@ class AppState extends ChangeNotifier {
       _log('[db] schemaHealth check skipped: $e');
     }
   }
-
-  void _bumpInsightsRevision() => bumpInsights();
 
   /// Say that the DURABLE data changed, so every screen reading it re-reads.
   ///
@@ -5180,7 +5147,7 @@ class AppState extends ChangeNotifier {
       // this the Workout tab, which loads once and caches, showed no trace of
       // the workout you had just finished in History, "This week", "Tracked"
       // or the weekly load until the app was restarted.
-      _bumpInsightsRevision();
+      bumpInsights();
     } catch (e) {
       _log('[workout] could not save session $id: $e — keeping it live');
       notifyListeners();

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -195,7 +195,6 @@ class AppState extends ChangeNotifier {
   // "last data: …" indicator must show. Seeded from the DB at init, advanced as
   // records (drained + live) flow in.
   int? _lastRecTs;
-  Map<String, int> dbCounts = {'raw': 0, 'pending': 0};
   final List<String> logLines = [];
   bool busy = false;
 
@@ -1383,7 +1382,6 @@ class AppState extends ChangeNotifier {
         heavy: heavy,
         onDayDone: (day, index, total) async {
           if (index == total || index == 1 || index % 3 == 0) {
-            dbCounts = await LocalDb.counts();
             notifyListeners();
           }
         },
@@ -1819,14 +1817,12 @@ class AppState extends ChangeNotifier {
         onDayDone: (day, index, total) async {
           reanalyzeProgress = 'Analyzing $index/$total';
           if (index == total || index == 1 || index % 3 == 0) {
-            dbCounts = await LocalDb.counts();
             notifyListeners();
           }
         },
       );
       await LocalDb.refreshComputeFreshness();
       bumpInsights();
-      dbCounts = await LocalDb.counts();
       return n;
     } catch (e) {
       _log('[derive] reanalyze failed: $e');
@@ -1897,7 +1893,6 @@ class AppState extends ChangeNotifier {
       // The day_result rows just changed — without this no RevisionReload screen
       // re-reads, so an override/nap edit only showed up after a restart.
       bumpInsights();
-      dbCounts = await LocalDb.counts();
     } catch (e) {
       _log('[derive] sleep-override re-derive failed: $e');
     } finally {
@@ -1923,7 +1918,6 @@ class AppState extends ChangeNotifier {
   Future<int> deleteDays(Set<String> dayIds) async {
     final deleted = await LocalDb.deleteDays(dayIds);
     await LocalDb.refreshComputeFreshness();
-    dbCounts = await LocalDb.counts();
     lastSynced = await LocalDb.latestSample();
     notifyListeners();
     return deleted;
@@ -1931,7 +1925,7 @@ class AppState extends ChangeNotifier {
 
   /// Debounced "new data stored" callback from the engine (continuous listening has
   /// no discrete sync end). The engine already coalesced the burst; we run a single
-  /// LIGHT derive over the affected day(s) and refresh DB counts for the UI.
+  /// LIGHT derive over the affected day(s).
   ///
   /// This is also THE reliable place to refresh `_lastRecTs` (the "last data"
   /// freshness banner reads it). `_runSyncBurst`'s own before/after frontier
@@ -1940,13 +1934,12 @@ class AppState extends ChangeNotifier {
   /// checkpoint-based refresh can miss a burst entirely. This callback fires
   /// on EVERY successful persist path (foreground burst, background/headless
   /// drain, live-triggered store) after the write is durable, so it can't
-  /// race it — same guarantee dbCounts already relies on above.
+  /// race it.
   void _onDataStored() {
     // Synchronously, before the async read below: this is the moment records
     // became durable, and it is the only path that sees every commit.
     _markSyncActivity();
     unawaited(() async {
-      dbCounts = await LocalDb.counts();
       final recTsHw = await LocalDb.getCursorInt('rec_ts_hw');
       if (recTsHw != null && recTsHw > (_lastRecTs ?? 0)) {
         _lastRecTs = recTsHw;
@@ -2039,7 +2032,6 @@ class AppState extends ChangeNotifier {
     // policies already trust).
     _lastRecTs =
         await LocalDb.getCursorInt('rec_ts_hw') ?? lastSynced?.tsEpoch;
-    dbCounts = await LocalDb.counts();
     await LocalDb.refreshComputeFreshness();
     _savedAlarm = (await SharedPreferences.getInstance()).getInt('alarm_epoch');
     // Band-gesture mapping: load the saved action + query native capabilities so the
@@ -3320,7 +3312,6 @@ class AppState extends ChangeNotifier {
         '(${report.complete ? "complete" : "stopped early"}).',
       );
       if (report.records > 0) {
-        dbCounts = await LocalDb.counts();
         _deriveScheduler.markStoredData();
       }
     } catch (e) {
@@ -3883,7 +3874,7 @@ class AppState extends ChangeNotifier {
       // The foreground guard stops a wake from fighting this live session for the band.
       IosBleRestore.foregroundActive = true;
       IosBleRestore.arm(band.remoteId);
-      _log('===== SESSION START ===== raw=${dbCounts['raw']}');
+      _log('===== SESSION START =====');
       await _ensureForegroundLease();
       // connect() now subscribes → SET_CLOCK → INIT, so the historical offload is
       // ALREADY streaming the moment this returns.
@@ -3924,14 +3915,12 @@ class AppState extends ChangeNotifier {
       await _recoverOrphanedLiveSession();
       _resetLivePedometer(); // fresh live step count for this connected session
       await engine.enableLiveStreams();
-      dbCounts = await LocalDb.counts();
       unawaited(
         _kickSyncBurst(kickFirst: false).then((report) async {
           _log(
             'Backlog drained: ${report.records} records in ${report.batches} '
             'batches (${report.complete ? "complete" : "stopped early"}).',
           );
-          dbCounts = await LocalDb.counts();
           // Re-evaluate the high-frequency wake window now the backlog landed.
           await _refreshHighFreqWakeWindow();
           // The whole backlog landed → heavy foreground finalize (full sleep
@@ -4059,7 +4048,6 @@ class AppState extends ChangeNotifier {
           _log('Reconnected — live on; draining backlog in background.');
           unawaited(
             _kickSyncBurst(kickFirst: false).then((report) async {
-              dbCounts = await LocalDb.counts();
               _log('Reconnect backlog drained: ${report.records} records.');
               // Re-evaluate the high-frequency wake window now the backlog
               // landed.
@@ -4122,7 +4110,6 @@ class AppState extends ChangeNotifier {
         await _syncBurst;
       }
       await _kickSyncBurst(kickFirst: true);
-      dbCounts = await LocalDb.counts();
       notifyListeners();
       // A just-finished workout window landed from flash → derive it (light).
       _deriveScheduler.markStoredData();
@@ -4168,7 +4155,6 @@ class AppState extends ChangeNotifier {
       if (!await engine.requestForegroundSync()) return;
       final report = await _kickSyncBurst(kickFirst: false);
       if (report.records > 0) {
-        dbCounts = await LocalDb.counts();
         _deriveScheduler.markStoredData();
         notifyListeners();
       }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1919,6 +1919,12 @@ class AppState extends ChangeNotifier {
     final deleted = await LocalDb.deleteDays(dayIds);
     await LocalDb.refreshComputeFreshness();
     lastSynced = await LocalDb.latestSample();
+    // Deleting days is a durable write like any other, so the screens holding a
+    // cached read have to be told. `notifyListeners()` alone leaves a
+    // RevisionReload screen showing days that are gone until some unrelated
+    // bump or a restart — and this is the one write where the stale copy is of
+    // data the user explicitly asked to destroy.
+    if (deleted > 0) bumpInsights();
     notifyListeners();
     return deleted;
   }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -418,38 +418,11 @@ class AppState extends ChangeNotifier {
 
   Future<int> importEdgeBackup(String path) async {
     importRollupError = null;
-    // The app's OWN automatic backup is gzipped (`.db.gz`, see
-    // auto_backup.dart's kBackupExtension) and `importFromDbFile` opens a
-    // SQLite file, so restoring one on a new phone failed — the most important
-    // import path there is, and the only one where the user has already lost
-    // the original. Detected by magic bytes rather than by extension so a
-    // renamed file still restores.
-    String src = path;
-    String? inflated;
-    try {
-      final head = await File(path).openRead(0, 2).first;
-      if (head.length >= 2 && head[0] == 0x1f && head[1] == 0x8b) {
-        inflated = '$path.inflated.db';
-        final sink = File(inflated).openWrite();
-        await File(path).openRead().transform(gzip.decoder).pipe(sink);
-        src = inflated;
-      }
-    } catch (_) {
-      // Unreadable header — hand the original to the importer and let its own
-      // error be the one the user sees.
-      src = path;
-    }
-    final counts = await () async {
-      try {
-        return await LocalDb.importFromDbFile(src);
-      } finally {
-        if (inflated != null) {
-          try {
-            await File(inflated).delete();
-          } catch (_) {}
-        }
-      }
-    }();
+    // Gzipped auto-backups (`.db.gz`) are inflated INSIDE importFromDbFile —
+    // do not add it back here. Its inflate checks the gzip trailer, so a
+    // truncated backup fails loudly; `gzip.decoder` returns partial output
+    // without raising and would restore short while reporting success.
+    final counts = await LocalDb.importFromDbFile(path);
     // Imported rows include derived day_result/metric_series → refresh rollups.
     try {
       await _derive.finalizeImport(_profile);

--- a/lib/ui2/activity/live.dart
+++ b/lib/ui2/activity/live.dart
@@ -1808,8 +1808,14 @@ class _LiveFlowState extends State<LiveFlow>
     // No `setState`: this body follows the shell's clock, which already
     // rebuilds it once a second, so the wrapper only bought a second rebuild
     // of the same subtree at the same rate.
+    //
+    // WHICH IS WHY THE PAUSE CHECK IS HERE. A paused session stops advancing
+    // `elapsedSec`, so the shell stops repainting — and a hold that kept
+    // counting behind a frozen screen would sit there wrong and then jump on
+    // resume. It is a pacer for a pose being held; a paused session is not
+    // holding anything.
     _hold = Timer.periodic(Motion.tick, (_) {
-      if (!mounted) return;
+      if (!mounted || LiveDraft.current?.pausedAt != null) return;
       hold = hold > 0 ? hold - 1 : 30;
     });
   }

--- a/lib/ui2/activity/live.dart
+++ b/lib/ui2/activity/live.dart
@@ -1076,7 +1076,17 @@ class _LiveStrengthState extends State<LiveStrength> {
   final logged = <LoggedSet>[];
 
   static const restTarget = 90;
-  int restLeft = 0;
+
+  /// A listenable rather than a field behind `setState`, for the same reason
+  /// [LiveShellState.clock] is one: the countdown ticks once a second for a
+  /// minute and a half between sets, and putting it behind `setState` rebuilt
+  /// this state, and with it the whole [LiveShell] — header, transport,
+  /// footer, body — when the only thing that moved was the ring.
+  ///
+  /// `setState` still runs at the ZERO CROSSING, where the screen genuinely
+  /// changes shape: the footer flips back to Log set and the body back to the
+  /// entry pad.
+  final restLeft = ValueNotifier<int>(0);
   Timer? _rest;
 
   @override
@@ -1089,6 +1099,7 @@ class _LiveStrengthState extends State<LiveStrength> {
   @override
   void dispose() {
     _rest?.cancel();
+    restLeft.dispose();
     super.dispose();
   }
 
@@ -1164,15 +1175,17 @@ class _LiveStrengthState extends State<LiveStrength> {
           rpe: rpe,
           restSec: prior == null ? null : now.difference(prior).inSeconds,
           at: now));
-      restLeft = restTarget;
     });
+    restLeft.value = restTarget;
     _persist();
     _rest?.cancel();
     _rest = Timer.periodic(Motion.tick, (t) {
       if (!mounted) return;
-      setState(() => restLeft--);
-      if (restLeft <= 0) {
+      restLeft.value--;
+      if (restLeft.value <= 0) {
         t.cancel();
+        // The one tick the shell has to see — see [restLeft].
+        setState(() {});
         HapticFeedback.mediumImpact();
         // A buzz is not a message. The rest-over moment was reachable only by
         // feeling the watch, or by watching a number nobody was told to watch.
@@ -1184,10 +1197,8 @@ class _LiveStrengthState extends State<LiveStrength> {
   void goExercise(int i) {
     if (i < 0 || i >= plan.length) return;
     _rest?.cancel();
-    setState(() {
-      index = i;
-      restLeft = 0;
-    });
+    restLeft.value = 0;
+    setState(() => index = i);
     _seedFromHistory();
   }
 
@@ -1250,13 +1261,15 @@ class _LiveStrengthState extends State<LiveStrength> {
           widget.feed?.call() ?? LiveFeed.none, widget.weightKg, elapsed,
           widget.private,
           strength: log),
-      footer: (ctx) => restLeft > 0
+      footer: (ctx) => restLeft.value > 0
           ? Row(children: [
               Expanded(
                 child: BigButton('+30s',
                     color: C.teal,
                     soft: true,
-                    onTap: () => setState(() => restLeft += 30)),
+                    // No `setState`: nothing on the shell changes shape while
+                    // the countdown stays above zero, and the ring listens.
+                    onTap: () => restLeft.value += 30),
               ),
               const SizedBox(width: S.x3),
               Expanded(
@@ -1265,7 +1278,8 @@ class _LiveStrengthState extends State<LiveStrength> {
                     color: C.teal,
                     onTap: () {
                       _rest?.cancel();
-                      setState(() => restLeft = 0);
+                      restLeft.value = 0;
+                      setState(() {});
                     }),
               ),
             ])
@@ -1355,7 +1369,13 @@ class _LiveStrengthState extends State<LiveStrength> {
               fontFeatures: const [FontFeature.tabularFigures()])),
       const SizedBox(height: S.x6),
 
-      if (restLeft > 0) _rest_(p) else ..._entry(p),
+      if (restLeft.value > 0)
+        ValueListenableBuilder<int>(
+          valueListenable: restLeft,
+          builder: (_, _, _) => _rest_(p),
+        )
+      else
+        ..._entry(p),
 
       const SizedBox(height: S.x6),
       if (setsHere.isNotEmpty) ...[
@@ -1483,9 +1503,10 @@ class _LiveStrengthState extends State<LiveStrength> {
           child: Stack(alignment: Alignment.center, children: [
             CustomPaint(
                 size: const Size(170, 170),
-                painter: Ring(restLeft / restTarget, p.on(C.teal), p.track)),
+                painter:
+                    Ring(restLeft.value / restTarget, p.on(C.teal), p.track)),
             Column(mainAxisSize: MainAxisSize.min, children: [
-              Text(clock(restLeft), style: F.n34.copyWith(color: p.ink)),
+              Text(clock(restLeft.value), style: F.n34.copyWith(color: p.ink)),
               if (logged.isNotEmpty)
                 Text(
                     logged.last.loadKg == null
@@ -1784,9 +1805,12 @@ class _LiveFlowState extends State<LiveFlow>
     super.initState();
     pose = (LiveDraft.current?.data['pose'] as num?)?.toInt() ?? 0;
     reached = (LiveDraft.current?.data['pose_max'] as num?)?.toInt() ?? pose;
+    // No `setState`: this body follows the shell's clock, which already
+    // rebuilds it once a second, so the wrapper only bought a second rebuild
+    // of the same subtree at the same rate.
     _hold = Timer.periodic(Motion.tick, (_) {
       if (!mounted) return;
-      setState(() => hold = hold > 0 ? hold - 1 : 30);
+      hold = hold > 0 ? hold - 1 : 30;
     });
   }
 

--- a/lib/ui2/profile/band_notifications.dart
+++ b/lib/ui2/profile/band_notifications.dart
@@ -228,6 +228,11 @@ class _AppRow extends StatelessWidget {
   Widget build(BuildContext c) {
     final p = P.of(c);
     final icon = app.icon;
+    // Decoded at the size it is drawn at, same reasoning as _IconChoice in
+    // settings.dart: these are launcher masters (Android ships up to 512 px)
+    // decoded in full to paint a 32 pt row. WIDTH ONLY — a third-party icon
+    // need not be square, and constraining both dimensions would distort it.
+    final px = (32 * MediaQuery.devicePixelRatioOf(c)).round();
     return Pressable(
       onTap: () => onChanged?.call(app.package, !app.on),
       semanticLabel:
@@ -239,7 +244,10 @@ class _AppRow extends StatelessWidget {
             borderRadius: R.rSm,
             child: icon != null && icon.isNotEmpty
                 ? Image.memory(icon,
-                    width: 32, height: 32, gaplessPlayback: true)
+                    width: 32,
+                    height: 32,
+                    cacheWidth: px,
+                    gaplessPlayback: true)
                 : Container(
                     width: 32,
                     height: 32,

--- a/test/ble_safe_trim_test.dart
+++ b/test/ble_safe_trim_test.dart
@@ -16,8 +16,9 @@ import 'package:openstrap_edge/data/models.dart';
 import 'package:openstrap_edge/sync/sync_policy.dart';
 
 /// A well-formed inner-frame hex: [0]=0x2f historical, [1]=0x18 (revision 24),
-/// then the u32 record counter. BurstStats re-parses this, so it must be real
-/// hex, not a label.
+/// then the u32 record counter. Nothing re-parses it any more — BurstStats is
+/// handed the revision the ingest path already read — but the commit path
+/// stores it, so it stays real hex rather than a label.
 String _hex(int counter) =>
     '2f18${counter.toRadixString(16).padLeft(8, '0')}';
 
@@ -61,7 +62,7 @@ void main() {
         (raws, samples, token, {archives, deviceFamily}) async =>
             throw StateError('OOM in SqlCommand.getSqlArguments'),
       );
-      d.onHistoricalRecord(_raw(1), _sample(1));
+      d.onHistoricalRecord(_raw(1), _sample(1), 24);
 
       final durable = await d.commit(_tokenA);
 
@@ -76,8 +77,8 @@ void main() {
       final d = _drainWith(
         (raws, samples, token, {archives, deviceFamily}) async => throw StateError('rollback'),
       );
-      d.onHistoricalRecord(_raw(1), _sample(1));
-      d.onHistoricalRecord(_raw(2), _sample(2));
+      d.onHistoricalRecord(_raw(1), _sample(1), 24);
+      d.onHistoricalRecord(_raw(2), _sample(2), 24);
       d.onUndecodableRecord(_archive(3));
 
       expect(d.bufferedRecords, 2);
@@ -98,8 +99,8 @@ void main() {
         seenArchives.addAll((archives ?? const []).map((a) => a.hex));
       });
       // (rebuild the same state on a controller whose commit succeeds)
-      d2.onHistoricalRecord(_raw(1), _sample(1));
-      d2.onHistoricalRecord(_raw(2), _sample(2));
+      d2.onHistoricalRecord(_raw(1), _sample(1), 24);
+      d2.onHistoricalRecord(_raw(2), _sample(2), 24);
       d2.onUndecodableRecord(_archive(3));
       expect(await d2.commit(_tokenA), isTrue);
       expect(seenRaws, [_hex(1), _hex(2)]);
@@ -127,10 +128,10 @@ void main() {
           log: (_) {},
         );
 
-        d.onHistoricalRecord(_raw(1), _sample(1));
+        d.onHistoricalRecord(_raw(1), _sample(1), 24);
         final inFlight = d.commit(_tokenA);
         // A record arrives while the commit is parked mid-await.
-        d.onHistoricalRecord(_raw(2), _sample(2));
+        d.onHistoricalRecord(_raw(2), _sample(2), 24);
         gate.complete();
         expect(await inFlight, isFalse);
 
@@ -155,12 +156,12 @@ void main() {
 
       // Empty token-only commits do not count as trim advance (would feed
       // auto-continue while the durable frontier stayed frozen).
-      d.onHistoricalRecord(_raw(0), _sample(0));
+      d.onHistoricalRecord(_raw(0), _sample(0), 24);
       expect(await d.commit(_tokenA), isTrue);
       expect(d.lastTrimAdvanced, isTrue);
 
       fail = true;
-      d.onHistoricalRecord(_raw(1), _sample(1));
+      d.onHistoricalRecord(_raw(1), _sample(1), 24);
       expect(await d.commit(_tokenB), isFalse);
       // The cursor did NOT move to tokenB, so nothing may claim it did.
       expect(d.lastTrimAdvanced, isTrue, reason: 'rolled back to the tokenA state');
@@ -189,7 +190,7 @@ void main() {
 
     test('a successful commit clears the buffer and reports durable', () async {
       final d = _drainWith((raws, samples, token, {archives, deviceFamily}) async {});
-      d.onHistoricalRecord(_raw(1), _sample(1));
+      d.onHistoricalRecord(_raw(1), _sample(1), 24);
 
       expect(await d.commit(_tokenA), isTrue);
       expect(d.bufferedRecords, 0);
@@ -380,7 +381,7 @@ void main() {
         onArchive: null,
         log: (_) {},
       );
-      d.onHistoricalRecord(_raw(1), _sample(1));
+      d.onHistoricalRecord(_raw(1), _sample(1), 24);
       expect(d.bufferedRecords, 0);
       expect(d.supportsSafeTrim, isFalse);
       expect(wrote, 1);
@@ -390,7 +391,7 @@ void main() {
   group('P0 — a discarded burst poisons its HISTORY_END token', () {
     test('discardOpenChunk marks the open burst un-ACKable', () async {
       final d = _drainWith((raws, samples, token, {archives, deviceFamily}) async {});
-      d.onHistoricalRecord(_raw(1), _sample(1));
+      d.onHistoricalRecord(_raw(1), _sample(1), 24);
       expect(d.burstDiscarded, isFalse);
 
       d.discardOpenChunk();
@@ -424,7 +425,7 @@ void main() {
       // flight, landed on a clean guard, and got ACKed verbatim: the band
       // trimmed exactly the records the watchdog threw away.
       final d = _drainWith((raws, samples, token, {archives, deviceFamily}) async {});
-      d.onHistoricalRecord(_raw(1), _sample(1));
+      d.onHistoricalRecord(_raw(1), _sample(1), 24);
       d.discardOpenChunk();
 
       d.rearm();

--- a/test/daily_energy_consistency_test.dart
+++ b/test/daily_energy_consistency_test.dart
@@ -354,8 +354,6 @@ void main() {
           sleepHr: const [],
           sleepRrTsMs: const [],
           sleepRrMs: const [],
-          sleepSpo2Red: const [],
-          sleepSpo2Ir: const [],
           sleepSkinTemp: const [],
           sleepJson: const {},
           hypnoStages: const [],

--- a/test/derivation_pipeline_test.dart
+++ b/test/derivation_pipeline_test.dart
@@ -108,7 +108,7 @@ void main() {
     final n0 = sub.length;
     final tiles = (1800 / n0).ceil() + 1;
     final dayTs = <int>[], dayHr = <int>[];
-    final sRed = <int>[], sIr = <int>[], sTemp = <int>[];
+    final sTemp = <int>[];
     final rrTs = <double>[], rrMs = <double>[];
     final base = sub.tsSec.first;
     for (var t = 0; t < tiles; t++) {
@@ -116,8 +116,6 @@ void main() {
       for (var i = 0; i < n0; i++) {
         dayTs.add(base + shift + i);
         dayHr.add(sub.hr[i]);
-        sRed.add(sub.spo2Red[i]);
-        sIr.add(sub.spo2Ir[i]);
         sTemp.add(sub.skinTemp[i]);
       }
       // Re-anchor each RR beat into this tile's second (preserves order/spacing).
@@ -140,8 +138,6 @@ void main() {
       sleepHr: dayHr,
       sleepRrTsMs: rrTs,
       sleepRrMs: rrMs,
-      sleepSpo2Red: sRed,
-      sleepSpo2Ir: sIr,
       sleepSkinTemp: sTemp,
       sleepJson: day.sleep.toJson(),
       hypnoStages: hypno,
@@ -249,8 +245,6 @@ void main() {
         sleepHr: hr,
         sleepRrTsMs: const [],
         sleepRrMs: const [],
-        sleepSpo2Red: List<int>.filled(n, 0),
-        sleepSpo2Ir: List<int>.filled(n, 0),
         // One temp sample every `tempEvery` seconds; 0 is the absent sentinel.
         sleepSkinTemp: <int>[
           for (var i = 0; i < n; i++) i % tempEvery == 0 ? 3000 : 0,
@@ -428,8 +422,6 @@ Map<String, dynamic> _nightBundle({required int hours}) {
     sleepHr: hr,
     sleepRrTsMs: rrTs,
     sleepRrMs: rrMs,
-    sleepSpo2Red: List<int>.filled(tsSec.length, 0),
-    sleepSpo2Ir: List<int>.filled(tsSec.length, 0),
     sleepSkinTemp: List<int>.filled(tsSec.length, 0),
     sleepJson: const {},
     hypnoStages: const [],

--- a/test/hr_ceiling_zones_test.dart
+++ b/test/hr_ceiling_zones_test.dart
@@ -168,8 +168,6 @@ void main() {
           sleepHr: const [],
           sleepRrTsMs: const [],
           sleepRrMs: const [],
-          sleepSpo2Red: const [],
-          sleepSpo2Ir: const [],
           sleepSkinTemp: const [],
           sleepJson: const {},
           hypnoStages: const [],

--- a/test/resting_hr_nocturnal_only_test.dart
+++ b/test/resting_hr_nocturnal_only_test.dart
@@ -39,8 +39,6 @@ Map<String, dynamic> _bundle({required bool scoredSleep}) {
       sleepHr: scoredSleep ? hr : const [],
       sleepRrTsMs: const [],
       sleepRrMs: const [],
-      sleepSpo2Red: scoredSleep ? zeros : const [],
-      sleepSpo2Ir: scoredSleep ? zeros : const [],
       sleepSkinTemp: scoredSleep ? zeros : const [],
       sleepJson: scoredSleep
           ? <String, dynamic>{'tst_sec': wornSec, 'efficiency_pct': 90.0}

--- a/test/strain_resting_hr_source_test.dart
+++ b/test/strain_resting_hr_source_test.dart
@@ -150,8 +150,6 @@ void main() {
       sleepHr: hr,
       sleepRrTsMs: rrTsMs,
       sleepRrMs: rrMs,
-      sleepSpo2Red: List<int>.filled(1800, 0),
-      sleepSpo2Ir: List<int>.filled(1800, 0),
       sleepSkinTemp: List<int>.filled(1800, 0),
       sleepJson: {
         'tst_sec': 1800,

--- a/test/ui2_activity_test.dart
+++ b/test/ui2_activity_test.dart
@@ -1373,6 +1373,36 @@ void main() {
       expect(find.text('141'), findsOneWidget);
     });
 
+    testWidgets('the rest countdown ticks without rebuilding the shell',
+        (tester) async {
+      tester.view.physicalSize = const Size(390 * 3, 2400 * 3);
+      tester.view.devicePixelRatio = 3;
+      addTearDown(tester.view.reset);
+      addTearDown(LiveDraft.clear);
+
+      await tester.pumpWidget(_frame(
+          LiveStrength(activityByName('weight_training')!),
+          Brightness.light,
+          1.0));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Log set'));
+      await tester.pump();
+      expect(find.text('01:30'), findsOneWidget);
+
+      // The countdown used to be a field behind setState, so every one of the
+      // ninety ticks rebuilt this state — and with it a whole new LiveShell,
+      // header and transport and all. The widget instance is the tell: only
+      // _LiveStrengthState.build makes a new one.
+      final shell = tester.widget<LiveShell>(find.byType(LiveShell));
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text('01:29'), findsOneWidget,
+          reason: 'the ring still counts down');
+      expect(identical(tester.widget<LiveShell>(find.byType(LiveShell)), shell),
+          isTrue,
+          reason: 'the shell must not be rebuilt for a number inside the body');
+    });
+
     testWidgets('a session that failed to save says so and can retry',
         (tester) async {
       tester.view.physicalSize = const Size(390 * 3, 2200 * 3);

--- a/tool/derive_probe.dart
+++ b/tool/derive_probe.dart
@@ -54,8 +54,6 @@ void main(List<String> args) {
       sleepHr: sleepSub.hr,
       sleepRrTsMs: sleepSub.rrTsMs,
       sleepRrMs: sleepSub.rrMs,
-      sleepSpo2Red: sleepSub.spo2Red,
-      sleepSpo2Ir: sleepSub.spo2Ir,
       sleepSkinTemp: sleepSub.skinTemp,
       sleepJson: day.sleep.toJson(),
       hypnoStages: hypno,


### PR DESCRIPTION
### **User description**
Stacked on #261. **Nothing here changes a derived number — there is no `kAlgoVersion` bump, and if one becomes necessary the change is wrong.** This is "faster and shorter", nothing else. 


## deletions

**~90 lines of SpO2 diagnostics ran on the calling isolate, per derived day, in release.** SpO2 is refused *permanently*, not parked — the pipeline says so in its own words and `odi` is a `const Metric.absent`, so most of what the logger printed was a compile-time constant. It did ~14 full passes over ~28,800-sample arrays plus two `HashSet`s and a growable `List<double>`, for every day including backfill. Deleting it orphaned `DayBundleInput.sleepSpo2Red`/`sleepSpo2Ir`, which `deriveDayBundle` never read — they were serialized and copied across the isolate boundary purely to be ignored. 8 call sites fixed.
The refusal metric, its `tier`, `inputs_used` and note are untouched. This deletes a logger, never an abstention path.

**`dbCounts` cost 13 full-table `COUNT(*)` pairs and fed one log line.** With the writes gone the field would have been written never and read once, printing a permanent `raw=0` — a field that exists only to log a lie — so it went too. `LocalDb.counts()` stays; two tests use it. Every enclosing block survived: five of those sites sit inside `if (…) { notifyListeners(); }`-shaped blocks, and deleting the block rather than the statement would have re-introduced the staleness bug #261 just fixed.

**`importEdgeBackup` hand-inflated gzip that `importFromDbFile` already inflates.** The duplicate was also the unsafe one: Dart's `gzip.decoder` returns partial output on a truncated `.db.gz` **without raising**, so a half-synced backup restored short and reported success — on the one path where the original is already gone. The downstream inflate reads the CRC32/ISIZE trailer off the file.

## the one that is a bug wearing a perf costume

**`_reanalyzeForOverride` never bumped `insightsRevision`.** Every sleep override, nap edit and phone-steps toggle rewrites `day_result` and no `RevisionReload` screen noticed. One line.

## hot paths

**`onHistoricalData` re-parsed its own hex back into bytes to read one byte the caller already had.** It takes `revision` now; the unused `Sample?` went with it. Semantics are exact — the caller already computes `recType = inner.length > 1 ? inner[1] : -1`, so the new `revision < 0` guard *is* the old `inner.length < 2` guard. ~6 MB of garbage per gen4 offload (not the 18 MB originally claimed; v20/v21/v26 never reach this path).

**The rest countdown rebuilt the entire workout shell once a second**, in the file that introduced `LiveTick` to stop exactly this — ~1,200 full-subtree rebuilds in a strength session. `restLeft` is a `ValueNotifier`; only the body branch is wrapped, the footer is untouched, and `setState` stays at the zero crossing where the shape genuinely changes.
The test asserts the `LiveShell` **instance is identical** across a tick, not just that the text moved — a text-only assertion passes on the broken version too. Verified it fails pre-change.

**App icons decoded at source resolution.** `cacheWidth` only; the source is a third-party launcher icon and need not be square.

**`DayBundleInput.fromJson` unboxed every array the substrate deliberately packed.** `dbls` returns a `Float64List` — copied, never aliased, so the synchronous test path cannot hand two repos a shared mutable array. The `ints`/`strs` fast paths were skipped on purpose: Smis and Strings box nothing per element, and a `strs` fast path would hand out a `const []` where a growable list goes out today.
Worth a reviewer's eye: `Float64List` is fixed-length where `.toList()` was growable. Nothing mutates these and all six `deriveDayBundle` test callers exercise the typed lists through `toJson`/`fromJson`, so if something downstream ever starts growing a caller-owned list it throws rather than corrupts — loud, not silent.

## housekeeping

One commit (`drop the spo2 diagnostic logger…`) also contains the `Float64List` change; the message only describes the first. The no-amend rule caught it after the fact. Diff is correct, message is incomplete.

`DerivationEngine.runDays` now has zero production callers — deleting `reanalyzeDays` took the last one, and only `derive_result_protection_test.dart` calls it. Left alone deliberately; that is a decision, not a reflex delete.

2795 tests pass, 422 golden skips, analyze clean.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Remove `sleepSpo2Red`/`sleepSpo2Ir` fields and ~90-line SpO2 diagnostic logger that ran per-day on the calling isolate, burning CPU on permanently-refused data

- Eliminate `dbCounts` field and all 13 `LocalDb.counts()` calls; fix sleep-override/nap re-derive not refreshing screens by calling `bumpInsights()` instead

- Stop double-inflating gzip backups in `importEdgeBackup`; `importFromDbFile` already handles it with trailer validation

- Convert strength-workout rest countdown from `setState` field to `ValueNotifier`, preventing full `LiveShell` rebuilds on every tick; fix yoga hold timer similarly


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BLE ingest\n(ble_engine.dart)"] -- "passes revision int\n(not raw hex)" --> B["BurstStats.onHistoricalData"]
  C["importEdgeBackup\n(app_state.dart)"] -- "removed hand-rolled\ngzip inflate" --> D["LocalDb.importFromDbFile\n(handles gzip internally)"]
  E["_reanalyzeForOverride\n_reanalyzeDays\nstopWorkout"] -- "replaced _bumpInsightsRevision\nalias" --> F["bumpInsights()"]
  G["DayBundleInput"] -- "removed sleepSpo2Red\nsleepSpo2Ir fields" --> H["deriveDayBundle\n(isolate boundary)"]
  I["_LiveStrengthState\nrestLeft field + setState"] -- "converted to" --> J["ValueNotifier<int>\n+ ValueListenableBuilder"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ble_engine.dart</strong><dd><code>Pass revision int to BurstStats, drop hex re-parse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/263/files#diff-6ab6bfb845fca8d59abbc4cb3d3afc4d41e6ccd63608a71bb397ba7a748c7b85">+11/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>onehz_pipeline.dart</strong><dd><code>Drop sleepSpo2Red/Ir fields; optimize dbls() with Float64List</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/263/files#diff-fbeca04c08901aebd9a6c53f79a6d0e93a3d0ca685559234fb893e4e3cc43bfa">+16/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>band_notifications.dart</strong><dd><code>Decode notification app icons at display size only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/263/files#diff-496735a911ca4c4a804986d459be889dc838ca8aa5dcddf93e31fa1969c0c3fb">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>derivation_engine.dart</strong><dd><code>Remove SpO2 diagnostic logger and spo2Red/spo2Ir inputs</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/263/files#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6">+0/-83</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_state.dart</strong><dd><code>Remove dbCounts, fix override re-derive screen refresh, drop </code><br><code>double-gzip</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/263/files#diff-d56ba858e512e18dc3962da198adee46d354aca39ff7c1b4a11d5f19b9afc1ae">+14/-88</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>live.dart</strong><dd><code>Rest countdown to ValueNotifier; fix yoga hold timer rebuild</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/263/files#diff-2f2e622d36da30da8d60d3a015edfb466d43d3d2fe570a85d819169e2e7aa4ec">+39/-15</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>ble_safe_trim_test.dart</strong><dd><code>Update onHistoricalRecord calls to pass revision int</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/263/files#diff-f113b81c5613d2794d7f512fe05b78ff80c348c2db330bc46bacf5a2b63825c0">+16/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>daily_energy_consistency_test.dart</strong><dd><code>Remove sleepSpo2Red/Ir from DayBundleInput test fixture</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/263/files#diff-f317634af34f6477f6c8ec9756a31f9b38db2ea7e89a2308aa0c3d7246b9e8ce">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>derivation_pipeline_test.dart</strong><dd><code>Remove spo2 arrays from pipeline test fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/263/files#diff-a007f7baf912be909a6e457aebe963e0d8d37617c39b3e63f0edb2c159d05c3b">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hr_ceiling_zones_test.dart</strong><dd><code>Remove sleepSpo2Red/Ir from HR ceiling zones test fixture</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/263/files#diff-0a0b12c9dd90443b0b963bdabafcd8eb49c0cf0ee0c709d55dd9d67378d9a961">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>resting_hr_nocturnal_only_test.dart</strong><dd><code>Remove sleepSpo2Red/Ir from resting HR test fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/263/files#diff-68766d2fbe452eec5ca8ab275342485d806da2880d490058908b0737951150c5">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>strain_resting_hr_source_test.dart</strong><dd><code>Remove sleepSpo2Red/Ir from strain/RHR test fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/263/files#diff-f103bdab4b30be9de9db0104e7183b20057c5d18d31019fcc965648dca87c2b3">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ui2_activity_test.dart</strong><dd><code>Add test: rest countdown does not rebuild LiveShell</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/263/files#diff-33fd1fa00e48987fae63a8d3d39bafe57349eadaa4b3852c45968012f8547232">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>derive_probe.dart</strong><dd><code>Remove sleepSpo2Red/Ir from derive probe tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/263/files#diff-5dd554f91341d146a7afeb903e16458634457148c11acb648ede48a9629c32f2">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved historical data processing by preserving packet revision information and handling invalid values safely.
  - Resolved a data-type issue that could cause derivation failures.
  - Simplified backup imports for more reliable database restoration.

- **Performance**
  - Reduced unnecessary payload parsing and database-count refreshes.
  - Improved countdown updates for smoother exercise screens.
  - Optimized notification icon loading.

- **Changes**
  - Removed internal SpO₂ diagnostics and related serialized fields.
  - Replaced database-count updates with insight refresh notifications.
  - Removed the selected-day reanalysis option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->