### PR TITLE
repin analytics for the stager pass

### DIFF
--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -1310,7 +1310,14 @@ const int kAlgoVersion = 76;
 // produced and no baseline ever held. For a user whose data is valid, every
 // number out of both packages is byte-identical, so a bump would invalidate
 // every stored day to recompute the same answers.
-const String kAnalyticsPin = '3174a493472a5e6280b11a0ab11fec82483507e1';
+//
+// This repin picks up the analytics perf pass, and kAlgoVersion holds at 76 for
+// the same reason: the stager does the same arithmetic in fewer passes. The one
+// place that could have gone wrong was sorting the HR window before `stddev`,
+// which re-orders a float summation — that is computed before the sort now, and
+// the real overnight capture staged identically down to the last digit of
+// confidence.
+const String kAnalyticsPin = 'd9362a66fbeac326d5d7d7b1fe27b28e41169a79';
 const String kProtocolPin = 'c761f29bcbed73886b1b059dcd9e92e4333574f5';
 
 // Fold idempotency, the minimum-nights warm-up, and legacy-payload handling

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -924,8 +924,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "3174a493472a5e6280b11a0ab11fec82483507e1"
-      resolved-ref: "3174a493472a5e6280b11a0ab11fec82483507e1"
+      ref: d9362a66fbeac326d5d7d7b1fe27b28e41169a79
+      resolved-ref: d9362a66fbeac326d5d7d7b1fe27b28e41169a79
       url: "https://github.com/OpenStrap/analytics.git"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -198,7 +198,7 @@ dependencies:
       # abstains rather than billing every waking minute as active when the
       # anchors are unusable — which is source-breaking here, not
       # number-changing (see `onehz_pipeline` and `_dailyEnergy`).
-      ref: 3174a493472a5e6280b11a0ab11fec82483507e1
+      ref: d9362a66fbeac326d5d7d7b1fe27b28e41169a79
 
   # BLE — flutter_blue_plus is the maintained cross-platform GATT client.
   flutter_blue_plus: ^1.36.8


### PR DESCRIPTION
### **User description**
analytics#49 merged, so edge was still pinned a commit behind and not getting the stager work.

`kAlgoVersion` holds at 76. the stager does the same arithmetic in fewer passes — one beat-gather instead of three hand-copies, the local HR window sorted once instead of twice, and a binary search instead of rescanning the night per epoch. ~950ms → ~805ms on a full real night.

the one place that could have silently changed a number was sorting the HR window before `stddev`, since that re-orders a float summation and feeds the wake threshold. computed before the sort now, and the real overnight capture stages identically: epochs=1068 wake=52 rem=300 nrem=716 deep=137 light=579 conf=0.5501404494382023.

goldens fail in CI as always (`test/goldens/` gitignored); everything else green.


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Repins the `analytics` sibling package in `pubspec.yaml` to a new commit SHA (`d9362a66...`).

- Improves sleep stager performance with faster derivation times.

- Explicit callout: `kAlgoVersion` was NOT bumped (remains at 76) because the analytics output and data effects remain identical.

- Note: No new tests were added under `test/` (expected, as user-visible behavior and output are unchanged).


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pubspec.yaml"] -- "updates analytics ref" --> B["New Commit SHA"]
  C["derivation_engine.dart"] -- "updates kAnalyticsPin" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>derivation_engine.dart</strong><dd><code>Update analytics pin constant and documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/compute/derivation_engine.dart

<ul><li>Updates the <code>kAnalyticsPin</code> constant to match the new <code>analytics</code> commit <br>SHA.<br> <li> Adds documentation explaining that <code>kAlgoVersion</code> is intentionally held <br>at 76 because the stager arithmetic changes do not alter the final <br>output.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/269/files#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pubspec.yaml</strong><dd><code>Repin analytics dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pubspec.yaml

<ul><li>Updates the <code>analytics</code> dependency <code>ref</code> to <br><code>d9362a66fbeac326d5d7d7b1fe27b28e41169a79</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/269/files#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

