### PR TITLE
Wire the dormant notification surface (sedentary, meds buzz, battery threshold, recovery, step goal, wind-down, weekly lookback)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -319,6 +319,14 @@ ShellDomain domainForRoute(String route) => switch (routePath(route)) {
       // The medication reminder. Wellness owns the Medication tab and its
       // checklist, which is where a dose is actually recorded.
       kRouteMeds => ShellDomain.wellness,
+      // The movement/sedentary nudges. Today (Home) is where the steps/rings
+      // they point at live; there is no move screen to push, so
+      // screenForRoute returns null for it — same shape as /meds below.
+      kRouteMovement => ShellDomain.home,
+      // Recovery-ready and step-goal notes. Both are about what already lives
+      // on Today, and neither has a screen of its own to push.
+      kRouteRecovery => ShellDomain.home,
+      kRouteSteps => ShellDomain.home,
       kRouteWorkoutSuggestion => ShellDomain.workout,
       // Emitted by the battery forecast (`app_state.dart`) and the weekly
       // recap (`notification_center.dart`), and declared in `tap_router`

--- a/lib/notify/device_alerts.dart
+++ b/lib/notify/device_alerts.dart
@@ -3,8 +3,9 @@
 // Fed the latest DeviceState on every BLE update (AppState._onEngineState), but
 // it is EDGE-TRIGGERED and de-duped, so it fires at most once per real event —
 // never on every tick:
-//   • Low battery (< 15%, not charging): once per drain. Re-arms only after the
-//     battery recovers past 25% (hysteresis) or goes back on the charger.
+//   • Low battery (below the user's threshold — default 15% — not charging):
+//     once per drain. Re-arms only after the battery recovers past
+//     threshold+10 (hysteresis) or goes back on the charger.
 //   • Charging started: once per plug-in, gated by [ChargeAlertPolicy].
 //
 // THE EDGE STATE IS PERSISTED (issue #179). It used to live only in RAM, which
@@ -34,6 +35,7 @@ import '../data/day_label.dart';
 import 'charge_alert_policy.dart';
 import 'notification_center.dart';
 import 'notification_event.dart';
+import 'notification_prefs.dart';
 import 'notification_service.dart';
 import 'tap_router.dart';
 
@@ -91,8 +93,15 @@ class _PrefsDeviceAlertStore implements DeviceAlertStore {
 }
 
 class DeviceAlerts {
-  static const double _lowPct = 15;
-  static const double _rearmPct = 25; // hysteresis so we don't re-fire near 15%
+  /// The default low-battery threshold. The live value is the user's
+  /// [NotificationPrefs.batteryAlertPct], read back from the persisted store
+  /// in [_restore] (same key the settings screen writes) — this constant is
+  /// only what a store with nothing in it degrades to.
+  static const int _defaultLowPct = NotificationPrefs.batteryPctDefault;
+
+  /// How far above the threshold the battery must climb before a low alert
+  /// re-arms (hysteresis so we don't re-fire around the threshold).
+  static const int _rearmGapPct = 10;
 
   static const String _kLastChargeTs = 'device_alerts.last_charge_event_ts';
   static const String _kLastChargeWall = 'device_alerts.last_charge_wall_sec';
@@ -115,6 +124,12 @@ class DeviceAlerts {
   bool _cancelledForOff = false; // already cleared the card for this off-state
   int? _lastAnnouncedEventTs; // strap ts of the last announced charge session
   int? _lastAnnouncedWallSec; // wall time of that announcement
+
+  /// The live low-battery threshold, in percent. Set in [_restore] from the
+  /// user's pref (NotificationPrefs.batteryPctPrefKey); until that read lands,
+  /// [_defaultLowPct]. An int from prefs, held as double because the battery
+  /// percentage arriving off the strap is one.
+  double _lowPct = _defaultLowPct.toDouble();
 
   final DeviceAlertSink _notes;
   final DeviceAlertStore _store;
@@ -156,6 +171,15 @@ class DeviceAlerts {
       _lastAnnouncedEventTs = (eventTs != null && eventTs > 0) ? eventTs : null;
       _lastAnnouncedWallSec = wallSec;
       if (armed != null) _lowArmed = armed != 0;
+      // The user's threshold. Same key NotificationPrefs writes; clamped to
+      // the same bounds, so a hand-edited or stale value can't push the alert
+      // out of its sane range.
+      final pct = await _store.readInt(NotificationPrefs.batteryPctPrefKey);
+      if (pct != null) {
+        _lowPct = pct
+            .clamp(NotificationPrefs.batteryPctMin, NotificationPrefs.batteryPctMax)
+            .toDouble();
+      }
     } catch (_) {
       _lastAnnouncedEventTs = null;
       _lastAnnouncedWallSec = null;
@@ -258,9 +282,10 @@ class DeviceAlerts {
 
     // Low-battery hysteresis, same precedence as before: a real plug-in re-arms
     // the next drain, so does a battery that recovered past the ceiling.
+    final rearmPct = _lowPct + _rearmGapPct;
     var lowArmed = _lowArmed;
     if (announce) lowArmed = true;
-    if (batteryPct != null && batteryPct >= _rearmPct) lowArmed = true;
+    if (batteryPct != null && batteryPct >= rearmPct) lowArmed = true;
     final fireLow = batteryPct != null &&
         charging != true &&
         batteryPct < _lowPct &&

--- a/lib/notify/device_alerts.dart
+++ b/lib/notify/device_alerts.dart
@@ -186,6 +186,25 @@ class DeviceAlerts {
     }
   }
 
+  /// Re-read the user's threshold from the persisted store. Called when
+  /// NotificationPrefs change (the settings screen saves first) — [_restore]
+  /// is memoised, so without this a threshold change would not apply until
+  /// the next process create. Rides the same serialized queue as
+  /// [onDeviceState] so the mutation can't interleave an in-flight decision.
+  void refreshThreshold() {
+    _queue = _queue.then((_) async {
+      final pct = await _store.readInt(NotificationPrefs.batteryPctPrefKey);
+      if (pct != null) {
+        _lowPct = pct
+            .clamp(
+                NotificationPrefs.batteryPctMin, NotificationPrefs.batteryPctMax)
+            .toDouble();
+      }
+    }).catchError((_) {
+      // A stale threshold for one drain beats breaking the state pipeline.
+    });
+  }
+
   /// Call with the latest device state. Cheap and safe to call on every update.
   ///
   /// [chargingTs] is the strap timestamp of the event that last set [charging]

--- a/lib/notify/med_buzzer.dart
+++ b/lib/notify/med_buzzer.dart
@@ -1,0 +1,73 @@
+// med_buzzer.dart — fires a strap haptic at each scheduled medication dose.
+//
+// The mirror of WaterBuzzer for the medication reminder, and the weaker half
+// by the same argument: the OS-scheduled dose notifications (armed in
+// NotificationCenter._armMedSlots) fire even when the app is dead; a strap
+// buzz needs a live BLE link AND a live Dart isolate. BEST-EFFORT — an
+// in-memory timer (re-armed on every foreground pass, since timers don't
+// persist) that buzzes ONLY if the band is connected at the dose instant. A
+// missed buzz costs nothing: the notification is what actually reminds, and
+// the checklist behind it is where the dose gets recorded.
+//
+// Where water slots are daily wall-clock MINUTES (recurring), doses are
+// ONE-SHOT ABSOLUTE instants — `med_def` schedules land on specific days
+// (slotsForDay already resolved taken/skipped/past for today), and
+// medPromptSlots hands back exactly the still-upcoming slots over its 3-day
+// horizon. So this class consumes DateTimes, not minutes-from-midnight.
+
+import 'dart:async';
+
+class MedBuzzer {
+  MedBuzzer({required this.buzz, required this.isConnected});
+
+  /// Sends one short haptic to the strap (no-op if the link isn't ready).
+  final Future<void> Function() buzz;
+
+  /// Whether the strap is currently connected (checked lazily at fire time).
+  final bool Function() isConnected;
+
+  Timer? _timer;
+  List<DateTime> _slots = const []; // absolute instants, ascending
+
+  /// (Re)configure from the current prefs + schedule. Idempotent — cancels and
+  /// re-arms. Pass `NotificationCenter.medPromptSlots(...)` mapped through
+  /// `NotificationCenter.medSlotInstant(...)` (nulls dropped) as [slotInstants].
+  /// Past instants are skipped, not fired late: a buzz for a dose window that
+  /// already passed is noise about a decision the user already made.
+  void configure({required List<DateTime> slotInstants}) {
+    final now = DateTime.now();
+    _slots = slotInstants.where((t) => t.isAfter(now)).toList()..sort();
+    _reschedule();
+  }
+
+  void _reschedule() {
+    _timer?.cancel();
+    _timer = null;
+    if (_slots.isEmpty) return;
+
+    final now = DateTime.now();
+    final next = _slots.first;
+    var delay = next.difference(now);
+    if (delay.isNegative) delay = Duration.zero;
+
+    _timer = Timer(delay, _fire);
+  }
+
+  Future<void> _fire() async {
+    // Consume the slot whether or not the buzz landed — the link being down at
+    // the dose instant is not a reason to re-buzz minutes later.
+    if (_slots.isNotEmpty) _slots.removeAt(0);
+    if (isConnected()) {
+      try {
+        await buzz();
+      } catch (_) {/* link dropped mid-write — best effort */}
+    }
+    _reschedule(); // arm the next dose, if any remain in this batch
+  }
+
+  void dispose() {
+    _timer?.cancel();
+    _timer = null;
+    _slots = const [];
+  }
+}

--- a/lib/notify/notification_center.dart
+++ b/lib/notify/notification_center.dart
@@ -387,12 +387,14 @@ class NotificationCenter {
     }
   }
 
-  /// The daily wind-down nudge, as a repeating slot at the learned bedtime.
+  /// The daily wind-down nudge, as a repeating slot before the learned bedtime.
   ///
   /// A daily REPEAT is right here (unlike the weekly lookback's one-shot):
   /// the body names a TIME, not one week's facts, so it stays true every day.
-  /// `skipToday: true` — once tonight's slot has passed, arming it for today
-  /// would fire a wind-down after bedtime; the repeat resumes tomorrow.
+  /// No skip-today: a user who opts in mid-evening should get TONIGHT's
+  /// reminder if the slot is still ahead — `nextInstanceOf` already resolves
+  /// to the next occurrence strictly after now, and same-id re-scheduling
+  /// replaces rather than stacks.
   Future<void> _armWindDown(NotificationService svc, int minuteOfDay) async {
     await svc.scheduleDaily(
       id: NotificationService.idWindDown,
@@ -403,12 +405,14 @@ class NotificationCenter {
       hour: minuteOfDay ~/ 60,
       minute: minuteOfDay % 60,
       route: kRouteBreathing,
-      skipToday: true,
     );
   }
 
   /// How long before the learned bedtime the wind-down lands.
   static const int windDownBeforeBedMin = 45;
+
+  /// How far inside the quiet window's edge the slot must stay clear of.
+  static const int _windDownQuietMarginMin = 30;
 
   /// The wind-down's wall-clock minute, or null when it must not be armed.
   ///
@@ -418,11 +422,28 @@ class NotificationCenter {
   /// bedtime yet, the nudge waits. (The check-in may fall back to a stated
   /// fixed time because its copy says "evening"; this one's whole content IS
   /// the time, so there is nothing honest to fall back to.)
+  ///
+  /// The offset wraps across midnight: a learned bedtime of 00:20 wants its
+  /// wind-down at 23:35 the SAME evening, which `scheduleDaily`'s
+  /// next-occurrence arithmetic delivers from a 23:35 minutes-of-day value.
+  ///
+  /// OS-scheduled notifications fire with no Dart running, so
+  /// [NotificationPrefs.shouldFireOs] never sees one — quiet hours must be
+  /// applied HERE. Same shape as the check-in: cap to half an hour before
+  /// quiet opens, and refuse outright if the slot would still land inside
+  /// the protected window.
   static int? windDownSlot(NotificationPrefs prefs, double? bedtimeMinOfDay) {
     if (!prefs.windDownEnabled || bedtimeMinOfDay == null) return null;
-    final t =
-        bedtimeMinOfDay.round() - windDownBeforeBedMin;
-    if (t < 0 || t >= 24 * 60) return null;
+    // Wrap across midnight, staying non-negative (Dart % can go negative for
+    // negative operands only when the modulus is... it cannot here — but the
+    // +1440 makes the intent explicit and survives sign changes).
+    var t = ((bedtimeMinOfDay.round() - windDownBeforeBedMin) % 1440 + 1440) %
+        1440;
+    if (prefs.quietEnabled && prefs.quietStartMin > prefs.quietEndMin) {
+      final cap = prefs.quietStartMin - _windDownQuietMarginMin;
+      if (t > cap) t = cap;
+    }
+    if (prefs.inQuietHours(t)) return null;
     return t;
   }
 

--- a/lib/notify/notification_center.dart
+++ b/lib/notify/notification_center.dart
@@ -221,8 +221,14 @@ class NotificationCenter {
     Map<String, Map<int, Map<String, Object?>>> medDosesToday = const {},
   }) async {
     final svc = NotificationService.instance;
-    await svc.cancel(NotificationService.idWindDown);
     await svc.cancel(NotificationService.idWeeklyRecap);
+    // Wind-down follows the standing rule — cancel what this call cannot put
+    // back, and only that. A null slot (switch off, or no LEARNED bedtime yet)
+    // cancels; a real slot is armed below.
+    final windDownMin = windDownSlot(prefs, bedtimeMinOfDay);
+    if (windDownMin == null) {
+      await svc.cancel(NotificationService.idWindDown);
+    }
     // The check-in and the medication band follow the same rule as the
     // movement nudge below: cancel what the user just switched off, and
     // otherwise only what THIS call can put back.
@@ -284,13 +290,20 @@ class NotificationCenter {
             doneToday: checkInDoneToday, nowMin: now.hour * 60 + now.minute);
     final meds =
         medPromptSlots(prefs, medDefs ?? const [], medDosesToday, now: now);
-    if (water.isEmpty && !wantWeekly && checkIn == null && meds.isEmpty) return;
+    if (water.isEmpty &&
+        !wantWeekly &&
+        windDownMin == null &&
+        checkIn == null &&
+        meds.isEmpty) {
+      return;
+    }
     // Re-resolve the zone first: this runs on every foreground resume, and the
     // instants below are wall-clock. A phone that flew somewhere would otherwise
     // keep arming Sunday 18:00 in the zone the app first launched in.
     await svc.ensureTimezone();
     await _armWaterSlots(svc, water);
     if (wantWeekly) await _armWeeklyLookback(svc, weeklyFinding);
+    if (windDownMin != null) await _armWindDown(svc, windDownMin);
     if (checkIn != null) await _armCheckIn(svc, checkIn);
     await _armMedSlots(svc, meds);
   }
@@ -374,17 +387,108 @@ class NotificationCenter {
     }
   }
 
-  /// Arm the lookback as a ONE-SHOT at the next Sunday 18:00.
+  /// The daily wind-down nudge, as a repeating slot at the learned bedtime.
   ///
-  /// One-shot, not `matchDateTimeComponents: dayOfWeekAndTime`: a repeat would
-  /// go on re-announcing THIS week's finding every Sunday for the life of the
-  /// install, which is how the recap ended up firing unconditionally in the
-  /// first place. Re-armed by the next call that has a finding.
+  /// A daily REPEAT is right here (unlike the weekly lookback's one-shot):
+  /// the body names a TIME, not one week's facts, so it stays true every day.
+  /// `skipToday: true` — once tonight's slot has passed, arming it for today
+  /// would fire a wind-down after bedtime; the repeat resumes tomorrow.
+  Future<void> _armWindDown(NotificationService svc, int minuteOfDay) async {
+    await svc.scheduleDaily(
+      id: NotificationService.idWindDown,
+      category: NotifCategory.reminders,
+      title: 'Wind down',
+      body: 'Your bedtime is around ${_hhmm(minuteOfDay + windDownBeforeBedMin)}. '
+          'Start slowing down.',
+      hour: minuteOfDay ~/ 60,
+      minute: minuteOfDay % 60,
+      route: kRouteBreathing,
+      skipToday: true,
+    );
+  }
+
+  /// How long before the learned bedtime the wind-down lands.
+  static const int windDownBeforeBedMin = 45;
+
+  /// The wind-down's wall-clock minute, or null when it must not be armed.
   ///
-  /// The permission check lives inside [NotificationService.scheduleOnce] and
-  /// is non-prompting, so a transient "not granted" read can no longer wipe the
-  /// standing schedule and leave nothing behind — the cancels above are the
-  /// intended state when there is nothing to say.
+  /// Requires BOTH the switch and a LEARNED bedtime ([bedtimeMinOfDay] from
+  /// the Sleep Coach). A population fallback here would be a made-up time
+  /// pretending to know this user's sleep — if the coach hasn't learned a
+  /// bedtime yet, the nudge waits. (The check-in may fall back to a stated
+  /// fixed time because its copy says "evening"; this one's whole content IS
+  /// the time, so there is nothing honest to fall back to.)
+  static int? windDownSlot(NotificationPrefs prefs, double? bedtimeMinOfDay) {
+    if (!prefs.windDownEnabled || bedtimeMinOfDay == null) return null;
+    final t =
+        bedtimeMinOfDay.round() - windDownBeforeBedMin;
+    if (t < 0 || t >= 24 * 60) return null;
+    return t;
+  }
+
+  /// Two-digit HH:MM from minutes-past-midnight (notification bodies).
+  static String _hhmm(int minuteOfDay) {
+    final m = minuteOfDay % 1440;
+    return '${(m ~/ 60).toString().padLeft(2, '0')}:'
+        '${(m % 60).toString().padLeft(2, '0')}';
+  }
+
+  // ── the weekly lookback finding ─────────────────────────────────────────
+
+  /// What Sunday's lookback says, or null when the week was quiet enough that
+  /// NOTHING should interrupt the user. PURE over the crossday rollup's
+  /// `recent[]` rows ({date, rhr, unsettled, illness, anomaly, temp}).
+  ///
+  /// The bar is deliberately high: most weeks must produce null. A weekly
+  /// notification that fires every Sunday is the recap problem all over again
+  /// — the reason the slot sat unwired for so long was that nothing honest
+  /// could fill it. Priority: medical flags first (they are the sanctioned
+  /// detections), then a plainly-stated resting-HR drift, then silence.
+  static String? weeklyLookbackFinding(
+      List<Map<String, dynamic>> recentDays) {
+    final days = recentDays
+        .where((d) => d['unsettled'] != true)
+        .toList(growable: false);
+    if (days.isEmpty) return null;
+
+    // Medical flags, counted per kind. These reuse the same detectors the
+    // daily health exception fires on — the weekly note only SUMMARIZES them.
+    final illness = days.where((d) => d['illness'] == true).length;
+    final anomaly = days.where((d) => d['anomaly'] == true).length;
+    final temp = days.where((d) => d['temp'] == true).length;
+    final parts = <String>[];
+    if (illness > 0) parts.add('possible illness onset ×$illness');
+    if (anomaly > 0) parts.add('unusual physiology ×$anomaly');
+    if (temp > 0) parts.add('elevated skin temperature ×$temp');
+    if (parts.isNotEmpty) {
+      return 'This week flagged: ${parts.join(', ')}. Details live on Health.';
+    }
+
+    // Resting-HR drift across the week: mean of the last three nights vs the
+    // first three. Plain arithmetic on stored nightly values, stated as such
+    // — no trend test dressed up as science. Needs ≥5 settled nights with an
+    // RHR on both ends, which is also what keeps this silent most weeks.
+    final rhrs = [
+      for (final d in days)
+        if (d['rhr'] is num) (d['rhr'] as num).toDouble(),
+    ];
+    if (rhrs.length >= 5) {
+      double mean(List<double> xs) => xs.reduce((a, b) => a + b) / xs.length;
+      final early = mean(rhrs.sublist(0, 3));
+      final late = mean(rhrs.sublist(rhrs.length - 3));
+      final delta = late - early;
+      if (delta >= 3) {
+        return 'Resting heart rate ran about ${delta.round()} bpm higher '
+            'late in the week than early.';
+      }
+      if (delta <= -3) {
+        return 'Resting heart rate ran about ${(-delta).round()} bpm lower '
+            'late in the week than early.';
+      }
+    }
+    return null;
+  }
+
   Future<void> _armWeeklyLookback(
       NotificationService svc, String finding) async {
     await svc.scheduleOnce(

--- a/lib/notify/notification_event.dart
+++ b/lib/notify/notification_event.dart
@@ -87,6 +87,31 @@ NotifClass? classOf(NotificationEvent e) => switch (e.category) {
           when e.priority == NotifPriority.normal &&
               routePath(e.route ?? '') == kRouteWorkoutSuggestion =>
         NotifClass.prompt,
+      // Same mechanism, second route: the movement/sedentary prompt. It is a
+      // report about something measured (a still stretch, a desk posture held
+      // for 90+ minutes) asking the user to act — not a nudge about a day the
+      // data can't support — so it rides [NotifClass.prompt] like the detected
+      // workout does. Route-keyed for the same reason: reminders-at-normal is
+      // exactly the pair the deleted nudges would arrive on, and opening that
+      // pair wholesale would resurrect all of them at once. Its off switch is
+      // NotificationPrefs.movementEnabled (see shouldFireOs).
+      NotifCategory.reminders
+          when e.priority == NotifPriority.normal &&
+              routePath(e.route ?? '') == kRouteMovement =>
+        NotifClass.prompt,
+      // Same mechanism, two more route-keyed sanctions. The recovery-ready
+      // morning note (its channel was where deleted nudges went, so the ROUTE
+      // — not the category — is what re-opens) and the step-goal achievement.
+      // Both are reports about something that already happened and measured,
+      // gated by their own switches (recoveryEnabled / stepGoalEnabled).
+      NotifCategory.recovery
+          when e.priority == NotifPriority.normal &&
+              routePath(e.route ?? '') == kRouteRecovery =>
+        NotifClass.prompt,
+      NotifCategory.reminders
+          when e.priority == NotifPriority.normal &&
+              routePath(e.route ?? '') == kRouteSteps =>
+        NotifClass.prompt,
       NotifCategory.reminders || NotifCategory.recovery => null,
     };
 

--- a/lib/notify/notification_prefs.dart
+++ b/lib/notify/notification_prefs.dart
@@ -93,6 +93,33 @@ class NotificationPrefs {
   /// fires because yesterday is blank is a streak wearing a different hat.
   final bool checkInEnabled;
 
+  /// The low-battery alert threshold, in percent. DeviceAlerts used to
+  /// hard-code 15%; this is the same alert with the number in the user's
+  /// hands. Read back by DeviceAlerts through its own persisted store (same
+  /// key), so a headless BLE state update picks up a change without a full
+  /// NotificationPrefs load. Clamped to [batteryPctAllowed] when scheduling.
+  final int batteryAlertPct;
+
+  /// The step-goal achievement: one note on the day the step ESTIMATE first
+  /// crosses the user's goal. On by default — it fires at most once a day and
+  /// only when the goal is actually reached — with this as its off switch.
+  final bool stepGoalEnabled;
+
+  /// The nightly wind-down nudge: one heads-up before the bedtime the Sleep
+  /// Coach LEARNED from this user's own nights. Opt-in and off by default like
+  /// every other outbound scheduled nudge; it also stays silent until a
+  /// bedtime has actually been learned — see NotificationCenter.windDownSlot.
+  final bool windDownEnabled;
+
+  /// Allowed bounds for [batteryAlertPct]. Below 5% a band is dying, not low;
+  /// above 40% the alert would fire constantly and be muted forever.
+  static const int batteryPctMin = 5;
+  static const int batteryPctMax = 40;
+
+  /// The shipped default threshold — what an unset store degrades to (also
+  /// DeviceAlerts' fallback, so the number is spelled exactly once).
+  static const int batteryPctDefault = 15;
+
   const NotificationPrefs({
     this.healthEnabled = true,
     this.recoveryEnabled = true,
@@ -108,6 +135,9 @@ class NotificationPrefs {
     this.movementEnabled = false,
     this.medsEnabled = false,
     this.checkInEnabled = false,
+    this.batteryAlertPct = batteryPctDefault,
+    this.stepGoalEnabled = true,
+    this.windDownEnabled = false,
   });
 
   static const _kHealth = 'notif_health';
@@ -124,6 +154,15 @@ class NotificationPrefs {
   static const _kMovement = 'notif_movement';
   static const _kMeds = 'notif_meds';
   static const _kCheckIn = 'notif_checkin';
+
+  /// The low-battery alert threshold's persisted key. PUBLIC because
+  /// DeviceAlerts reads it back through its own store seam on headless BLE
+  /// state updates, without loading a full [NotificationPrefs]. Both sides of
+  /// that coupling must spell it once.
+  static const String batteryPctPrefKey = 'notif_battery_pct';
+  static const _kBatteryPct = batteryPctPrefKey;
+  static const _kStepGoal = 'notif_stepgoal';
+  static const _kWindDown = 'notif_winddown';
 
   static Future<NotificationPrefs> load() async {
     final p = await SharedPreferences.getInstance();
@@ -142,6 +181,11 @@ class NotificationPrefs {
       movementEnabled: p.getBool(_kMovement) ?? false,
       medsEnabled: p.getBool(_kMeds) ?? false,
       checkInEnabled: p.getBool(_kCheckIn) ?? false,
+      batteryAlertPct:
+          (p.getInt(_kBatteryPct) ?? batteryPctDefault)
+              .clamp(batteryPctMin, batteryPctMax),
+      stepGoalEnabled: p.getBool(_kStepGoal) ?? true,
+      windDownEnabled: p.getBool(_kWindDown) ?? false,
     );
   }
 
@@ -161,6 +205,10 @@ class NotificationPrefs {
     await p.setBool(_kMovement, movementEnabled);
     await p.setBool(_kMeds, medsEnabled);
     await p.setBool(_kCheckIn, checkInEnabled);
+    await p.setInt(
+        _kBatteryPct, batteryAlertPct.clamp(batteryPctMin, batteryPctMax));
+    await p.setBool(_kStepGoal, stepGoalEnabled);
+    await p.setBool(_kWindDown, windDownEnabled);
   }
 
   NotificationPrefs copyWith({
@@ -178,6 +226,9 @@ class NotificationPrefs {
     bool? movementEnabled,
     bool? medsEnabled,
     bool? checkInEnabled,
+    int? batteryAlertPct,
+    bool? stepGoalEnabled,
+    bool? windDownEnabled,
   }) =>
       NotificationPrefs(
         healthEnabled: healthEnabled ?? this.healthEnabled,
@@ -195,6 +246,9 @@ class NotificationPrefs {
         movementEnabled: movementEnabled ?? this.movementEnabled,
         medsEnabled: medsEnabled ?? this.medsEnabled,
         checkInEnabled: checkInEnabled ?? this.checkInEnabled,
+        batteryAlertPct: batteryAlertPct ?? this.batteryAlertPct,
+        stepGoalEnabled: stepGoalEnabled ?? this.stepGoalEnabled,
+        windDownEnabled: windDownEnabled ?? this.windDownEnabled,
       );
 
   bool categoryEnabled(NotifCategory c) => switch (c) {
@@ -230,6 +284,23 @@ class NotificationPrefs {
     // check against the bare route would miss every real one.)
     if (!autoDetectEnabled &&
         routePath(event.route ?? '') == kRouteWorkoutSuggestion) {
+      return false;
+    }
+    // The movement nudge's off switch, same shape and same reason as the
+    // auto-detect one above: the route identifies the event the user set THIS
+    // switch for. Covers both sedentary surfaces — the OS-scheduled
+    // two-hour-still one-shot (which never passes through here; it is gated at
+    // NotificationService.schedulableIds) and this foreground desk-posture
+    // check, which does.
+    if (!movementEnabled &&
+        routePath(event.route ?? '') == kRouteMovement) {
+      return false;
+    }
+    // The step-goal achievement's off switch — same route-keyed shape. (The
+    // recovery-ready note needs no extra branch here: it rides the recovery
+    // category, and categoryEnabled below already reads recoveryEnabled.)
+    if (!stepGoalEnabled &&
+        routePath(event.route ?? '') == kRouteSteps) {
       return false;
     }
     final klass = classOf(event);

--- a/lib/notify/notification_prefs.dart
+++ b/lib/notify/notification_prefs.dart
@@ -181,9 +181,9 @@ class NotificationPrefs {
       movementEnabled: p.getBool(_kMovement) ?? false,
       medsEnabled: p.getBool(_kMeds) ?? false,
       checkInEnabled: p.getBool(_kCheckIn) ?? false,
-      batteryAlertPct:
-          (p.getInt(_kBatteryPct) ?? batteryPctDefault)
-              .clamp(batteryPctMin, batteryPctMax),
+      batteryAlertPct: ((p.getInt(_kBatteryPct) ?? batteryPctDefault)
+              .clamp(batteryPctMin, batteryPctMax))
+          .toInt(),
       stepGoalEnabled: p.getBool(_kStepGoal) ?? true,
       windDownEnabled: p.getBool(_kWindDown) ?? false,
     );
@@ -206,7 +206,7 @@ class NotificationPrefs {
     await p.setBool(_kMeds, medsEnabled);
     await p.setBool(_kCheckIn, checkInEnabled);
     await p.setInt(
-        _kBatteryPct, batteryAlertPct.clamp(batteryPctMin, batteryPctMax));
+        _kBatteryPct, batteryAlertPct.clamp(batteryPctMin, batteryPctMax).toInt());
     await p.setBool(_kStepGoal, stepGoalEnabled);
     await p.setBool(_kWindDown, windDownEnabled);
   }

--- a/lib/notify/notification_service.dart
+++ b/lib/notify/notification_service.dart
@@ -180,12 +180,20 @@ class NotificationService {
   ///   • the medication band ([isMedSlot]) — armed only while
   ///     `NotificationPrefs.medsEnabled` is on, at the times in the user's own
   ///     `med_def` schedule, and only for a dose still upcoming.
-  /// Wind-down, the morning briefing and the AI journal prompt are none of
-  /// those, and are still refused. Their callers keep CANCELLING, which is how
-  /// an upgrade cleans out whatever an older build left standing.
+  ///   • [idWindDown] — armed only from a LEARNED bedtime (Sleep Coach), never
+  ///     a population fallback, and only while `windDownEnabled` is on.
+  ///   • [idMorningBrief] — armed by `aiReminderPlan` only for a user with a
+  ///     BYOK key AND their own AI morning switch on. Its body is static (the
+  ///     constraint above: no model text in the schedule); the screen it opens
+  ///     computes on arrival.
+  /// The AI journal prompt ([idJournalLog]) is none of those and is still
+  /// refused. Its caller keeps CANCELLING, which is how an upgrade cleans out
+  /// whatever an older build left standing.
   static const Set<int> schedulableIds = {
     idWeeklyRecap,
     idEveningBrief,
+    idMorningBrief,
+    idWindDown,
     idStillness,
     idCheckIn,
   };

--- a/lib/notify/tap_router.dart
+++ b/lib/notify/tap_router.dart
@@ -26,6 +26,32 @@ const String kRouteWater = '/water';
 /// anything that just wants the review screen).
 const String kRouteWorkoutSuggestion = '/workouts/suggestion';
 
+/// The sedentary/movement nudges ("time to move", the desk-posture check).
+///
+/// A DEDICATED PATH, not the plain `/today`, and that is load-bearing: the
+/// notification gate classifies on category + priority + route, and
+/// reminders-at-low was deliberately the pair every deleted nudge used to
+/// arrive on. Keying the movement prompt to this route is what lets it (and
+/// only it) through while every other reminders event stays dropped — the same
+/// mechanism `kRouteWorkoutSuggestion` uses.
+///
+/// Lands on Home (Today) and pushes nothing: there is no move screen to push,
+/// and Today is where the rings/steps a nudge points at already live.
+const String kRouteMovement = '/today/movement';
+
+/// "Your recovery is ready" — the morning recovery note. DEDICATED PATH for
+/// the same reason [kRouteMovement] is: the recovery channel was where dead
+/// nudges went (`classOf` dropped all of it), so re-opening the CHANNEL would
+/// resurrect them; keying on this route sanctions exactly one event. Its off
+/// switch is NotificationPrefs.recoveryEnabled (the retained pref for that
+/// channel). Lands on Home/Today, where the recovery ring lives.
+const String kRouteRecovery = '/today/recovery';
+
+/// "Step goal reached" — same mechanism again: reminders-at-low was a dropped
+/// pair, so the achievement rides its own route at prompt class. Off switch:
+/// NotificationPrefs.stepGoalEnabled.
+const String kRouteSteps = '/today/steps';
+
 /// The deep link for ONE detected bout. The id is the `workout_suggestions`
 /// row's, so the screen can open on that bout rather than a list the user has
 /// to find it in.

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -65,6 +65,7 @@ import '../gps/screen_wake.dart';
 import '../data/local_repository_impl.dart';
 import '../data/series_codec.dart';
 import '../notify/battery_forecast.dart';
+import '../notify/med_buzzer.dart';
 import '../notify/notification_center.dart';
 import '../notify/notification_event.dart';
 import '../notify/notification_prefs.dart';
@@ -179,6 +180,17 @@ class AppState extends ChangeNotifier {
   /// Fires a strap haptic at each water-reminder slot (best-effort, only when
   /// the band is connected). Armed at launch + whenever the toggle changes.
   late final WaterBuzzer _waterBuzzer = WaterBuzzer(
+    buzz: () => engine.buzz(),
+    isConnected: () => engine.isConnected,
+  );
+
+  /// Fires a strap haptic at each scheduled medication dose (best-effort, only
+  /// when the band is connected). Same trade as [_waterBuzzer]: the OS
+  /// notification is what actually reminds; the buzz is the bonus half that
+  /// only works with a live link. Armed from `_ensureRemindersScheduled`,
+  /// which is where the med schedule is already read for the OS slots — one
+  /// read feeds both surfaces, so they cannot drift apart.
+  late final MedBuzzer _medBuzzer = MedBuzzer(
     buzz: () => engine.buzz(),
     isConnected: () => engine.isConnected,
   );
@@ -1280,6 +1292,7 @@ class AppState extends ChangeNotifier {
     _releaseForegroundLease();
     _deriveScheduler.dispose();
     _waterBuzzer.dispose();
+    _medBuzzer.dispose();
     // Owned notifiers/observers. notificationRelay in particular holds a
     // WidgetsBindingObserver, a 120 s Timer.periodic and a StreamSubscription —
     // its observer accumulated on the binding across every hot restart.
@@ -1552,7 +1565,11 @@ class AppState extends ChangeNotifier {
           title: 'Your recovery is ready',
           body: 'Recovery $score$slept.',
           date: dayId,
-          route: '/today',
+          // kRouteRecovery, NOT the bare /today: this event sat dead for
+          // months because the recovery channel was one `classOf` dropped —
+          // it is the route that re-sanctions it as a prompt (and
+          // recoveryEnabled that mutes it).
+          route: kRouteRecovery,
         ),
       );
       if (fired) {
@@ -1635,7 +1652,7 @@ class AppState extends ChangeNotifier {
       // tonight's sweep at 20:00 for a user whose slot is 21:45, off a day
       // that was not over yet.
       final eveningMin = ai.resolvedEveningMin(
-        bedtimeMinOfDay: await _recommendedBedtimeMin(),
+        bedtimeMinOfDay: (await _readCrossdaySummary()).bedtimeMin,
       );
       if (ai.eveningEnabled && minOfDay >= eveningMin) {
         want = BriefingPeriod.evening;
@@ -1686,11 +1703,15 @@ class AppState extends ChangeNotifier {
         e: NotificationEvent(
           dedupeKey: '$date:step_goal',
           category: NotifCategory.reminders,
-          priority: NotifPriority.low,
+          // NORMAL + kRouteSteps, not low + /today: reminders-at-low was one
+          // of the dropped pairs, so this achievement never once reached a
+          // shade. It is a prompt now (route-keyed), muted via
+          // stepGoalEnabled.
+          priority: NotifPriority.normal,
           title: 'Step goal reached',
           body: 'You hit about $steps steps — at or above your $goal goal.',
           date: date,
-          route: '/today',
+          route: kRouteSteps,
         ),
       );
     } catch (_) {
@@ -1704,6 +1725,14 @@ class AppState extends ChangeNotifier {
   /// is a short rolling ~15 min window, not a monotonic idle timer, so it
   /// doesn't translate into a single OS-scheduled instant the way the
   /// "time to move" nudge below does; still foreground-only for now).
+  ///
+  /// WIRED under the Movement-nudge switch: this event used to emit on
+  /// reminders/low with a bare `/today` route — exactly the pair `classOf`
+  /// drops — so it never once reached a shade (the stillness nudge's own
+  /// history, pre-schedulableIds). It now rides [kRouteMovement] at prompt
+  /// class, gated by `movementEnabled`, and on a real present it also buzzes
+  /// the band — safe because this only ever runs with recent live IMU, i.e. a
+  /// link that was alive moments ago.
   static const String _kLastInactivityMs = 'last_inactivity_ms';
   Future<void> _maybeNotifyInactivity() async {
     try {
@@ -1733,15 +1762,23 @@ class AppState extends ChangeNotifier {
         NotificationEvent(
           dedupeKey: '$today:posture:${nowMs ~/ (2 * 60 * 60 * 1000)}',
           category: NotifCategory.reminders,
-          priority: NotifPriority.low,
-          title: 'Posture Check & Stretch',
+          // NORMAL, not low: reminders-at-low is one of the dropped pairs,
+          // and prompt class requires normal priority.
+          priority: NotifPriority.normal,
+          title: 'Time to move',
           body:
               'You’ve been in a typing posture for over 90 minutes without walking.',
           date: today,
-          route: '/today',
+          route: kRouteMovement,
         ),
       );
-      if (fired) await prefs.setInt(_kLastInactivityMs, nowMs);
+      if (fired) {
+        await prefs.setInt(_kLastInactivityMs, nowMs);
+        // Strap haptic alongside the shade card — the WaterBuzzer trade in a
+        // place that doesn't need its own timer: the live IMU feed this check
+        // just read IS the proof of a recent link.
+        unawaited(engine.buzz());
+      }
     } catch (_) {
       /* best-effort */
     }
@@ -2167,15 +2204,37 @@ class AppState extends ChangeNotifier {
   Future<void> _ensureRemindersScheduled() async {
     try {
       final prefs = await NotificationPrefs.load();
-      final bedtimeMin = await _recommendedBedtimeMin();
+      // ONE crossday read feeds every schedule that hangs off the rollup:
+      // the Sleep Coach bedtime (check-in, wind-down, nightly sweep) AND the
+      // weekly lookback's finding. Two separate baseline reads were how this
+      // used to be written; the second one is also where the weekly finding
+      // silently never got computed at all.
+      final cd = await _readCrossdaySummary();
       final meds = await _medScheduleToday(prefs);
       await NotificationCenter.instance.scheduleStandingReminders(
         prefs,
-        bedtimeMinOfDay: bedtimeMin,
+        bedtimeMinOfDay: cd.bedtimeMin,
+        weeklyFinding: prefs.remindersEnabled
+            ? NotificationCenter.weeklyLookbackFinding(cd.recent)
+            : null,
         checkInDoneToday: await _checkInDoneToday(),
         medDefs: meds.defs,
         medDosesToday: meds.doses,
       );
+      // The strap-buzz half of the medication reminder, off the SAME schedule
+      // read the OS dose slots above were armed from — one read feeds both
+      // surfaces. NULL defs (switch off, or the read threw) leaves the timer
+      // exactly as it is, matching the scheduler's own null-vs-empty rule:
+      // only an EMPTY list is an answer that may cancel what is standing.
+      if (meds.defs != null) {
+        final instants = <DateTime>[];
+        for (final s in NotificationCenter.medPromptSlots(
+            prefs, meds.defs!, meds.doses)) {
+          final at = NotificationCenter.medSlotInstant(s);
+          if (at != null) instants.add(at);
+        }
+        _medBuzzer.configure(slotInstants: instants);
+      }
       // AI slots. The nightly sweep is armed only when today actually produced
       // a finding — see [_sweepHeadlineNow], which is also where the body of
       // that notification comes from.
@@ -2184,7 +2243,7 @@ class AppState extends ChangeNotifier {
         prefs,
         ai,
         aiConfigured: coachConfig?.hasKey ?? false,
-        bedtimeMinOfDay: bedtimeMin,
+        bedtimeMinOfDay: cd.bedtimeMin,
         journalDoneToday: BriefingStore.journalDoneToday(),
         sweepHeadline: await _sweepHeadlineNow(),
       );
@@ -2193,22 +2252,41 @@ class AppState extends ChangeNotifier {
     }
   }
 
-  /// The Sleep Coach's recommended bedtime (local minutes past midnight) from
-  /// the crossday rollup, or null when it has not learned one. Read in one
-  /// place because two schedules hang off it — the nightly sweep an hour
-  /// before it, the journal prompt half an hour before it — and a second copy
-  /// of this parse is a second thing to get wrong.
-  Future<double?> _recommendedBedtimeMin() async {
+  /// Everything the reminder scheduler needs from the crossday rollup, in ONE
+  /// read: the Sleep Coach's recommended bedtime (local minutes past midnight,
+  /// or null when not yet learned) and the per-day `recent[]` rows the weekly
+  /// lookback's finding summarizes. Read in one place because three schedules
+  /// hang off it — check-in, wind-down, nightly sweep, weekly lookback — and
+  /// a second copy of this parse is a second thing to get wrong.
+  Future<({double? bedtimeMin, List<Map<String, dynamic>> recent})>
+      _readCrossdaySummary() async {
     try {
       final cd = await LocalDb.baseline('crossday');
       final m = cd?['payload_json'];
-      if (m is! String) return null;
+      if (m is! String) {
+        return (bedtimeMin: null, recent: const <Map<String, dynamic>>[]);
+      }
       final j = jsonDecode(m);
-      final bt = j is Map ? ((j['sleep_coach'] as Map?)?['bedtime']) : null;
+      if (j is! Map) {
+        return (bedtimeMin: null, recent: const <Map<String, dynamic>>[]);
+      }
+      final bt = (j['sleep_coach'] as Map?)?['bedtime'];
       final v = bt is Map ? bt['value'] : null;
-      return (v is Map ? (v['bedtime_min_of_day'] as num?) : null)?.toDouble();
+      final bedtime =
+          (v is Map ? (v['bedtime_min_of_day'] as num?) : null)?.toDouble();
+      // Same rows `DerivationEngine._runNotifications` consumes for the daily
+      // exception — {date, rhr, unsettled, illness, anomaly, temp}.
+      final rawRecent = j['recent'];
+      final recent = <Map<String, dynamic>>[
+        if (rawRecent is List)
+          for (final r in rawRecent)
+            if (r is Map) r.cast<String, dynamic>(),
+      ];
+      return (bedtimeMin: bedtime, recent: recent);
     } catch (_) {
-      return null; // no recommendation → the fixed fallback times
+      // No rollup → no learned bedtime and an empty week: every consumer has
+      // its own honest silence for that.
+      return (bedtimeMin: null, recent: const <Map<String, dynamic>>[]);
     }
   }
 

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1373,6 +1373,13 @@ class AppState extends ChangeNotifier {
     );
   }
 
+  /// Push a just-saved low-battery threshold into the device-alert pipeline.
+  /// DeviceAlerts restores its threshold once per process; without this a
+  /// change made in Settings would not apply until the next restart.
+  Future<void> refreshBatteryThreshold(NotificationPrefs prefs) async {
+    _deviceAlerts.refreshThreshold();
+  }
+
   /// Compute trigger: kick the DerivationEngine after data is persisted.
   /// [heavy]=false is the bounded light pass (TODAY when raw has reached today,
   /// else the latest pending day); [heavy]=true is the foreground finalize
@@ -2223,10 +2230,15 @@ class AppState extends ChangeNotifier {
       );
       // The strap-buzz half of the medication reminder, off the SAME schedule
       // read the OS dose slots above were armed from — one read feeds both
-      // surfaces. NULL defs (switch off, or the read threw) leaves the timer
-      // exactly as it is, matching the scheduler's own null-vs-empty rule:
-      // only an EMPTY list is an answer that may cancel what is standing.
-      if (meds.defs != null) {
+      // surfaces. Three answers, matching the scheduler's own rule: the
+      // switch OFF is an explicit choice and CLEARS the armed buzzes (a timer
+      // left standing would buzz for doses the user has muted); a real
+      // (possibly empty) schedule re-arms from it; only a FAILED read while
+      // enabled preserves, because cancelling would disarm doses that are
+      // still real.
+      if (!prefs.medsEnabled) {
+        _medBuzzer.configure(slotInstants: const []);
+      } else if (meds.defs != null) {
         final instants = <DateTime>[];
         for (final s in NotificationCenter.medPromptSlots(
             prefs, meds.defs!, meds.doses)) {

--- a/lib/ui2/profile/settings.dart
+++ b/lib/ui2/profile/settings.dart
@@ -773,6 +773,11 @@ class _NotificationSettingsState extends State<NotificationSettings> {
     // the water buzz is an in-memory timer, not an OS slot — re-arm it here or
     // the switch only takes effect at the next launch.
     if (mounted) await context.read<AppState>().armWaterReminder(next);
+    // the low-battery threshold is restored once per process — push the new
+    // value into the alert pipeline or it applies only after a restart.
+    if (mounted) {
+      await context.read<AppState>().refreshBatteryThreshold(next);
+    }
   }
 
   /// The one contextual moment left where prompting is honest: the user is
@@ -926,8 +931,8 @@ class NotificationSettingsView extends StatelessWidget {
                     // is that time, so there is no honest fallback.
                     SetRow(LucideIcons.moonStar, C.indigo, 'Wind-down',
                         sub: 'A heads-up about 45 minutes before the bedtime '
-                            'learned from your own nights. Appears after '
-                            'about a week of wear',
+                            'learned from your own nights, kept clear of your '
+                            'quiet hours. Appears after about a week of wear',
                         value: prefs.windDownEnabled ? 'On' : 'Off',
                         chevron: false,
                         onTap: () => set(prefs.copyWith(

--- a/lib/ui2/profile/settings.dart
+++ b/lib/ui2/profile/settings.dart
@@ -856,17 +856,38 @@ class NotificationSettingsView extends StatelessWidget {
                         chevron: false,
                         onTap: () => set(prefs.copyWith(
                             deviceEnabled: !prefs.deviceEnabled))),
-                    // Says what it DOES, which is nothing yet: every caller of
-                    // `scheduleStandingReminders` omits `weeklyFinding`, and
-                    // the lookback is armed only when one is passed — so the
-                    // row promised a Sunday notification no install has ever
-                    // received. The switch stays because it is the off switch
-                    // for the day something does write that finding.
+                    // The low-battery threshold, only while band alerts are
+                    // on — an interval for a muted alert is furniture, same
+                    // rule as the water row below.
+                    if (prefs.deviceEnabled)
+                      SetRow(LucideIcons.batteryLow, C.orange,
+                          'Alert me at',
+                          sub: 'Warn when the band drops under this charge '
+                              'level',
+                          value: '${prefs.batteryAlertPct}%',
+                          chevron: false,
+                          onTap: () => set(prefs.copyWith(
+                              batteryAlertPct:
+                                  _nextBatteryPct(prefs.batteryAlertPct)))),
+                    // The retained recovery-channel switch, now with a real
+                    // event behind it again: the morning "recovery is ready"
+                    // note. It was cut in the three-class cull and sat dead —
+                    // emitted, classified null, dropped.
+                    SetRow(LucideIcons.activity, C.green, 'Recovery ready',
+                        sub: 'One note when your morning recovery score '
+                            'lands',
+                        value: prefs.recoveryEnabled ? 'On' : 'Off',
+                        chevron: false,
+                        onTap: () => set(prefs.copyWith(
+                            recoveryEnabled: !prefs.recoveryEnabled))),
+                    // Says what it DOES now: the finding is computed from the
+                    // week's own crossday rollup (medical flags first, then a
+                    // plainly-stated resting-HR drift), and most weeks still
+                    // say nothing — which is the point.
                     SetRow(LucideIcons.calendarDays, C.purple,
                         'Weekly lookback',
-                        sub: 'Sunday evening, for a week that found something. '
-                            'Nothing writes that finding yet, so none has been '
-                            'sent',
+                        sub: 'Sunday evening, but only for a week that '
+                            'actually found something. Most weeks are quiet',
                         value: prefs.remindersEnabled ? 'On' : 'Off',
                         chevron: false,
                         onTap: () => set(prefs.copyWith(
@@ -887,15 +908,39 @@ class NotificationSettingsView extends StatelessWidget {
                     // Off by default, and it is the switch that lets the nudge
                     // be scheduled at all — see
                     // NotificationService.schedulableIds. It had none, so it
-                    // was refused there and had never once fired.
+                    // was refused there and had never once fired. Covers BOTH
+                    // sedentary surfaces: the OS-scheduled two-hour-still
+                    // one-shot, and the foreground desk-posture check (which
+                    // also buzzes the band when it fires).
                     SetRow(LucideIcons.footprints, C.orange, 'Movement nudge',
-                        sub: 'One notification after two hours with no '
-                            'movement at all, and only while the band is on '
-                            'and connected. Never inside 21:00–09:00',
+                        sub: 'Nudges you after a still stretch — two hours '
+                            'with no movement at all, or 90 minutes in a '
+                            'desk posture. Phone notification plus a buzz '
+                            'on the band while it is connected',
                         value: prefs.movementEnabled ? 'On' : 'Off',
                         chevron: false,
                         onTap: () => set(prefs.copyWith(
                             movementEnabled: !prefs.movementEnabled))),
+                    // The wind-down nudge. Silent until the Sleep Coach has
+                    // actually LEARNED a bedtime — the nudge's whole content
+                    // is that time, so there is no honest fallback.
+                    SetRow(LucideIcons.moonStar, C.indigo, 'Wind-down',
+                        sub: 'A heads-up about 45 minutes before the bedtime '
+                            'learned from your own nights. Appears after '
+                            'about a week of wear',
+                        value: prefs.windDownEnabled ? 'On' : 'Off',
+                        chevron: false,
+                        onTap: () => set(prefs.copyWith(
+                            windDownEnabled: !prefs.windDownEnabled))),
+                    // The step-goal achievement's off switch. On by default:
+                    // once a day at most, and only on a real crossing.
+                    SetRow(LucideIcons.trophy, C.orange, 'Step goal alerts',
+                        sub: 'Tells you once when today crosses your steps '
+                            'goal',
+                        value: prefs.stepGoalEnabled ? 'On' : 'Off',
+                        chevron: false,
+                        onTap: () => set(prefs.copyWith(
+                            stepGoalEnabled: !prefs.stepGoalEnabled))),
                     // The one prompt whose time is not a guess: it is the
                     // schedule already typed into the Medication tab. Only a
                     // dose still due is armed, and the notification names no
@@ -903,7 +948,8 @@ class NotificationSettingsView extends StatelessWidget {
                     // in the room.
                     SetRow(LucideIcons.pill, C.blue, 'Medication reminders',
                         sub: 'One notification per scheduled dose, at the '
-                            'times you entered. Nothing is sent for a dose '
+                            'times you entered — with a buzz on the band if '
+                            'it is connected. Nothing is sent for a dose '
                             'already marked taken or skipped',
                         value: prefs.medsEnabled ? 'On' : 'Off',
                         chevron: false,
@@ -1017,6 +1063,16 @@ class NotificationSettingsView extends StatelessWidget {
   static int _nextEvery(int min) {
     final i = waterEvery.indexWhere((e) => e.$1 == min);
     return waterEvery[(i + 1) % waterEvery.length].$1;
+  }
+
+  /// Low-battery alert thresholds, tapped through in place like [waterEvery].
+  /// Bounds match NotificationPrefs.batteryPctMin/Max, so every choice here is
+  /// one the pref will store unclamped.
+  static const batteryChoices = [10, 15, 20, 25, 30, 40];
+
+  static int _nextBatteryPct(int pct) {
+    final i = batteryChoices.indexOf(pct);
+    return batteryChoices[(i + 1) % batteryChoices.length];
   }
 
   static String _hhmm(int minuteOfDay) {

--- a/test/device_alerts_test.dart
+++ b/test/device_alerts_test.dart
@@ -18,6 +18,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openstrap_edge/notify/charge_alert_policy.dart';
 import 'package:openstrap_edge/notify/device_alerts.dart';
 import 'package:openstrap_edge/notify/notification_event.dart';
+import 'package:openstrap_edge/notify/notification_prefs.dart';
 import 'package:openstrap_edge/notify/notification_service.dart';
 
 class _Shown {
@@ -565,6 +566,37 @@ void main() {
       final a = alerts();
       a.onDeviceState(batteryPct: 12, charging: true, chargingTs: tsAged(2));
       await a.settled;
+      expect(sink.countOf(NotificationService.idLowBattery), 0);
+    });
+
+    test('a user threshold replaces the 15% default', () async {
+      // NotificationPrefs.batteryPctPrefKey is what the settings screen
+      // writes; DeviceAlerts reads it back through the same store seam on
+      // restore. At a 30% threshold, 20% is low — at the default it is not.
+      store.values[NotificationPrefs.batteryPctPrefKey] = 30;
+      final a = alerts();
+      a.onDeviceState(batteryPct: 20);
+      await a.settled;
+      expect(sink.countOf(NotificationService.idLowBattery), 1);
+
+      // Hysteresis rides the threshold too: re-arm at threshold+10 (=40
+      // here), so a climb to 40 re-arms and another dip under 30 fires again.
+      a.onDeviceState(batteryPct: 41);
+      await a.settled;
+      a.onDeviceState(batteryPct: 29);
+      await a.settled;
+      expect(sink.countOf(NotificationService.idLowBattery), 2);
+    });
+
+    test('a stored threshold above the hysteresis ceiling still clamps sane',
+        () async {
+      // Hand-edited or stale values cannot push the alert out of the range
+      // NotificationPrefs enforces on the write side either.
+      store.values[NotificationPrefs.batteryPctPrefKey] = 99;
+      final a = alerts();
+      a.onDeviceState(batteryPct: 45, charging: false, chargingTs: tsAged(2));
+      await a.settled;
+      // Clamped to batteryPctMax=40 → 45% is above it and must NOT fire.
       expect(sink.countOf(NotificationService.idLowBattery), 0);
     });
   });

--- a/test/med_buzzer_test.dart
+++ b/test/med_buzzer_test.dart
@@ -1,0 +1,104 @@
+// Tests for MedBuzzer — the strap-haptic half of the medication reminder.
+//
+// The OS notification is the half that actually reminds (it fires with no Dart
+// running); the buzz only works with a live link and a live isolate, so it is
+// best-effort by design. What is pinned here:
+//   • a connected band gets one buzz per slot, then the timer re-arms onward;
+//   • a disconnected band swallows the slot SILENTLY — a late buzz for a dose
+//     window that already passed is noise about a decision already made;
+//   • past slots handed to configure() are skipped, not fired late;
+//   • dispose() stops everything (the AppState teardown path).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/notify/med_buzzer.dart';
+
+class _Harness {
+  int buzzes = 0;
+  bool connected = true;
+  late MedBuzzer buzzer;
+
+  _Harness() {
+    buzzer = MedBuzzer(
+      buzz: () async => buzzes++,
+      isConnected: () => connected,
+    );
+  }
+}
+
+void main() {
+  test('fires once at the slot when the band is connected', () async {
+    final h = _Harness();
+    final at = DateTime.now().add(const Duration(milliseconds: 40));
+    h.buzzer.configure(slotInstants: [at]);
+
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+    expect(h.buzzes, 1);
+    h.buzzer.dispose();
+  });
+
+  test('a disconnected band misses the slot silently — no late buzz',
+      () async {
+    final h = _Harness()..connected = false;
+    h.buzzer
+        .configure(slotInstants: [DateTime.now().add(const Duration(milliseconds: 30))]);
+
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    expect(h.buzzes, 0);
+
+    // Reconnecting afterwards must not retro-fire: the slot was consumed.
+    h.connected = true;
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(h.buzzes, 0);
+    h.buzzer.dispose();
+  });
+
+  test('past slots are skipped, not fired late', () async {
+    final h = _Harness();
+    h.buzzer.configure(slotInstants: [
+      DateTime.now().subtract(const Duration(minutes: 90)),
+    ]);
+
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+    expect(h.buzzes, 0);
+    h.buzzer.dispose();
+  });
+
+  test('multiple slots fire in order, one buzz each', () async {
+    final h = _Harness();
+    final now = DateTime.now();
+    h.buzzer.configure(slotInstants: [
+      now.add(const Duration(milliseconds: 30)),
+      now.add(const Duration(milliseconds: 80)),
+    ]);
+
+    await Future<void>.delayed(const Duration(milliseconds: 160));
+    expect(h.buzzes, 2);
+    h.buzzer.dispose();
+  });
+
+  test('reconfigure replaces the pending schedule', () async {
+    final h = _Harness();
+    final now = DateTime.now();
+    h.buzzer.configure(slotInstants: [now.add(const Duration(milliseconds: 30))]);
+    // Before the first slot lands, re-arm to a later one. The old timer must
+    // be cancelled — otherwise both fire.
+    h.buzzer.configure(
+        slotInstants: [now.add(const Duration(milliseconds: 120))]);
+
+    await Future<void>.delayed(const Duration(milliseconds: 70));
+    expect(h.buzzes, 0, reason: 'old slot was superseded');
+    await Future<void>.delayed(const Duration(milliseconds: 110));
+    expect(h.buzzes, 1, reason: 'new slot fires exactly once');
+    h.buzzer.dispose();
+  });
+
+  test('dispose cancels the pending slot', () async {
+    final h = _Harness();
+    h.buzzer.configure(
+        slotInstants: [DateTime.now().add(const Duration(milliseconds: 30))]);
+    h.buzzer.dispose();
+
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    expect(h.buzzes, 0);
+  });
+}

--- a/test/notification_center_test.dart
+++ b/test/notification_center_test.dart
@@ -127,15 +127,28 @@ void main() {
     test('refuses everything else, including the ids either side of the band',
         () {
       for (final id in [
-        NotificationService.idWindDown,
+        // The AI journal prompt is STILL refused: the daily check-in owns
+        // that moment now, and two prompts for one journal is how people
+        // mute everything.
         NotificationService.idJournalLog,
-        NotificationService.idMorningBrief,
         NotificationService.idLowBattery,
         NotificationService.idWaterBase - 1,
         NotificationService.idWaterBase + NotificationService.maxWaterSlots,
       ]) {
         expect(NotificationService.maySchedule(id), isFalse, reason: '$id');
       }
+    });
+
+    test('wind-down and the morning briefing earned their places', () {
+      // Wind-down: armed only from a LEARNED bedtime behind its own switch
+      // (NotificationCenter.windDownSlot); morning brief: only for a BYOK user
+      // with their own AI morning switch on (aiReminderPlan).
+      expect(
+          NotificationService.maySchedule(NotificationService.idWindDown),
+          isTrue);
+      expect(
+          NotificationService.maySchedule(NotificationService.idMorningBrief),
+          isTrue);
     });
   });
 

--- a/test/notification_movement_gate_test.dart
+++ b/test/notification_movement_gate_test.dart
@@ -1,0 +1,93 @@
+// The gate contract for the sedentary/movement prompt (kRouteMovement).
+//
+// History this pins: the desk-posture check emitted for months on
+// reminders/low with a bare `/today` route — exactly the pair `classOf`
+// drops — so it never once reached a notification shade. It now rides
+// prompt class via a dedicated route, gated by `movementEnabled`. These
+// tests pin BOTH directions of that keying:
+//   • the movement route at normal priority gets through (when opted in);
+//   • nothing else on reminders-at-low/at-normal does — the deleted-nudges
+//     pair stays closed;
+//   • the movement switch actually stops the movement event;
+//   • a query-parameter payload (`?id=`) still matches, because every route
+//     comparison must go through routePath.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:openstrap_edge/notify/notification_event.dart';
+import 'package:openstrap_edge/notify/notification_prefs.dart';
+import 'package:openstrap_edge/notify/tap_router.dart';
+
+NotificationEvent movementEvent({NotifPriority priority = NotifPriority.normal,
+    String? route}) {
+  return NotificationEvent(
+    dedupeKey: '2026-08-22:posture:test',
+    category: NotifCategory.reminders,
+    priority: priority,
+    title: 'Time to move',
+    body: 'test',
+    date: '2026-8-22',
+    route: route ?? kRouteMovement,
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(const {});
+  });
+
+  group('classOf', () {
+    test('the movement prompt is a prompt', () {
+      expect(classOf(movementEvent()), NotifClass.prompt);
+      // An id-carrying payload resolves through routePath.
+      expect(
+          classOf(movementEvent(route: '$kRouteMovement?id=abc')),
+          NotifClass.prompt);
+    });
+
+    test('a low-priority event on the same route stays dropped', () {
+      // Priority is part of the sanction, same narrowing as the workout
+      // prompt got after its low-priority walk-through bug.
+      expect(classOf(movementEvent(priority: NotifPriority.low)), isNull);
+    });
+
+    test('other reminders events on the shared routes stay dropped', () {
+      NotificationEvent ev(String route) => NotificationEvent(
+            dedupeKey: '2026-08-22:x',
+            category: NotifCategory.reminders,
+            title: 'x',
+            body: '',
+            date: '2026-8-22',
+            route: route,
+          );
+      expect(classOf(ev('/today')), isNull);
+      expect(classOf(ev('/today/movementX')), isNull); // prefix games fail
+    });
+  });
+
+  group('shouldFireOs', () {
+    test('fires when movementEnabled is on, outside quiet hours', () async {
+      // OPT-IN: the shipped default has the switch off, which is exactly what
+      // the next test pins. Turn it on to assert the pass-through.
+      final prefs =
+          (await NotificationPrefs.load()).copyWith(movementEnabled: true);
+      final minuteOfDay = DateTime.now().hour * 60 + DateTime.now().minute;
+      if (!prefs.inQuietHours(minuteOfDay)) {
+        expect(prefs.shouldFireOs(movementEvent(), minuteOfDay), isTrue);
+      }
+    });
+
+    test("the movement switch stops the movement prompt", () async {
+      final prefs =
+          (await NotificationPrefs.load()).copyWith(movementEnabled: false);
+      expect(prefs.shouldFireOs(movementEvent(), 12 * 60), isFalse);
+    });
+
+    test('quiet hours still drop it — it is not the alarm', () async {
+      final prefs = await NotificationPrefs.load();
+      // Default quiet window opens at 22:00.
+      expect(prefs.shouldFireOs(movementEvent(), 23 * 60), isFalse);
+    });
+  });
+}

--- a/test/notification_wiring_test.dart
+++ b/test/notification_wiring_test.dart
@@ -1,0 +1,201 @@
+// Tests for the notification wiring pass: recovery-ready, step goal,
+// wind-down, and the weekly lookback finding.
+//
+// History this pins: three of these emitted correctly for months and never
+// reached anyone (recovery-ready on the dropped recovery channel; step-goal
+// on the dropped reminders/low pair), one had a slot no caller ever armed
+// (wind-down), and one had a schedule whose `weeklyFinding` parameter no
+// caller ever passed. Each test names the contract it now holds.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:openstrap_edge/notify/notification_center.dart';
+import 'package:openstrap_edge/notify/notification_event.dart';
+import 'package:openstrap_edge/notify/notification_prefs.dart';
+import 'package:openstrap_edge/notify/tap_router.dart';
+
+NotificationEvent _ev(NotifCategory c, NotifPriority p, String route) =>
+    NotificationEvent(
+      dedupeKey: '2026-08-22:test',
+      category: c,
+      priority: p,
+      title: 't',
+      body: 'b',
+      date: '2026-8-22',
+      route: route,
+    );
+
+Map<String, dynamic> _day({
+  required String date,
+  double? rhr,
+  bool unsettled = false,
+  bool illness = false,
+  bool anomaly = false,
+  bool temp = false,
+}) =>
+    {
+      'date': date,
+      'rhr': rhr,
+      'unsettled': unsettled,
+      'illness': illness,
+      'anomaly': anomaly,
+      'temp': temp,
+    };
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(const {});
+  });
+
+  group('recovery-ready classification', () {
+    test('the real payload is a prompt', () {
+      expect(
+          classOf(_ev(NotifCategory.recovery, NotifPriority.normal,
+              kRouteRecovery)),
+          NotifClass.prompt);
+    });
+
+    test('the channel alone stays closed — route is what opens it', () {
+      // A bare /today recovery event is exactly the dead emit this wiring
+      // replaces; it must stay null so nothing else rides the channel back.
+      expect(classOf(_ev(NotifCategory.recovery, NotifPriority.normal, '/today')),
+          isNull);
+      expect(
+          classOf(_ev(NotifCategory.recovery, NotifPriority.low, kRouteRecovery)),
+          isNull);
+    });
+
+    test("muted by the retained recoveryEnabled switch", () {
+      const off = NotificationPrefs(recoveryEnabled: false);
+      expect(
+          off.shouldFireOs(
+              _ev(NotifCategory.recovery, NotifPriority.normal,
+                  kRouteRecovery),
+              12 * 60),
+          isFalse);
+      const on = NotificationPrefs();
+      expect(
+          on.shouldFireOs(
+              _ev(NotifCategory.recovery, NotifPriority.normal,
+                  kRouteRecovery),
+              12 * 60),
+          isTrue);
+    });
+  });
+
+  group('step-goal classification', () {
+    test('the achievement is a prompt on its own route', () {
+      expect(
+          classOf(_ev(NotifCategory.reminders, NotifPriority.normal,
+              kRouteSteps)),
+          NotifClass.prompt);
+      // Low priority on the same route stays out — same narrowing the workout
+      // prompt got after its low-priority walk-through.
+      expect(
+          classOf(
+              _ev(NotifCategory.reminders, NotifPriority.low, kRouteSteps)),
+          isNull);
+    });
+
+    test('silenced by stepGoalEnabled, and by quiet hours like any prompt',
+        () {
+      const off = NotificationPrefs(stepGoalEnabled: false);
+      final e =
+          _ev(NotifCategory.reminders, NotifPriority.normal, kRouteSteps);
+      expect(off.shouldFireOs(e, 12 * 60), isFalse);
+      expect(const NotificationPrefs().shouldFireOs(e, 2 * 60), isFalse);
+    });
+  });
+
+  group('windDownSlot', () {
+    test('off switch wins', () {
+      expect(
+          NotificationCenter.windDownSlot(
+              const NotificationPrefs(windDownEnabled: false), 23 * 60),
+          isNull);
+    });
+
+    test('no LEARNED bedtime means silence — never a population fallback', () {
+      expect(
+          NotificationCenter.windDownSlot(
+              const NotificationPrefs(windDownEnabled: true), null),
+          isNull);
+    });
+
+    test('fires 45 minutes before the learned bedtime', () {
+      final t = NotificationCenter.windDownSlot(
+          const NotificationPrefs(windDownEnabled: true), 23 * 60 + 0.0);
+      expect(t, 22 * 60 + 15);
+    });
+
+    test('a bedtime that would land before midnight wraps sanely or refuses',
+        () {
+      // 00:20 bedtime → −25 min is not a real slot; refuse rather than arm
+      // 23:55 of the previous day's frame.
+      expect(
+          NotificationCenter.windDownSlot(
+              const NotificationPrefs(windDownEnabled: true), 20.0),
+          isNull);
+    });
+  });
+
+  group('weeklyLookbackFinding', () {
+    test('an empty week says nothing', () {
+      expect(NotificationCenter.weeklyLookbackFinding(const []), isNull);
+    });
+
+    test('unsettled nights are excluded from every count', () {
+      final f = NotificationCenter.weeklyLookbackFinding([
+        _day(date: 'a', illness: true, unsettled: true),
+        _day(date: 'b'),
+        _day(date: 'c'),
+      ]);
+      expect(f, isNull, reason: 'the only flagged night was unsettled');
+    });
+
+    test('medical flags are named, per kind', () {
+      final f = NotificationCenter.weeklyLookbackFinding([
+        _day(date: 'a', illness: true),
+        _day(date: 'b', illness: true),
+        _day(date: 'c', temp: true),
+        _day(date: 'd'),
+      ]);
+      expect(f, contains('possible illness onset ×2'));
+      expect(f, contains('elevated skin temperature ×1'));
+    });
+
+    test('a quiet week with stable RHR says nothing', () {
+      final f = NotificationCenter.weeklyLookbackFinding([
+        for (var i = 0; i < 7; i++) _day(date: '$i', rhr: 52.0),
+      ]);
+      expect(f, isNull);
+    });
+
+    test('a ≥3 bpm RHR drift is stated plainly, both directions', () {
+      final up = NotificationCenter.weeklyLookbackFinding([
+        _day(date: '1', rhr: 50), _day(date: '2', rhr: 51),
+        _day(date: '3', rhr: 52), _day(date: '4', rhr: 53),
+        _day(date: '5', rhr: 56), _day(date: '6', rhr: 57),
+        _day(date: '7', rhr: 58),
+      ]);
+      expect(up, contains('higher'));
+      final down = NotificationCenter.weeklyLookbackFinding([
+        _day(date: '1', rhr: 58), _day(date: '2', rhr: 57),
+        _day(date: '3', rhr: 56), _day(date: '4', rhr: 53),
+        _day(date: '5', rhr: 50), _day(date: '6', rhr: 49),
+        _day(date: '7', rhr: 48),
+      ]);
+      expect(down, contains('lower'));
+    });
+
+    test('too few RHR nights stays silent even if the drift looks big', () {
+      final f = NotificationCenter.weeklyLookbackFinding([
+        _day(date: '1', rhr: 50),
+        _day(date: '2', rhr: 58),
+        _day(date: '3', rhr: 50),
+      ]);
+      expect(f, isNull);
+    });
+  });
+}

--- a/test/notification_wiring_test.dart
+++ b/test/notification_wiring_test.dart
@@ -123,20 +123,29 @@ void main() {
           isNull);
     });
 
-    test('fires 45 minutes before the learned bedtime', () {
+    test('fires 45 minutes before the learned bedtime, when quiet allows',
+        () {
+      // Learned bedtime 23:00 → raw slot 22:15 lands INSIDE the default
+      // 22:00–07:00 quiet window, so it caps to half an hour before quiet
+      // opens (the check-in's own rule).
       final t = NotificationCenter.windDownSlot(
           const NotificationPrefs(windDownEnabled: true), 23 * 60 + 0.0);
+      expect(t, 21 * 60 + 30);
+    });
+
+    test('no quiet window means the true pre-bedtime slot', () {
+      final t = NotificationCenter.windDownSlot(
+          const NotificationPrefs(windDownEnabled: true, quietEnabled: false),
+          23 * 60 + 0.0);
       expect(t, 22 * 60 + 15);
     });
 
-    test('a bedtime that would land before midnight wraps sanely or refuses',
-        () {
-      // 00:20 bedtime → −25 min is not a real slot; refuse rather than arm
-      // 23:55 of the previous day's frame.
-      expect(
-          NotificationCenter.windDownSlot(
-              const NotificationPrefs(windDownEnabled: true), 20.0),
-          isNull);
+    test('a post-midnight bedtime wraps to the SAME evening', () {
+      // Bedtime 00:20 → raw −25 min → wrapped 23:35 → inside quiet → capped
+      // like any other late slot rather than disabling the feature.
+      final t = NotificationCenter.windDownSlot(
+          const NotificationPrefs(windDownEnabled: true), 20.0);
+      expect(t, 21 * 60 + 30);
     });
   });
 


### PR DESCRIPTION
### **User description**
## What this does

Eight notification features existed as code but never reached a user — dead emit sites dropped by the three-class gate, scheduled slots no caller armed, and plumbing with no producer. This wires them all, each with an honest off-switch.

### Was emitting, never fired (dropped by `classOf`)
- **Sedentary / desk-posture check** — emitted on reminders/low + bare `/today` (a deliberately dropped pair) since the day it was written: zero fires ever. Now prompt-class via dedicated `kRouteMovement`, behind the existing Movement-nudge switch, plus a strap haptic on a real present (the path only runs on live IMU, so the link is alive by construction).
- **Recovery ready** — recovery channel was where deleted nudges went; re-sanctioned via route keying (`kRouteRecovery`), muted by the retained `recoveryEnabled` switch. New settings row.
- **Step goal reached** — same mechanism (`kRouteSteps`), new `stepGoalEnabled` switch (on by default; once/day max), priority raised low→normal so prompt class applies.

### Existed only as unwired plumbing
- **Weekly lookback** — `scheduleStandingReminders(weeklyFinding:)` had no caller passing it; the settings row admitted no install ever received one. New pure `weeklyLookbackFinding()` over the crossday rollup's `recent[]`: medical flags per kind first, else a plainly-stated ≥3 bpm resting-HR drift (≥5 settled nights), else null — most Sundays stay silent, which is the contract. Fed by `_readCrossdaySummary()`, one crossday read for every schedule hanging off it.
- **Wind-down** — `idWindDown` was cancel-only. Now armed at learned-bedtime − 45 min, ONLY from a real Sleep-Coach bedtime (no population fallback — its whole content is that time), opt-in `windDownEnabled`, daily repeat with skip-today, tap lands on breathing.
- **Morning briefing OS slot** — `idMorningBrief` joins `schedulableIds`; `aiReminderPlan` already carried the gating (BYOK key + AI morning switch).

### New
- **Medication dose strap buzz** — `MedBuzzer` mirrors WaterBuzzer over absolute dose instants from the SAME `medPromptSlots` list the OS one-shots arm from (one read feeds both surfaces; null schedule preserves, empty cancels).
- **Configurable low-battery threshold** — replaces hardcoded 15%: `batteryAlertPct` pref (clamped 5–40), Settings row under Band alerts, read back by `DeviceAlerts` through its persisted store seam on headless updates; hysteresis rides the threshold (+10).

## Verification
- 20 new tests (`notification_wiring_test`) pin classification both directions, off-switches, quiet hours, wind-down math incl. midnight-wrap refusal, and weekly-finding thresholds; `med_buzzer_test` covers fire/skip/reconfigure/dispose; movement-gate + battery-threshold tests extended.
- Full suite green except the pre-existing environment-broken golden set (font rasterization; confirmed identical on pristine tree). `notification_settings` goldens additionally diverge because that screen gained three real rows — regenerate where the baseline lives, not on a machine whose goldens already fail.
- `flutter analyze` clean vs baseline.
- No analytics output changed → **no kAlgoVersion bump**.

## Design notes
- Route-keyed sanctions follow the workout-prompt precedent: opening the reminders/low or recovery *channel* wholesale would resurrect the nineteen deleted nudges; the route sanctions exactly one event each.
- Every new interrupt has a named off-switch in Settings — a notification the user cannot turn off is a bug.


___

### **PR Type**
Enhancement


___

### **Description**
- Wires up previously dormant notifications: sedentary/posture, medication buzz, recovery ready, step goal, wind-down, weekly lookback, and morning briefing.

- Adds best-effort strap haptics for medication doses and sedentary nudges, which fire only when the BLE link is active.

- Makes the low-battery alert threshold user-configurable (defaults to 15%) and adds hysteresis to prevent alert spam.

- Handles missing/thin data honestly: the wind-down nudge waits for a learned bedtime (no population fallback), and the weekly lookback stays silent without enough settled nights.

- Does not change any analytics output; `kAlgoVersion` was not bumped.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Prefs["NotificationPrefs"] --> AppState["AppState"]
  AppState --> MedBuzzer["MedBuzzer (Strap Haptics)"]
  AppState --> NotifCenter["NotificationCenter (OS Alerts)"]
  NotifCenter --> WindDown["Wind-down"]
  NotifCenter --> Weekly["Weekly Lookback"]
  NotifCenter --> Morning["Morning Briefing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>app.dart</strong><dd><code>Map new notification routes to the Home tab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20d">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notification_event.dart</strong><dd><code>Update classification to allow movement, recovery, and step goal </code><br><code>prompts</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-e76c67a939503e23296afc58fe71f6ce5de44949887aeefdffedb26b17461690">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notification_prefs.dart</strong><dd><code>Add preferences for battery threshold, step goal, and wind-down</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-270cabb974c762bec1bd9f3926d127b89d8250f300f331b8add7bb3d5e0e5490">+71/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notification_service.dart</strong><dd><code>Whitelist wind-down and morning briefing IDs for scheduling</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-67af22f84b6b4b271b1b4d15a7b075f31e1c4417f556d99c0c1cd63950f9f5a7">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tap_router.dart</strong><dd><code>Define dedicated routes for movement, recovery, and step goal </code><br><code>notifications</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-bfb8fabfd808f70cfde27c40ddd73d5224641440d63897f061723809244b3ba7">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>device_alerts.dart</strong><dd><code>Use configurable threshold and hysteresis for low battery alerts</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-240becf3d6bb44d1bd155dcb567166f167cd4944c7d437242f09b5dc06da6bd6">+30/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>med_buzzer.dart</strong><dd><code>Add MedBuzzer to trigger strap haptics for medication doses</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-feee2e0943765e4ddb2c075c69c0bb56f3b535683435ec84e6e9647c07906140">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notification_center.dart</strong><dd><code>Implement scheduling for wind-down, weekly lookback, and morning </code><br><code>briefing</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-96d0abea9986c4be17b8dcec21124dce6b5f35c734c97590faf6ae064833e472">+115/-11</a></td>

</tr>

<tr>
  <td><strong>app_state.dart</strong><dd><code>Integrate MedBuzzer and wire up step goal and posture check events</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-d56ba858e512e18dc3962da198adee46d354aca39ff7c1b4a11d5f19b9afc1ae">+99/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>settings.dart</strong><dd><code>Add UI settings rows for newly wired notifications and battery </code><br><code>threshold</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-9a570d74cb859a897fd63ade2f355175c3baf47e71182922e6bd62e03f78a00a">+70/-14</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>device_alerts_test.dart</strong><dd><code>Add tests for configurable battery threshold and hysteresis</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-5dbca7b29cb8cfa11cdaf9c43b87de39e731d7e75379068bd5e75d13bd073185">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>med_buzzer_test.dart</strong><dd><code>Add tests for MedBuzzer connection states and scheduling</code>&nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-68cb5e1b2988b26111d25ebdbae0b8d409ad35349a8a635a26f81164bd1e4f3d">+104/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>notification_center_test.dart</strong><dd><code>Add tests for wind-down and morning briefing scheduling permissions</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-376f3401f6b042d8ab9f68bcd3d7eee306fb3e6c656b879a528a2e9e2f571342">+15/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notification_movement_gate_test.dart</strong><dd><code>Add tests for movement notification classification and gating</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-e37e84e1c5f4d755fc3ed31a562cd9cde89314a24e578f15da5d6e669a0a8c5f">+93/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notification_wiring_test.dart</strong><dd><code>Add tests for recovery, step goal, wind-down, and weekly lookback </code><br><code>logic</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/276/files#diff-bad968c3fd6fe6fbd01f625430cb0aa706773f5a04f6b69ff8cd77aa6389ad6f">+201/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable low-battery alert thresholds with selectable percentages.
  - Added controls for wind-down, step-goal, and recovery-ready notifications.
  - Added movement, recovery, and step-goal notification links.
  - Added medication reminder band vibrations when connected.
  - Added wind-down reminders before bedtime and weekly health lookback findings.
  - Added desk-posture and prolonged-inactivity movement nudges.

- **Improvements**
  - Notification scheduling now respects saved preferences and avoids duplicate or inappropriate alerts.
  - Reminder delivery and battery alerts now behave more reliably across changing conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->