### PR TITLE
journal: bring back 'Track something else' (#273)

### DIFF
--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -7777,8 +7777,22 @@ class LocalDb {
     ];
   }
 
+  /// Create-only. A conflicting key THROWS instead of replacing: REPLACE
+  /// would silently rewrite another definition's metadata (label, unit, kind)
+  /// while its recorded history stayed — a field that means something else
+  /// wearing the old rows. The UI rejects duplicates before it gets here; the
+  /// throw is the race/programmatic-caller backstop.
   static Future<void> putJournalFieldDef(JournalFieldSpec spec) async {
     final db = await instance;
+    final exists = await db.query(
+      'journal_field_def',
+      where: 'key = ?',
+      whereArgs: [spec.key],
+      limit: 1,
+    );
+    if (exists.isNotEmpty) {
+      throw StateError('journal field already exists: ${spec.key}');
+    }
     await db.insert('journal_field_def', {
       'key': spec.key,
       'label': spec.label,
@@ -7788,7 +7802,7 @@ class LocalDb {
       'step': spec.step,
       'has_time': spec.hasTime ? 1 : 0,
       'created_at': DateTime.now().millisecondsSinceEpoch,
-    }, conflictAlgorithm: ConflictAlgorithm.replace);
+    });
   }
 
   // ── nap edits ─────────────────────────────────────────────────────────────

--- a/lib/ui2/screens/custom_journal_field_sheet.dart
+++ b/lib/ui2/screens/custom_journal_field_sheet.dart
@@ -61,6 +61,9 @@ class _CustomFieldSheetState extends State<_CustomFieldSheet> {
     setState(() {
       _kind = k;
       // Sensible shapes per kind, so the common case needs no further tapping.
+      // Every branch sets BOTH unit and time — otherwise a unit typed under
+      // one kind silently rides along when the kind changes.
+      const durStep = 15.0;
       switch (k) {
         case JournalFieldKind.rating:
           _max = 5;
@@ -70,10 +73,14 @@ class _CustomFieldSheetState extends State<_CustomFieldSheet> {
         case JournalFieldKind.dose:
           _max = 100;
           _step = 1;
+          _unitCtrl.text = '';
+          _hasTime = false;
         case JournalFieldKind.duration:
-          _max = 480;
-          _step = 15;
+          // A value the ceiling chips can actually produce (step x 20).
+          _step = durStep;
+          _max = durStep * 20;
           _unitCtrl.text = 'min';
+          _hasTime = false;
       }
     });
   }
@@ -87,8 +94,14 @@ class _CustomFieldSheetState extends State<_CustomFieldSheet> {
     final key = customJournalFieldKey(label);
     // A name that slugs to nothing ("???") would produce a bare `custom_`
     // key that every other such name also produces.
-    if (key == 'custom_') {
+    if (key == customJournalFieldKey('')) {
       setState(() => _error = 'Use at least one letter or number');
+      return;
+    }
+    // An amount with no unit renders as a bare number everywhere after —
+    // correlations, findings, CSV. Demand it up front.
+    if (_kind == JournalFieldKind.dose && _unitCtrl.text.trim().isEmpty) {
+      setState(() => _error = 'Say what it is counted in (mg, ml, cups…)');
       return;
     }
     if (widget.existingKeys.contains(key)) {
@@ -182,8 +195,14 @@ class _CustomFieldSheetState extends State<_CustomFieldSheet> {
                                 onTap: () => setState(() {
                                   _step = st;
                                   // The ceiling must stay above the step or
-                                  // the field can only ever hold 0.
-                                  if (_max < st) _max = st * 20;
+                                  // the field can only ever hold 0 — and it
+                                  // must be one of the chips below, or the
+                                  // selected state lies. Anything not an exact
+                                  // multiple of the new step snaps back to the
+                                  // step-derived default.
+                                  if (_max < st || _max % st != 0) {
+                                    _max = st * 20;
+                                  }
                                 }),
                                 child: Pill(
                                   st.round().toString(),

--- a/lib/ui2/screens/custom_journal_field_sheet.dart
+++ b/lib/ui2/screens/custom_journal_field_sheet.dart
@@ -1,0 +1,250 @@
+// "Track something else" — define a user-invented numeric journal field.
+//
+// Ported from the pre-ui2 journal (lib/ui/journal/custom_journal_field_sheet.dart,
+// lost in the UI rebuild — issue #273). A custom field has to declare what its
+// number MEANS: without a unit its values render as bare numbers, and without
+// a ceiling a mis-tap can enter a value that dominates every correlation it
+// appears in.
+
+import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../data/journal_fields.dart';
+import '../ui2.dart';
+import 'journal_compose.dart' show OsTextField;
+
+/// Opens the sheet. Returns the new field, or null if dismissed.
+///
+/// [existingKeys] are rejected on save so a second field cannot quietly
+/// overwrite the first one's history by colliding on the generated key.
+Future<JournalFieldSpec?> showCustomJournalFieldSheet(
+  BuildContext context, {
+  required Set<String> existingKeys,
+}) {
+  return showModalBottomSheet<JournalFieldSpec>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (ctx) => Padding(
+      // The sheet holds a text field; without this it sits under the keyboard.
+      padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(ctx).bottom),
+      child: _CustomFieldSheet(existingKeys: existingKeys),
+    ),
+  );
+}
+
+class _CustomFieldSheet extends StatefulWidget {
+  const _CustomFieldSheet({required this.existingKeys});
+  final Set<String> existingKeys;
+
+  @override
+  State<_CustomFieldSheet> createState() => _CustomFieldSheetState();
+}
+
+class _CustomFieldSheetState extends State<_CustomFieldSheet> {
+  final _nameCtrl = TextEditingController();
+  final _unitCtrl = TextEditingController();
+  JournalFieldKind _kind = JournalFieldKind.rating;
+  double _max = 5;
+  double _step = 1;
+  bool _hasTime = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    _unitCtrl.dispose();
+    super.dispose();
+  }
+
+  void _selectKind(JournalFieldKind k) {
+    setState(() {
+      _kind = k;
+      // Sensible shapes per kind, so the common case needs no further tapping.
+      switch (k) {
+        case JournalFieldKind.rating:
+          _max = 5;
+          _step = 1;
+          _unitCtrl.text = '';
+          _hasTime = false;
+        case JournalFieldKind.dose:
+          _max = 100;
+          _step = 1;
+        case JournalFieldKind.duration:
+          _max = 480;
+          _step = 15;
+          _unitCtrl.text = 'min';
+      }
+    });
+  }
+
+  void _save() {
+    final label = _nameCtrl.text.trim();
+    if (label.isEmpty) {
+      setState(() => _error = 'Give it a name');
+      return;
+    }
+    final key = customJournalFieldKey(label);
+    // A name that slugs to nothing ("???") would produce a bare `custom_`
+    // key that every other such name also produces.
+    if (key == 'custom_') {
+      setState(() => _error = 'Use at least one letter or number');
+      return;
+    }
+    if (widget.existingKeys.contains(key)) {
+      setState(() => _error = 'You already track something by that name');
+      return;
+    }
+    Navigator.pop(
+      context,
+      JournalFieldSpec(
+        key: key,
+        label: label,
+        kind: _kind,
+        unit: _kind == JournalFieldKind.rating ? '' : _unitCtrl.text.trim(),
+        max: _max,
+        step: _step,
+        hasTime: _hasTime,
+        custom: true,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext c) {
+    final p = P.of(c);
+    return SafeArea(
+      top: false,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.sizeOf(c).height * 0.85,
+        ),
+        child: Surface(
+          pad: const EdgeInsets.all(S.x5),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Track something else',
+                style: F.head.copyWith(color: p.ink),
+              ),
+              const SizedBox(height: S.x4),
+              Flexible(
+                child: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      OsTextField(
+                        controller: _nameCtrl,
+                        label: 'What do you want to track?',
+                        hint: 'Magnesium, screen time, headache…',
+                      ),
+                      const SizedBox(height: S.x4),
+                      Text('What kind of number is it?',
+                          style: F.cap.copyWith(color: p.ink3)),
+                      const SizedBox(height: S.x2),
+                      Wrap(
+                        spacing: S.x2,
+                        runSpacing: S.x2,
+                        children: [
+                          for (final (kind, chipLabel) in const [
+                            (JournalFieldKind.rating, 'A 1–5 rating'),
+                            (JournalFieldKind.dose, 'An amount'),
+                            (JournalFieldKind.duration, 'Minutes'),
+                          ])
+                            Pressable(
+                              onTap: () => _selectKind(kind),
+                              child: Pill(
+                                chipLabel,
+                                _kind == kind ? C.domMind : C.n400,
+                                icon: _kind == kind ? LucideIcons.check : null,
+                              ),
+                            ),
+                        ],
+                      ),
+                      if (_kind != JournalFieldKind.rating) ...[
+                        const SizedBox(height: S.x4),
+                        OsTextField(
+                          controller: _unitCtrl,
+                          label: 'Unit',
+                          hint: 'mg, ml, cups…',
+                        ),
+                        const SizedBox(height: S.x4),
+                        Text('Step size', style: F.cap.copyWith(color: p.ink3)),
+                        const SizedBox(height: S.x2),
+                        Wrap(
+                          spacing: S.x2,
+                          runSpacing: S.x2,
+                          children: [
+                            for (final st in const [1.0, 5.0, 15.0, 50.0, 100.0])
+                              Pressable(
+                                onTap: () => setState(() {
+                                  _step = st;
+                                  // The ceiling must stay above the step or
+                                  // the field can only ever hold 0.
+                                  if (_max < st) _max = st * 20;
+                                }),
+                                child: Pill(
+                                  st.round().toString(),
+                                  _step == st ? C.domMind : C.n400,
+                                ),
+                              ),
+                          ],
+                        ),
+                        const SizedBox(height: S.x4),
+                        Text('Most you would log in a day',
+                            style: F.cap.copyWith(color: p.ink3)),
+                        const SizedBox(height: S.x2),
+                        Wrap(
+                          spacing: S.x2,
+                          runSpacing: S.x2,
+                          children: [
+                            for (final m in [
+                              _step * 10,
+                              _step * 20,
+                              _step * 50,
+                              _step * 100,
+                            ])
+                              Pressable(
+                                onTap: () => setState(() => _max = m),
+                                child: Pill(
+                                  m.round().toString(),
+                                  _max == m ? C.domMind : C.n400,
+                                ),
+                              ),
+                          ],
+                        ),
+                        const SizedBox(height: S.x4),
+                        Pressable(
+                          onTap: () =>
+                              setState(() => _hasTime = !_hasTime),
+                          child: Pill(
+                            'Ask when the last one was',
+                            _hasTime ? C.domMind : C.n400,
+                            icon: _hasTime ? LucideIcons.check : null,
+                          ),
+                        ),
+                      ],
+                      if (_error != null) ...[
+                        const SizedBox(height: S.x3),
+                        Text(_error!, style: F.cap.copyWith(color: C.red)),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: S.x4),
+              BigButton(
+                'Start tracking it',
+                icon: LucideIcons.check,
+                color: C.domMind,
+                onTap: _save,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui2/screens/journal_compose.dart
+++ b/lib/ui2/screens/journal_compose.dart
@@ -100,8 +100,27 @@ class _JournalComposeState extends State<JournalCompose> {
     );
     if (spec == null || !mounted) return;
     final repo = context.read<AppState>().repo;
-    if (repo == null) return;
-    await repo.postCustomJournalField(spec);
+    // No repo means the sheet should never have been reachable; say so rather
+    // than eating the tap.
+    if (repo == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Not ready yet — open the app first.')),
+      );
+      return;
+    }
+    try {
+      await repo.postCustomJournalField(spec);
+    } catch (_) {
+      if (!mounted) return;
+      // A failed persist must not read as success — the field would vanish
+      // from the list while the user believes it saved.
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text('Could not save it — check storage and retry.')),
+      );
+      return;
+    }
+    if (!mounted) return;
     await _load();
   }
 

--- a/lib/ui2/screens/journal_compose.dart
+++ b/lib/ui2/screens/journal_compose.dart
@@ -21,6 +21,7 @@ import '../../state/app_state.dart';
 import '../../state/units_controller.dart';
 import '../ui2.dart';
 import 'home_screen.dart' show unitsOf;
+import 'custom_journal_field_sheet.dart';
 import 'metric_detail.dart' show detailScaffold;
 
 class JournalCompose extends StatefulWidget {
@@ -89,6 +90,19 @@ class _JournalComposeState extends State<JournalCompose> {
         );
       }
     });
+  }
+
+  /// #273 — define + persist a user-invented field, then pick it up.
+  Future<void> _addField() async {
+    final spec = await showCustomJournalFieldSheet(
+      context,
+      existingKeys: _specs.map((f) => f.key).toSet(),
+    );
+    if (spec == null || !mounted) return;
+    final repo = context.read<AppState>().repo;
+    if (repo == null) return;
+    await repo.postCustomJournalField(spec);
+    await _load();
   }
 
   /// MT-06 — when the LAST one landed.
@@ -178,6 +192,23 @@ class _JournalComposeState extends State<JournalCompose> {
                                           ? () => _setTime(s.key)
                                           : null,
                                     ),
+                                  // #273 — custom fields come back. The old
+                                  // UI's "Track something else": define a
+                                  // personal numeric field and it behaves
+                                  // like a built-in everywhere after.
+                                  Pressable(
+                                    onTap: _addField,
+                                    child: Row(
+                                      children: [
+                                        Icon(LucideIcons.plusCircle,
+                                            size: 18, color: p.ink3),
+                                        const SizedBox(width: S.x2),
+                                        Text('Track something else',
+                                            style:
+                                                F.body.copyWith(color: p.ink3)),
+                                      ],
+                                    ),
+                                  ),
                               ],
                             ),
                           ),

--- a/lib/ui2/screens/journal_compose.dart
+++ b/lib/ui2/screens/journal_compose.dart
@@ -9,6 +9,8 @@
 // the ceiling exists so one mis-tap cannot enter forty coffees and dominate
 // every correlation that field appears in for months.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
@@ -92,8 +94,11 @@ class _JournalComposeState extends State<JournalCompose> {
     });
   }
 
+  bool _addingField = false;
+
   /// #273 — define + persist a user-invented field, then pick it up.
   Future<void> _addField() async {
+    if (_addingField) return;
     final spec = await showCustomJournalFieldSheet(
       context,
       existingKeys: _specs.map((f) => f.key).toSet(),
@@ -108,6 +113,7 @@ class _JournalComposeState extends State<JournalCompose> {
       );
       return;
     }
+    setState(() => _addingField = true);
     try {
       await repo.postCustomJournalField(spec);
     } catch (_) {
@@ -122,6 +128,7 @@ class _JournalComposeState extends State<JournalCompose> {
     }
     if (!mounted) return;
     await _load();
+    if (mounted) setState(() => _addingField = false);
   }
 
   /// MT-06 — when the LAST one landed.
@@ -216,7 +223,12 @@ class _JournalComposeState extends State<JournalCompose> {
                                   // personal numeric field and it behaves
                                   // like a built-in everywhere after.
                                   Pressable(
-                                    onTap: _addField,
+                                    // Disabled (null onTap) while a write is
+                                    // in flight: two submits would race the
+                                    // create-only insert below.
+                                    onTap: _addingField
+                                        ? null
+                                        : () => unawaited(_addField()),
                                     child: Row(
                                       children: [
                                         Icon(LucideIcons.plusCircle,

--- a/lib/ui2/screens/wellness_screen.dart
+++ b/lib/ui2/screens/wellness_screen.dart
@@ -641,17 +641,28 @@ class _WellnessScreenState extends State<WellnessScreen> with RevisionReload {
     if (name == null || name.isEmpty || !mounted) return;
     final repo = context.read<AppState>().repo;
     if (repo == null) return;
-    await repo.postCustomJournalField(
-      JournalFieldSpec(
-        key: customJournalFieldKey(name),
-        label: name,
-        kind: JournalFieldKind.rating,
-        unit: '',
-        max: 1,
-        step: 1,
-        custom: true,
-      ),
-    );
+    try {
+      await repo.postCustomJournalField(
+        JournalFieldSpec(
+          key: customJournalFieldKey(name),
+          label: name,
+          kind: JournalFieldKind.rating,
+          unit: '',
+          max: 1,
+          step: 1,
+          custom: true,
+        ),
+      );
+    } on StateError catch (_) {
+      // putJournalFieldDef is create-only now — a duplicate lands here
+      // instead of silently rewriting the first one's definition.
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('You already track "$name".')),
+        );
+        return;
+      }
+    }
     await _load();
   }
 


### PR DESCRIPTION
### **User description**
## What

Restores custom journal fields in the new UI — closes #273.

## Why it broke
The ui2 rebuild deleted `lib/ui/journal/` wholesale, taking the only door to custom fields with it. The backend survived untouched: `journal_field_def`, `getJournalFields()` merging defs into the spec list, and `postCustomJournalField`/`deleteCustomJournalField` on the repo seam. So 0.9.27 users could no longer define a personal field, and existing custom fields silently stopped being *creatable* (previously defined ones still render via the spec list).

## Changes
- Port `custom_journal_field_sheet.dart` into ui2: name → kind (1–5 rating / amount / minutes) → unit, step size, daily ceiling, optional 'ask when the last one was' — with the original guards kept (collision on generated key, empty-slug rejection).
- `JournalCompose`: a **'Track something else'** row under the field list; saving posts the spec and reloads, so the new field appears immediately in the Today section and behaves like a built-in everywhere after (dose–response findings, weekday effects, CSV export).
- Long-press removal of custom fields rides the existing Wellness > Habits delete path (`deleteCustomJournalField` keeps recorded values by design) — unchanged here.

## Verification
- `flutter analyze` clean; journal field/store/wellness widget tests green (34+).
- Sheet validates empty name, empty slug ('???'), and duplicate names against existing keys.

Closes #273.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Restores the "Track something else" feature in the new UI, allowing users to create custom journal fields.

- Introduces a bottom sheet to configure custom fields, including type (rating, amount, minutes), unit, step size, and daily ceiling.

- Adds validation to prevent duplicate field keys and empty or invalid names.

- Saves the new field specification to the local database and immediately reloads the journal compose screen.

- Note: This PR changes user-visible behavior but adds no new tests under `test/`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  JournalCompose["Journal Compose Screen"] -- "Taps 'Track something else'" --> CustomSheet["Custom Field Sheet"]
  CustomSheet -- "Validates & Returns Spec" --> JournalCompose
  JournalCompose -- "Saves to Repo" --> LocalDb["Local Database"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>custom_journal_field_sheet.dart</strong><dd><code>Add custom journal field creation sheet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/ui2/screens/custom_journal_field_sheet.dart

<ul><li>Adds <code>showCustomJournalFieldSheet</code> to display a bottom sheet for <br>creating custom journal fields.<br> <li> Implements UI for selecting field kind (rating, dose, duration), unit, <br>step size, and daily maximum.<br> <li> Includes validation logic to reject empty names, invalid slugs, and <br>duplicate keys.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/278/files#diff-d22af781b2b6748768074fdad7b05b09225c391bcc73da42d0694f0dd123743d">+250/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>journal_compose.dart</strong><dd><code>Integrate custom field creation button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/ui2/screens/journal_compose.dart

<ul><li>Adds a "Track something else" button at the bottom of the journal <br>fields list.<br> <li> Implements <code>_addField</code> to open the custom field sheet and handle the <br>result.<br> <li> Persists the new field via <code>repo.postCustomJournalField</code> and reloads the <br>UI.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/278/files#diff-25c126caa40a11dc6ae1179db6eceac47eb8f8d420fce766da0418e2da429655">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to create custom journal fields.
  * Configure field name, type, unit, step size, daily maximum, and optional last-entry prompts.
  * Added a “Track something else” option to the journal compose screen.
  * Custom fields are validated and saved, with clear feedback for invalid or unavailable configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->