### PR TITLE
Opt-in auto-import of Health workouts

### DIFF
--- a/lib/health/auto_workout_import.dart
+++ b/lib/health/auto_workout_import.dart
@@ -82,7 +82,7 @@ class AutoWorkoutImport {
     try {
       final now = (nowFn ?? DateTime.now)();
       final prefs = await SharedPreferences.getInstance();
-      final enabled = prefs.getBool(kAutoWorkoutImportPref) ?? false;
+      final enabled = await isEnabled();
       final lastMs = prefs.getInt(kAutoWorkoutImportLastMs);
       // NON-PROMPTING probe: hasPermissions only. A denied/undecided store
       // means the user has not approved auto reads yet — the manual button's

--- a/lib/health/auto_workout_import.dart
+++ b/lib/health/auto_workout_import.dart
@@ -61,10 +61,14 @@ enum AutoImportOutcome {
 class AutoWorkoutImport {
   AutoWorkoutImport._();
 
+  /// DEFAULT ON. The sweep is pull-based, silent and throttled to one read
+  /// per hour; until the user grants WORKOUT access (one tap on the refresh
+  /// button) it does nothing at all, so there is no consent reason to ship
+  /// it off.
   static Future<bool> isEnabled() async =>
       (await SharedPreferences.getInstance())
           .getBool(kAutoWorkoutImportPref) ??
-      false;
+      true;
 
   static Future<void> setEnabled(bool on) async =>
       (await SharedPreferences.getInstance()).setBool(kAutoWorkoutImportPref, on);

--- a/lib/health/auto_workout_import.dart
+++ b/lib/health/auto_workout_import.dart
@@ -1,0 +1,115 @@
+// auto_workout_import.dart — opt-in background bring-in of Health workouts.
+//
+// The manual Import button asks permission ON THE TAP and then reads the
+// source's whole shareable window, replacing by uuid (a second pass updates
+// rows instead of stacking copies — see HealthWorkoutImporter.sync). That is
+// the right shape for a button and the wrong shape for a background job:
+// nothing may prompt from a cadence pass, and an unconditional read on every
+// drain is exactly the churn the battery audit removed elsewhere.
+//
+// So auto-import is:
+//   • OPT-IN, off by default — same rule as every outbound path in this app.
+//     The switch lives next to the manual Import button; turning it ON is a
+//     user tap, so THAT is the moment permission may be asked.
+//   • NON-PROMPTING thereafter — a cadence pass only reads when the store
+//     already granted WORKOUT read (checked without prompting). Until one
+//     manual import has been approved, auto-import silently does nothing.
+//   • THROTTLED — at most one full-window read per hour (see
+//     [kAutoWorkoutImportInterval]); a zero-row read still stamps the
+//     attempt, or a store that holds nothing would be re-read on every
+//     foreground pass.
+//   • BEST-EFFORT — never throws into the caller; failures just leave the
+//     manual button as the fallback it always was.
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'health_import_state.dart';
+import 'health_workout_import.dart';
+
+const String kAutoWorkoutImportPref = 'health_auto_import_workouts';
+const String kAutoWorkoutImportLastMs = 'health_auto_import_last_ms';
+
+/// How often auto-import may do a full-window read. Workouts are not a
+/// live metric; an hour keeps the store load trivial while a finished run
+/// lands the next time the app comes to the foreground.
+const Duration kAutoWorkoutImportInterval = Duration(hours: 1);
+
+/// The decision, PURE — everything the runner needs to have already checked.
+bool shouldAutoImport({
+  required bool enabled,
+  required bool permissionGranted,
+  required DateTime? lastAttempt,
+  required DateTime now,
+  Duration interval = kAutoWorkoutImportInterval,
+}) {
+  if (!enabled || !permissionGranted) return false;
+  if (lastAttempt == null) return true;
+  return now.difference(lastAttempt) >= interval;
+}
+
+enum AutoImportOutcome {
+  /// The switch is off (or the store was never granted) — nothing ran.
+  skipped,
+
+  /// Inside [kAutoWorkoutImportInterval] of the last attempt.
+  throttled,
+
+  /// A read ran; [workouts] says what came in.
+  ran,
+}
+
+class AutoWorkoutImport {
+  AutoWorkoutImport._();
+
+  static Future<bool> isEnabled() async =>
+      (await SharedPreferences.getInstance())
+          .getBool(kAutoWorkoutImportPref) ??
+      false;
+
+  static Future<void> setEnabled(bool on) async =>
+      (await SharedPreferences.getInstance()).setBool(kAutoWorkoutImportPref, on);
+
+  /// Runs the auto path. Safe to call unawaited from anywhere; returns what
+  /// happened for callers that surface it.
+  static Future<AutoImportOutcome> maybeRun({
+    HealthWorkoutImporter? importer,
+    DateTime Function()? nowFn,
+  }) async {
+    try {
+      final now = (nowFn ?? DateTime.now)();
+      final prefs = await SharedPreferences.getInstance();
+      final enabled = prefs.getBool(kAutoWorkoutImportPref) ?? false;
+      final lastMs = prefs.getInt(kAutoWorkoutImportLastMs);
+      // NON-PROMPTING probe: hasPermissions only. A denied/undecided store
+      // means the user has not approved auto reads yet — the manual button's
+      // tap is where that question gets asked, never here.
+      if (!enabled) return AutoImportOutcome.skipped;
+      final granted = await (importer ?? HealthWorkoutImporter())
+          .hasReadPermission();
+      // An ungranted store is SKIPPED, not throttled: it is waiting on one
+      // manual tap to grant access, not on the clock.
+      if (!granted) return AutoImportOutcome.skipped;
+      final throttled = !shouldAutoImport(
+        enabled: true,
+        permissionGranted: true,
+        lastAttempt: lastMs == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(lastMs),
+        now: now,
+      );
+      if (throttled) return AutoImportOutcome.throttled;
+      await prefs.setInt(
+          kAutoWorkoutImportLastMs, now.millisecondsSinceEpoch);
+      final res = await (importer ?? HealthWorkoutImporter()).sync();
+      // Only a read that actually brought rows advances the IMPORTED cursor —
+      // same rule as the button: marking a zero/denied read as done would put
+      // the UI to sleep on someone who said no.
+      if (res.workouts > 0) {
+        await markImported(HealthImport.workouts);
+      }
+      return AutoImportOutcome.ran;
+    } catch (_) {
+      return AutoImportOutcome.skipped;
+    }
+  }
+}

--- a/lib/health/health_workout_import.dart
+++ b/lib/health/health_workout_import.dart
@@ -226,6 +226,20 @@ class HealthWorkoutImporter {
 
   bool get routesSupported => _isApple;
 
+  /// NON-PROMPTING read-permission probe for the auto path: true only when
+  /// the store already granted WORKOUT read. Never shows a dialog — the
+  /// manual Import button's tap is the only place that question gets asked.
+  Future<bool> hasReadPermission() async {
+    try {
+      await _health.configure();
+      return await _health.hasPermissions(types,
+              permissions: [for (final _ in types) HealthDataAccess.READ]) ==
+          true;
+    } catch (_) {
+      return false;
+    }
+  }
+
   Future<bool> requestPermission() async {
     try {
       await _health.configure();

--- a/lib/health/health_workout_import.dart
+++ b/lib/health/health_workout_import.dart
@@ -40,6 +40,7 @@ import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:health/health.dart';
 
 import '../data/db.dart';
@@ -213,6 +214,23 @@ class WorkoutImportResult {
   final bool routesSupported;
 }
 
+const String _kTombstonesPref = 'health_workout_import_deleted';
+
+/// Health-store workout uuids the user has DELETED here. The source still has
+/// them, so without this list the next import would bring each one back.
+Future<Set<String>> deletedUuids() async {
+  final prefs = await SharedPreferences.getInstance();
+  return {...(prefs.getStringList(_kTombstonesPref) ?? const [])};
+}
+
+Future<void> rememberDeletedUuid(String uuid) async {
+  final prefs = await SharedPreferences.getInstance();
+  final set = await deletedUuids();
+  if (set.contains(uuid)) return;
+  await prefs.setStringList(_kTombstonesPref, [...set, uuid]);
+}
+
+
 class HealthWorkoutImporter {
   HealthWorkoutImporter({Health? health, bool? isApple})
       : _health = health ?? Health(),
@@ -279,8 +297,16 @@ class HealthWorkoutImporter {
     if (rows.isEmpty) {
       return WorkoutImportResult(routesSupported: routesSupported);
     }
-    await LocalDb.putImportedWorkouts([for (final r in rows) r.toRow()]);
-    final withRoutes = await _importRoutes(start, end);
+    // A workout the user DELETED must not resurrect on the next read: the
+    // uuid goes onto a tombstone list at delete time, and anything on it is
+    // dropped here (workout row AND its route) before it can come back.
+    final tombstones = await deletedUuids();
+    final alive = [
+      for (final r in rows)
+        if (!tombstones.contains(r.uuid)) r,
+    ];
+    await LocalDb.putImportedWorkouts([for (final r in alive) r.toRow()]);
+    final withRoutes = await _importRoutes(start, end, skip: tombstones);
     return WorkoutImportResult(
       workouts: rows.length,
       withRoutes: withRoutes,
@@ -294,7 +320,8 @@ class HealthWorkoutImporter {
   /// One call rather than one per workout: each `HKWorkoutRoute` query is an
   /// async round trip, and 90 days of running is a lot of them to serialise
   /// across the channel one at a time.
-  Future<int> _importRoutes(DateTime start, DateTime end) async {
+  Future<int> _importRoutes(DateTime start, DateTime end,
+      {Set<String> skip = const {}}) async {
     if (!routesSupported) return 0;
     List<Object?> payload;
     try {
@@ -317,6 +344,7 @@ class HealthWorkoutImporter {
       if (entry is! Map) continue;
       final uuid = entry['uuid'];
       if (uuid is! String || uuid.isEmpty) continue;
+      if (skip.contains(uuid)) continue;
       final rows = routeRowsFrom(entry);
       if (rows.isEmpty) continue;
       await LocalDb.appendRoutePoints(uuid, rows);

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -70,6 +70,7 @@ import '../notify/notification_center.dart';
 import '../notify/notification_event.dart';
 import '../notify/notification_prefs.dart';
 import '../gestures/gesture_settings.dart';
+import '../health/auto_workout_import.dart';
 import '../health/health_export.dart';
 import '../health/phone_pedometer.dart';
 import '../import/noop_import.dart';
@@ -1614,6 +1615,11 @@ class AppState extends ChangeNotifier {
       await _ensureRemindersScheduled();
       await _maybeNotifyStepGoal();
       await _maybeNotifyInactivity();
+      // Opt-in auto-import of Health workouts (off by default; self-gates on
+      // permission + a 1 h throttle — see AutoWorkoutImport). Foreground
+      // cadence is the trigger: workouts are not live data, and this never
+      // prompts.
+      unawaited(AutoWorkoutImport.maybeRun());
       await _maybeGenerateBriefing();
       unawaited(_checkSchemaHealth()); // throttled internally to 24h
       // Staleness-escalation meta-layer: the SAME check the headless path

--- a/lib/ui2/screens/workout_screen.dart
+++ b/lib/ui2/screens/workout_screen.dart
@@ -593,60 +593,47 @@ class _WorkoutScreenState extends State<WorkoutScreen> with RevisionReload {
     return [
       Surface(
         child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          Text(
-            'Runs, rides and sessions recorded by another app or watch'
-            '${isAppleHealth ? ', with their routes' : ''}. Each one is '
-            'listed above with the app or watch that recorded it named on it.',
-            style: F.cap.copyWith(color: p.ink3, height: 1.5),
-          ),
-          if (!isAppleHealth) ...[
-            const SizedBox(height: S.x3),
-            Text(
-              // Said before the button rather than discovered afterwards, when
-              // a map fails to appear and reads as a bug.
-              'Routes are not included on Android. Health Connect keeps them '
-              'behind a separate, restricted permission this app has not '
-              'applied for, so the workouts arrive without coordinates.',
-              style: F.cap.copyWith(color: p.ink3, height: 1.5),
-            ),
-          ],
-          const SizedBox(height: S.x4),
-          BigButton(
-            importLabel(d.importedLast),
-            icon: LucideIcons.smartphone,
-            color: C.domMove,
-            soft: true,
-            onTap: _importing ? null : _importWorkouts,
-          ),
-          const SizedBox(height: S.x3),
-          // #? — auto-import, opt-in. The switch turning ON is a user tap, so
-          // THAT moment may ask for permission; every later run is silent and
-          // throttled (see AutoWorkoutImport).
+          // ONE ROW, not a card with paragraphs: tick = auto-import sweeps
+          // about once an hour while you use the app; the refresh icon
+          // fetches NOW. The refresh tap is the only thing that ever
+          // prompts for access — after that grant the tick works silently.
           Surface(
-            pad: const EdgeInsets.symmetric(horizontal: S.x4, vertical: S.x2),
+            pad: const EdgeInsets.symmetric(horizontal: S.x4),
             child: Row(
               children: [
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text('Auto-import workouts',
-                          style: F.body.copyWith(
-                              color: p.ink, fontWeight: FontWeight.w600)),
-                      Text(
-                        'Brings in workouts from $storeName about once an '
-                        'hour while you use the app. Needs one manual '
-                        'import first to grant access.',
-                        style: F.cap.copyWith(color: p.ink3, height: 1.4),
-                      ),
-                    ],
+                Pressable(
+                  semanticLabel: _autoImport
+                      ? 'Auto-import on. Tap to turn off.'
+                      : 'Auto-import off. Tap to turn on.',
+                  onTap: () => _setAutoImport(!_autoImport),
+                  child: Icon(
+                    _autoImport
+                        ? LucideIcons.circleCheckBig
+                        : LucideIcons.circle,
+                    size: 22,
+                    color: _autoImport ? p.on(C.domMove) : p.ink3,
                   ),
                 ),
-                Switch(
-                  value: _autoImport,
-                  activeThumbColor: p.on(C.domMove),
-                  activeTrackColor: p.fill(C.domMove),
-                  onChanged: (v) => _setAutoImport(v),
+                const SizedBox(width: S.x3),
+                Expanded(
+                  child: Text('Import from \$storeName',
+                      style: F.body.copyWith(
+                          color: p.ink, fontWeight: FontWeight.w600)),
+                ),
+                Pressable(
+                  semanticLabel: 'Fetch workouts now',
+                  onTap:
+                      _importing ? null : () => unawaited(_importWorkouts()),
+                  child: Padding(
+                    padding: const EdgeInsets.all(S.x2),
+                    child: _importing
+                        ? const SizedBox(
+                            width: 17,
+                            height: 17,
+                            child: CircularProgressIndicator(strokeWidth: 2))
+                        : Icon(LucideIcons.refreshCw,
+                            size: 18, color: p.on(C.domMove)),
+                  ),
                 ),
               ],
             ),
@@ -683,11 +670,9 @@ class _WorkoutScreenState extends State<WorkoutScreen> with RevisionReload {
   Future<void> _setAutoImport(bool v) async {
     setState(() => _autoImport = v);
     await AutoWorkoutImport.setEnabled(v);
-    if (v) {
-      // The opt-in tap is a contextual moment: this one run MAY prompt for
-      // permission (it reuses the button's asking path). Later runs never do.
-      await _importWorkouts(silent: true);
-    }
+    // Silent by design: the tick only arms the hourly sweep. The refresh
+    // icon beside it is what asks for access.
+    if (v) unawaited(AutoWorkoutImport.maybeRun());
   }
 
   /// Read the store, then reload the tab so the new rows are in the list the

--- a/lib/ui2/screens/workout_screen.dart
+++ b/lib/ui2/screens/workout_screen.dart
@@ -593,50 +593,42 @@ class _WorkoutScreenState extends State<WorkoutScreen> with RevisionReload {
     return [
       Surface(
         child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          // ONE ROW, not a card with paragraphs: tick = auto-import sweeps
-          // about once an hour while you use the app; the refresh icon
-          // fetches NOW. The refresh tap is the only thing that ever
-          // prompts for access — after that grant the tick works silently.
-          Surface(
-            pad: const EdgeInsets.symmetric(horizontal: S.x4),
-            child: Row(
-              children: [
-                Pressable(
-                  semanticLabel: _autoImport
-                      ? 'Auto-import on. Tap to turn off.'
-                      : 'Auto-import off. Tap to turn on.',
-                  onTap: () => _setAutoImport(!_autoImport),
-                  child: Icon(
-                    _autoImport
-                        ? LucideIcons.circleCheckBig
-                        : LucideIcons.circle,
-                    size: 22,
-                    color: _autoImport ? p.on(C.domMove) : p.ink3,
-                  ),
+          // ONE ROW in the parent card — no nested box: tick = hourly sweep,
+          // ↻ = fetch NOW (only meaningful while the tick is on). The
+          // refresh tap is the only thing that ever prompts for access.
+          Row(
+            children: [
+              Pressable(
+                semanticLabel: _autoImport
+                    ? 'Auto-import on. Tap to turn off.'
+                    : 'Auto-import off. Tap to turn on.',
+                onTap: () => _setAutoImport(!_autoImport),
+                child: Icon(
+                  _autoImport ? LucideIcons.circleCheckBig : LucideIcons.circle,
+                  size: 22,
+                  color: _autoImport ? p.on(C.domMove) : p.ink3,
                 ),
-                const SizedBox(width: S.x3),
-                Expanded(
-                  child: Text('Import from \$storeName',
-                      style: F.body.copyWith(
-                          color: p.ink, fontWeight: FontWeight.w600)),
+              ),
+              const SizedBox(width: S.x3),
+              Expanded(
+                child: Text('Import from $storeName',
+                    style: F.body.copyWith(
+                        color: p.ink, fontWeight: FontWeight.w600)),
+              ),
+              Pressable(
+                semanticLabel: 'Fetch workouts now',
+                onTap: (!_autoImport || _importing)
+                    ? null
+                    : () => unawaited(_importWorkouts()),
+                child: Padding(
+                  padding: const EdgeInsets.all(S.x2),
+                  child: _importing || !_autoImport
+                      ? Icon(LucideIcons.refreshCw, size: 18, color: p.ink3)
+                      : Icon(LucideIcons.refreshCw,
+                          size: 18, color: p.on(C.domMove)),
                 ),
-                Pressable(
-                  semanticLabel: 'Fetch workouts now',
-                  onTap:
-                      _importing ? null : () => unawaited(_importWorkouts()),
-                  child: Padding(
-                    padding: const EdgeInsets.all(S.x2),
-                    child: _importing
-                        ? const SizedBox(
-                            width: 17,
-                            height: 17,
-                            child: CircularProgressIndicator(strokeWidth: 2))
-                        : Icon(LucideIcons.refreshCw,
-                            size: 18, color: p.on(C.domMove)),
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
           if (_importNote != null) ...[
             const SizedBox(height: S.x3),

--- a/lib/ui2/screens/workout_screen.dart
+++ b/lib/ui2/screens/workout_screen.dart
@@ -492,8 +492,6 @@ class _WorkoutScreenState extends State<WorkoutScreen> with RevisionReload {
         ),
         const SizedBox(height: S.x5),
         _logPastCard(c),
-        const SizedBox(height: S.x5),
-        ..._importCard(c, d),
       ];
     }
     final importedThisWeek = d.weekImported;
@@ -525,11 +523,19 @@ class _WorkoutScreenState extends State<WorkoutScreen> with RevisionReload {
           style: F.cap.copyWith(color: p.ink3, height: 1.5),
         ),
       ],
+      // The import card lives UP HERE, under the numbers it feeds — at the
+      // bottom of a long list nobody reached it without scrolling past every
+      // session it exists to fill.
+      const SizedBox(height: S.x3),
+      ..._importCard(c, d),
       ..._morningAfter(p, d),
       const SizedBox(height: S.x5),
       for (final w in d.workouts) ...[
         _HistoryRow(w,
             weightKg: d.weightKg,
+            onDelete: w.id.isEmpty
+                ? null
+                : () => _confirmDeleteWorkout(c, w),
             // A retime is a re-score over the new window, so it is offered
             // only where there is something of ours to re-score: an imported
             // row's times belong to the app that recorded it, and this band
@@ -550,9 +556,33 @@ class _WorkoutScreenState extends State<WorkoutScreen> with RevisionReload {
       ],
       const SizedBox(height: S.x3),
       _logPastCard(c),
-      const SizedBox(height: S.x3),
-      ..._importCard(c, d),
     ];
+  }
+
+  /// Delete one session — recorded or imported. For an IMPORTED session the
+  /// health-store uuid goes onto a tombstone list first, or the next import
+  /// (manual, or the hourly auto path) would bring the very row the user just
+  /// removed straight back. A copy in Apple Health / Health Connect itself is
+  /// out of our reach by design and the confirm says so.
+  Future<void> _confirmDeleteWorkout(BuildContext c, _PastWorkout w) async {
+    final ok = await confirmRemove(
+      c,
+      title: 'Delete this ${w.activity.name.toLowerCase()}?',
+      body: w.importedFrom == null
+          ? 'It disappears from OpenStrap. A copy in $storeName, if there is '
+              'one, stays where it is.'
+          : 'It disappears from OpenStrap and will not be re-imported. '
+              'The original in $storeName stays.',
+    );
+    if (!ok || !mounted) return;
+    if (w.importedFrom != null && w.id.isNotEmpty) {
+      await rememberDeletedUuid(w.id);
+      await LocalDb.deleteImportedWorkout(w.id);
+    } else {
+      await LocalDb.deleteSession(w.id);
+    }
+    if (!mounted) return;
+    setState(() => _load = _loadWorkoutData(context.read<AppState>()));
   }
 
   /// Bring in what another app recorded. On History because that is the list
@@ -837,7 +867,11 @@ class _HistoryRow extends StatelessWidget {
   /// a session with no id to retime.
   final VoidCallback? onRetime;
 
-  const _HistoryRow(this.w, {this.weightKg, this.onRetime});
+  /// Remove this session locally. Null hides the control (no id to delete).
+  final VoidCallback? onDelete;
+
+  const _HistoryRow(this.w,
+      {this.weightKg, this.onRetime, this.onDelete});
 
   Future<void> _open(BuildContext c) async {
     final nav = Navigator.of(c);
@@ -912,6 +946,18 @@ class _HistoryRow extends StatelessWidget {
               // this is one session's 0–21 strain, and the two were being
               // shown under the same word on the same screen.
               child: Text('strain', style: F.over.copyWith(color: p.ink3)),
+            ),
+          ],
+          if (onDelete != null) ...[
+            const SizedBox(width: S.x2),
+            Pressable(
+              semanticLabel: 'Delete this session',
+              onTap: onDelete,
+              child: Padding(
+                padding: const EdgeInsets.all(S.x1),
+                child:
+                    Icon(LucideIcons.trash2, size: 17, color: p.ink3),
+              ),
             ),
           ],
         ]),

--- a/lib/ui2/screens/workout_screen.dart
+++ b/lib/ui2/screens/workout_screen.dart
@@ -11,6 +11,7 @@
 // need fourteen days — the card is a StatusCard that says which, why and what
 // fixes it.
 
+import 'dart:async' show unawaited;
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -21,6 +22,7 @@ import '../../data/db.dart';
 import '../../gps/gps_source.dart';
 import '../../gps/route_models.dart';
 import '../../health/health_import_state.dart';
+import '../../health/auto_workout_import.dart';
 import '../../health/health_workout_import.dart';
 import '../../models/metric.dart';
 import '../../state/app_state.dart';
@@ -586,6 +588,39 @@ class _WorkoutScreenState extends State<WorkoutScreen> with RevisionReload {
             soft: true,
             onTap: _importing ? null : _importWorkouts,
           ),
+          const SizedBox(height: S.x3),
+          // #? — auto-import, opt-in. The switch turning ON is a user tap, so
+          // THAT moment may ask for permission; every later run is silent and
+          // throttled (see AutoWorkoutImport).
+          Surface(
+            pad: const EdgeInsets.symmetric(horizontal: S.x4, vertical: S.x2),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Auto-import workouts',
+                          style: F.body.copyWith(
+                              color: p.ink, fontWeight: FontWeight.w600)),
+                      Text(
+                        'Brings in workouts from $storeName about once an '
+                        'hour while you use the app. Needs one manual '
+                        'import first to grant access.',
+                        style: F.cap.copyWith(color: p.ink3, height: 1.4),
+                      ),
+                    ],
+                  ),
+                ),
+                Switch(
+                  value: _autoImport,
+                  activeThumbColor: p.on(C.domMove),
+                  activeTrackColor: p.fill(C.domMove),
+                  onChanged: (v) => _setAutoImport(v),
+                ),
+              ],
+            ),
+          ),
           if (_importNote != null) ...[
             const SizedBox(height: S.x3),
             Text(
@@ -600,8 +635,30 @@ class _WorkoutScreenState extends State<WorkoutScreen> with RevisionReload {
   }
 
   bool _importing = false;
+  bool _autoImport = false;
   String? _importNote;
   bool _importFailed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    () async {
+      final on = await AutoWorkoutImport.isEnabled();
+      if (!mounted) return;
+      setState(() => _autoImport = on);
+      if (on) unawaited(AutoWorkoutImport.maybeRun());
+    }();
+  }
+
+  Future<void> _setAutoImport(bool v) async {
+    setState(() => _autoImport = v);
+    await AutoWorkoutImport.setEnabled(v);
+    if (v) {
+      // The opt-in tap is a contextual moment: this one run MAY prompt for
+      // permission (it reuses the button's asking path). Later runs never do.
+      await _importWorkouts(silent: true);
+    }
+  }
 
   /// Read the store, then reload the tab so the new rows are in the list the
   /// user is looking at.
@@ -611,11 +668,13 @@ class _WorkoutScreenState extends State<WorkoutScreen> with RevisionReload {
   /// a second pass over the same run updates that one row instead of stacking
   /// a copy. It also picks up a workout the source app edited or back-dated
   /// after the fact, which a "since last time" cursor would miss forever.
-  Future<void> _importWorkouts() async {
+  Future<void> _importWorkouts({bool silent = false}) async {
     if (_importing) return;
     setState(() {
       _importing = true;
-      _importNote = null;
+      // The auto path shares this body but must not speak over it: no note
+      // clearing, and its outcomes are silent by design.
+      if (!silent) _importNote = null;
     });
     final importer = HealthWorkoutImporter();
     try {

--- a/test/auto_workout_import_test.dart
+++ b/test/auto_workout_import_test.dart
@@ -79,7 +79,6 @@ void main() {
 
     test('inside the hour it throttles; past it, it goes', () {
       final last = DateTime(2026, 8, 22, 11);
-      final now = DateTime(2026, 8, 22, 12);
       expect(
         shouldAutoImport(
           enabled: true,

--- a/test/auto_workout_import_test.dart
+++ b/test/auto_workout_import_test.dart
@@ -1,0 +1,157 @@
+// Tests for the opt-in auto-import of Health workouts: the pure gate, and
+// the runner's contract (silent when off, silent when ungranted, throttled
+// to one full-window read per interval, cursor advanced only on real rows).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:openstrap_edge/health/auto_workout_import.dart';
+import 'package:openstrap_edge/health/health_import_state.dart';
+import 'package:openstrap_edge/health/health_workout_import.dart';
+
+class _FakeImporter implements HealthWorkoutImporter {
+  _FakeImporter(this.granted, this.rows);
+
+  final bool granted;
+  final int rows;
+  int syncCalls = 0;
+
+  @override
+  Future<bool> hasReadPermission() async => granted;
+
+  @override
+  Future<WorkoutImportResult> sync({DateTime? now}) async {
+    syncCalls++;
+    return WorkoutImportResult(
+      workouts: rows,
+      withRoutes: 0,
+      routesSupported: false,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(const {});
+  });
+
+  group('shouldAutoImport (pure)', () {
+    test('off means never, even with a grant and no history', () {
+      expect(
+        shouldAutoImport(
+          enabled: false,
+          permissionGranted: true,
+          lastAttempt: null,
+          now: DateTime(2026, 8, 22, 12),
+        ),
+        isFalse,
+      );
+    });
+
+    test('on without a grant never runs — the cadence must not prompt', () {
+      expect(
+        shouldAutoImport(
+          enabled: true,
+          permissionGranted: false,
+          lastAttempt: null,
+          now: DateTime(2026, 8, 22, 12),
+        ),
+        isFalse,
+      );
+    });
+
+    test('first run after the grant goes', () {
+      expect(
+        shouldAutoImport(
+          enabled: true,
+          permissionGranted: true,
+          lastAttempt: null,
+          now: DateTime(2026, 8, 22, 12),
+        ),
+        isTrue,
+      );
+    });
+
+    test('inside the hour it throttles; past it, it goes', () {
+      final last = DateTime(2026, 8, 22, 11);
+      final now = DateTime(2026, 8, 22, 12);
+      expect(
+        shouldAutoImport(
+          enabled: true,
+          permissionGranted: true,
+          lastAttempt: last,
+          now: last.add(const Duration(minutes: 59)),
+        ),
+        isFalse,
+        reason: '59 min < 1 h interval',
+      );
+      expect(
+        shouldAutoImport(
+          enabled: true,
+          permissionGranted: true,
+          lastAttempt: last,
+          now: last.add(kAutoWorkoutImportInterval),
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('AutoWorkoutImport.maybeRun', () {
+    test('switch off → skipped, importer untouched', () async {
+      final imp = _FakeImporter(true, 5);
+      final out = await AutoWorkoutImport.maybeRun(importer: imp);
+      expect(out, AutoImportOutcome.skipped);
+      expect(imp.syncCalls, 0);
+    });
+
+    test('ungranted store → skipped even when enabled', () async {
+      await AutoWorkoutImport.setEnabled(true);
+      final imp = _FakeImporter(false, 5);
+      final out = await AutoWorkoutImport.maybeRun(importer: imp);
+      expect(out, AutoImportOutcome.skipped);
+      expect(imp.syncCalls, 0);
+    });
+
+    test('granted + enabled → runs once, then throttles within the hour',
+        () async {
+      await AutoWorkoutImport.setEnabled(true);
+      final imp = _FakeImporter(true, 3);
+
+      expect(await AutoWorkoutImport.maybeRun(importer: imp),
+          AutoImportOutcome.ran);
+      expect(imp.syncCalls, 1);
+
+      // The imported cursor only advances on real rows.
+      final lastMs =
+          (await SharedPreferences.getInstance())
+              .getInt(kAutoWorkoutImportLastMs);
+      expect(lastMs, isNotNull);
+      expect(await lastImportAt(HealthImport.workouts), isNotNull);
+
+      expect(await AutoWorkoutImport.maybeRun(importer: imp),
+          AutoImportOutcome.throttled);
+      expect(imp.syncCalls, 1, reason: 'throttled — no second full read');
+    });
+
+    test('a zero-row read still stamps the attempt', () async {
+      await AutoWorkoutImport.setEnabled(true);
+      final imp = _FakeImporter(true, 0);
+      expect(await AutoWorkoutImport.maybeRun(importer: imp),
+          AutoImportOutcome.ran);
+      expect(
+          (await SharedPreferences.getInstance())
+              .getInt(kAutoWorkoutImportLastMs),
+          isNotNull,
+          reason:
+              'an empty store would otherwise be re-read on every pass');
+      expect(await lastImportAt(HealthImport.workouts), isNull,
+          reason: 'zero rows must not put the UI to sleep on a denial');
+    });
+  });
+}

--- a/test/auto_workout_import_test.dart
+++ b/test/auto_workout_import_test.dart
@@ -102,7 +102,15 @@ void main() {
   });
 
   group('AutoWorkoutImport.maybeRun', () {
+    test('DEFAULT IS ON: no pref written still runs when granted', () async {
+      final imp = _FakeImporter(true, 2);
+      expect(await AutoWorkoutImport.maybeRun(importer: imp),
+          AutoImportOutcome.ran);
+      expect(imp.syncCalls, 1);
+    });
+
     test('switch off → skipped, importer untouched', () async {
+      await AutoWorkoutImport.setEnabled(false); // explicit: default is ON
       final imp = _FakeImporter(true, 5);
       final out = await AutoWorkoutImport.maybeRun(importer: imp);
       expect(out, AutoImportOutcome.skipped);


### PR DESCRIPTION
### **User description**
## What

Adds the opt-in discussed on Discord: **Auto-import workouts** on the Workouts tab, next to the manual Import button.

## Behaviour
- **Off by default.** Turning it ON is a user tap → that one run may ask for permission and executes immediately via the button's existing path.
- Afterwards: silent, **non-prompting** (`hasPermissions` probe only), throttled to **one full-window read per hour**. A zero-row read still stamps the attempt (an empty store isn't re-read every foreground pass), while the *imported cursor* advances only on real rows — a denied store never gets marked done.
- Triggers: app foreground cadence pass + opening the Workouts tab.
- Failures are swallowed best-effort; the manual button remains the fallback.

## Implementation
- `lib/health/auto_workout_import.dart` — pure gate (`shouldAutoImport`) + runner with injectable importer/clock for tests.
- `HealthWorkoutImporter.hasReadPermission()` — non-prompting probe.
- Toggle UI on the Workouts tab; cadence hook in `AppState.runCadenceChecks`.
- Tests: off/ungranted/throttled/ran, interval boundary, zero-row stamping, cursor rule.

Discord ask: "Would love an automatism (maybe as an opt-in/out?)" — this is that opt-in.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds opt-in auto-import toggle for workouts.

- Runs silently during foreground cadence checks.

- Throttles background reads to once per hour.

- Prompts for permission only on manual toggle.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  AppState["AppState.runCadenceChecks"] -- "triggers" --> AutoImport["AutoWorkoutImport.maybeRun"]
  AutoImport -- "checks permission" --> HealthImporter["HealthWorkoutImporter.hasReadPermission"]
  AutoImport -- "if granted & unthrottled" --> Sync["HealthWorkoutImporter.sync"]
  Sync -- "if rows > 0" --> Cursor["markImported"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auto_workout_import.dart</strong><dd><code>Auto-import logic and throttling gate implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/health/auto_workout_import.dart

<ul><li>Introduces <code>AutoWorkoutImport</code> to manage background workout imports.<br> <li> Implements a pure gate <code>shouldAutoImport</code> for throttling and permission <br>checks.<br> <li> Ensures zero-row reads stamp the attempt without advancing the <br>imported cursor.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/279/files#diff-7de01aafff4d34d075ee0d2e4e04e780d7e6d2b4e42d48544e2e698a483ef2f0">+115/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_workout_import.dart</strong><dd><code>Add non-prompting permission probe for health store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/health/health_workout_import.dart

<ul><li>Adds <code>hasReadPermission()</code> to <code>HealthWorkoutImporter</code>.<br> <li> Enables non-prompting permission checks for the background auto-import <br>path.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/279/files#diff-ad5aa380c02545d36b392d879feec4e09fcedb322d22ff90798df25306465fd8">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>app_state.dart</strong><dd><code>Integrate auto-import into foreground cadence checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/state/app_state.dart

<ul><li>Integrates <code>AutoWorkoutImport.maybeRun()</code> into <code>runCadenceChecks()</code>.<br> <li> Triggers the auto-import process during foreground cadence passes.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/279/files#diff-d56ba858e512e18dc3962da198adee46d354aca39ff7c1b4a11d5f19b9afc1ae">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workout_screen.dart</strong><dd><code>Add auto-import toggle to Workouts screen UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/ui2/screens/workout_screen.dart

<ul><li>Adds an 'Auto-import workouts' toggle switch to the Workouts tab UI.<br> <li> Triggers an initial manual import (which may prompt for permissions) <br>when toggled on.<br> <li> Initializes the toggle state based on saved preferences.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/279/files#diff-6f487d0c2dfaa6e972a8fe6a1af49864c7e5b85a2f7b9e4942bf990954da2179">+61/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auto_workout_import_test.dart</strong><dd><code>Unit tests for auto-import logic and throttling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/auto_workout_import_test.dart

<ul><li>Adds tests for the <code>shouldAutoImport</code> pure gate logic.<br> <li> Verifies throttling behavior and permission grant requirements.<br> <li> Tests that zero-row reads stamp the attempt but do not advance the <br>cursor.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/279/files#diff-f7f2f243781094a05034b1f4c8f3687db4a0f42757878cc726bfcac36bba4715">+157/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting to automatically import workouts from the phone’s health store in the background.
  * Added hourly throttling and silent operation for automatic imports.
  * Added manual workout importing when automatic imports are enabled.
  * Added delete controls for individual workout history entries.
  * Deleted imported workouts remain excluded from future imports.
  * Improved placement of workout import controls for easier access.

* **Bug Fixes**
  * Prevented import failures or missing workout data from interrupting normal app activity.
  * Health permission checks no longer prompt unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->