### PR TITLE
fix(derive): cap the live-workout derive hold so a forgotten session cannot blank Home

### DIFF
--- a/lib/compute/derive_scheduler.dart
+++ b/lib/compute/derive_scheduler.dart
@@ -17,6 +17,7 @@ class DeriveScheduler {
     required this.onChanged,
     this.lightSettle = const Duration(seconds: 8),
     this.heavySettle = const Duration(seconds: 2),
+    this.workoutHoldCap = const Duration(hours: 6),
   });
 
   final Future<void> Function({required DeriveJobKind kind}) run;
@@ -24,6 +25,19 @@ class DeriveScheduler {
   final void Function() onChanged;
   final Duration lightSettle;
   final Duration heavySettle;
+
+  /// Ceiling on the live-workout hold. The hold's whole justification is "a
+  /// workout is minutes long and its own results are derived at the end
+  /// anyway, so deferring costs nothing" — which inverts the moment the user
+  /// forgets to finish the session: capture keeps landing records, every
+  /// queued job stays parked, today's `day_result` is never built, and Home
+  /// spends the day on "Nothing recorded for today — Sync the band" while the
+  /// strap is connected and syncing fine. Past the cap the session is treated
+  /// as forgotten and held work drains even though it is still live. Six
+  /// hours matches `AppState._kMaxLiveWorkoutAgeMs`, the ceiling past which a
+  /// live session row from a previous run is already judged "almost certainly
+  /// not something the user is still in".
+  final Duration workoutHoldCap;
 
   bool _offloadActive = false;
 
@@ -36,8 +50,17 @@ class DeriveScheduler {
   /// foregrounded, so derives ran at their most expensive possible moment,
   /// competing with the GPS stream, the live map and the BLE drain. A workout
   /// is minutes long and its own results are derived at the end anyway, so
-  /// deferring costs nothing.
+  /// deferring costs nothing — as long as the session actually ends; a
+  /// forgotten one is bounded by [workoutHoldCap].
   bool _workoutActive = false;
+
+  /// True once [workoutHoldCap] has elapsed on the CURRENT session's hold.
+  /// Cleared on release, so the next session holds again from scratch.
+  bool _workoutHoldExpired = false;
+  Timer? _workoutCapTimer;
+
+  /// The gate the drain actually checks: live workout, cap not yet blown.
+  bool get _workoutHeld => _workoutActive && !_workoutHoldExpired;
 
   // While the app is backgrounded we must NOT run derivation: a derive pass
   // decodes the retained substrate + runs the metric compute, and doing
@@ -71,6 +94,7 @@ class DeriveScheduler {
   Map<String, dynamic> snapshot() => {
         'offload_active': _offloadActive,
         'workout_active': _workoutActive,
+        'workout_hold_expired': _workoutHoldExpired,
         'background': _background,
         'running': _running,
         'pending_light': _pendingLight,
@@ -93,10 +117,21 @@ class DeriveScheduler {
     if (active) {
       _timer?.cancel();
       _timer = null;
+      _workoutCapTimer?.cancel();
+      _workoutCapTimer = Timer(workoutHoldCap, () {
+        _workoutHoldExpired = true;
+        log('[derive-scheduler] workout still live past the hold cap — '
+            'treating it as forgotten; derive may run');
+        onChanged();
+        _arm();
+      });
       log('[derive-scheduler] workout live — holding derive work');
       onChanged();
       return;
     }
+    _workoutCapTimer?.cancel();
+    _workoutCapTimer = null;
+    _workoutHoldExpired = false;
     log('[derive-scheduler] workout ended — derive may run');
     onChanged();
     _arm();
@@ -140,6 +175,8 @@ class DeriveScheduler {
   void dispose() {
     _timer?.cancel();
     _timer = null;
+    _workoutCapTimer?.cancel();
+    _workoutCapTimer = null;
   }
 
   Future<void> _enqueue({
@@ -152,7 +189,7 @@ class DeriveScheduler {
   }
 
   void _arm() {
-    if (_running || _offloadActive || _background || _workoutActive) return;
+    if (_running || _offloadActive || _background || _workoutHeld) return;
     if (!_pendingLight && !_pendingHeavy) {
       unawaited(_refreshSnapshot());
       return;
@@ -165,7 +202,7 @@ class DeriveScheduler {
   }
 
   Future<void> _drain() async {
-    if (_running || _offloadActive || _background || _workoutActive) return;
+    if (_running || _offloadActive || _background || _workoutHeld) return;
     _timer?.cancel();
     _timer = null;
     final job = await LocalDb.takeNextComputeJob();
@@ -179,7 +216,7 @@ class DeriveScheduler {
     // land) inside it — at which point running the pass is exactly what the
     // gate exists to prevent. The job is already marked `running` by
     // takeNextComputeJob, so hand it back rather than leaving it claimed.
-    if (_offloadActive || _background || _workoutActive) {
+    if (_offloadActive || _background || _workoutHeld) {
       if (id != null && id.isNotEmpty) {
         await LocalDb.requeueComputeJob(id);
       }

--- a/lib/ui2/screens/home_screen.dart
+++ b/lib/ui2/screens/home_screen.dart
@@ -114,6 +114,18 @@ DbRebuild? dbRebuildOf(BuildContext c) {
   }
 }
 
+/// Whether a live workout is open, or false in a golden. `select`, not
+/// `watch`: AppState ticks at ~1 Hz while a session is live, and this screen
+/// only cares about the bool flipping. The bare-day card branches on it — see
+/// [workoutHoldCard].
+bool workoutLiveOf(BuildContext c) {
+  try {
+    return c.select<AppState, bool>((a) => a.activeWorkout != null);
+  } catch (_) {
+    return false;
+  }
+}
+
 /// Read a metric envelope. `_scalarMetric` writes the literal string `'—'` for
 /// an absent value, so this must never be replaced by `map['value'] as num`.
 Metric metricOf(Object? raw) => Metric.parse(raw);
@@ -360,6 +372,21 @@ StatusCard? dbRebuiltCard(DbRebuild? r) {
     icon: LucideIcons.databaseBackup,
   );
 }
+
+/// The bare day during a live workout — missing COMPUTE, not data. A live
+/// session holds derivation (`DeriveScheduler.setWorkoutActive`), so nothing
+/// lands in `day_result` until it ends: the band keeps recording, the sync
+/// keeps landing records, and "Sync the band" is a false answer — the sync
+/// completes and changes nothing on this screen. The true remedy is finishing
+/// the session, and its bar is pinned right below this card, so the card
+/// points there rather than duplicating the door.
+StatusCard workoutHoldCard() => const StatusCard(
+      'A workout is still running',
+      'Today is on hold while a workout is live: the band keeps recording, '
+      'but the numbers are computed once the session ends. Finish the workout '
+      'from the bar below and today fills in — syncing will not.',
+      icon: LucideIcons.timer,
+    );
 
 StatusCard? staleInsightsCard(
     Map<String, dynamic>? reason, VoidCallback? onSync) {
@@ -1071,7 +1098,11 @@ class HomeScreen extends StatefulWidget {
   /// noise that trains you to regenerate without looking.
   final int? hour;
 
-  const HomeScreen({super.key, this.data, this.hour});
+  /// Whether a workout is live, injected only by tests/goldens — production
+  /// reads it off AppState via [workoutLiveOf].
+  final bool? workoutLive;
+
+  const HomeScreen({super.key, this.data, this.hour, this.workoutLive});
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
@@ -1270,18 +1301,22 @@ class _HomeScreenState extends State<HomeScreen> with RevisionReload {
       ),
 
       if (bare)
-        StatusCard(
-          d.heldOverNight == null
-              ? 'Nothing derived yet'
-              : 'Nothing recorded for today',
-          d.heldOverNight == null
-              ? 'No band recordings processed yet.'
-              : 'The last night this app scored was '
-                  '${prettyDay(d.heldOverNight)}. Nothing has reached it since.',
-          fix: syncOf(c) == null ? '' : 'Sync the band',
-          icon: LucideIcons.watch,
-          onFix: syncOf(c),
-        )
+        // A live workout holds derivation, so a bare day with a session open
+        // is the hold at work, not a sync problem — see [workoutHoldCard].
+        (widget.workoutLive ?? workoutLiveOf(c))
+            ? workoutHoldCard()
+            : StatusCard(
+                d.heldOverNight == null
+                    ? 'Nothing derived yet'
+                    : 'Nothing recorded for today',
+                d.heldOverNight == null
+                    ? 'No band recordings processed yet.'
+                    : 'The last night this app scored was '
+                        '${prettyDay(d.heldOverNight)}. Nothing has reached it since.',
+                fix: syncOf(c) == null ? '' : 'Sync the band',
+                icon: LucideIcons.watch,
+                onFix: syncOf(c),
+              )
       else ...[
         // ── the three rings ──
         //

--- a/test/ui2_wiring_r2_test.dart
+++ b/test/ui2_wiring_r2_test.dart
@@ -384,6 +384,25 @@ void main() {
       await t.pumpWidget(frame(const HomeData(dayId: '2026-05-20')));
       expect(find.text('Nothing derived yet'), findsOneWidget);
     });
+
+    // A bare day during a live workout is missing COMPUTE, not data: the
+    // session holds derivation (DeriveScheduler.setWorkoutActive), so "sync
+    // the band" is a false answer — the sync completes and changes nothing.
+    // The card must name the workout instead.
+    testWidgets('a bare day during a live workout blames the workout, not sync',
+        (t) async {
+      await t.pumpWidget(MaterialApp(
+          theme: buildTheme(Brightness.light),
+          home: const Scaffold(
+              body: HomeScreen(
+                  data: HomeData(
+                      dayId: '2026-05-20', heldOverNight: '2026-05-16'),
+                  hour: 20,
+                  workoutLive: true))));
+      expect(find.text('A workout is still running'), findsOneWidget);
+      expect(find.text('Nothing recorded for today'), findsNothing);
+      expect(find.text('Sync the band'), findsNothing);
+    });
   });
 
   // ── the one observation Home is allowed to make ──

--- a/test/workout_reliability_test.dart
+++ b/test/workout_reliability_test.dart
@@ -129,6 +129,75 @@ void main() {
             reason: 'and it must drain once the session ends, not be dropped');
       },
     );
+
+    test(
+      'the hold is time-capped — a forgotten workout cannot park work forever',
+      () async {
+        // The reported bug: start a workout, forget it, and Home spends the
+        // rest of the day on "Nothing recorded for today — Sync the band"
+        // while the strap is connected and syncing fine. The sync was never
+        // the problem: every derive job it queued was parked behind a hold
+        // whose design assumed "a workout is minutes long".
+        var cappedRuns = 0;
+        final capped = DeriveScheduler(
+          run: ({required DeriveJobKind kind}) async => cappedRuns++,
+          log: logs.add,
+          onChanged: () {},
+          lightSettle: const Duration(milliseconds: 10),
+          heavySettle: const Duration(milliseconds: 10),
+          workoutHoldCap: const Duration(milliseconds: 150),
+        );
+        addTearDown(capped.dispose);
+
+        capped.setWorkoutActive(true);
+        capped.markStoredData();
+        await _until(() => capped.snapshot()['pending_light'] == true);
+        expect(cappedRuns, 0,
+            reason: 'inside the cap the hold works exactly as before');
+
+        // The workout is never ended. The cap alone must release the work.
+        await _until(() => cappedRuns == 1);
+        expect(cappedRuns, 1,
+            reason: 'past the cap the queued job must run — the workout is '
+                'forgotten, not in progress');
+
+        // And work arriving AFTER expiry runs too: the pipeline is unwedged
+        // for the rest of the session, not for one job.
+        capped.markStoredData();
+        await _until(() => cappedRuns == 2);
+        expect(cappedRuns, 2);
+      },
+    );
+
+    test('ending a workout re-arms the cap for the next session', () async {
+      var cappedRuns = 0;
+      final capped = DeriveScheduler(
+        run: ({required DeriveJobKind kind}) async => cappedRuns++,
+        log: logs.add,
+        onChanged: () {},
+        lightSettle: const Duration(milliseconds: 10),
+        heavySettle: const Duration(milliseconds: 10),
+        workoutHoldCap: const Duration(milliseconds: 150),
+      );
+      addTearDown(capped.dispose);
+
+      // Let one session expire its cap…
+      capped.setWorkoutActive(true);
+      capped.markStoredData();
+      await _until(() => cappedRuns == 1);
+      capped.setWorkoutActive(false);
+
+      // …then a NEW session must hold again from scratch. An expiry that
+      // survived the release would make the gate one-shot per launch.
+      capped.setWorkoutActive(true);
+      capped.markStoredData();
+      await _until(() => capped.snapshot()['pending_light'] == true);
+      expect(cappedRuns, 1,
+          reason: 'a fresh session holds again — the expiry must not stick');
+      capped.setWorkoutActive(false);
+      await _until(() => cappedRuns == 2);
+      expect(cappedRuns, 2);
+    });
   });
 
   group('requeueComputeJob (the post-claim gate race)', () {


### PR DESCRIPTION
## The bug

Start a workout and forget to finish it, and Home degrades into the bare-day empty state: no stats, and "Nothing recorded for today — Sync the band" — while the strap is connected and syncing fine. Tapping the sync CTA completes a real sync and changes nothing.

## Root cause

`startWorkout()` calls `DeriveScheduler.setWorkoutActive(true)`, which parks **all** derive work — deliberately, so a heavy isolate spawn can't land mid-ride against GPS, the live map and the BLE drain. The hold's own justification is "a workout is minutes long and its own results are derived at the end anyway, so deferring costs nothing."

That assumption inverts the moment the session is forgotten:

- capture keeps running (the offload is not gated on the workout), records keep landing,
- every derive job — including the ones the "Sync the band" CTA queues — stays parked,
- today's `day_result` is never built, so Home's `bare` branch renders the first-run/no-data card,
- and the card's claim is false on both halves: data *was* recorded, and syncing *cannot* help.

Even a relaunch doesn't clear it: `_reconcileOrphanedLiveWorkout` rehydrates a live session up to 6 h old and re-arms the hold.

## The fix

Two changes, one per half of the symptom:

1. **`DeriveScheduler` gains a `workoutHoldCap` (default 6 h).** Past the cap the session is treated as forgotten and held work drains even though it is still live; jobs arriving after expiry run too, so the pipeline is unwedged for the rest of the session. Ending the workout clears the expiry, so the next session holds again from scratch. Inside the cap nothing changes. Six hours matches `AppState._kMaxLiveWorkoutAgeMs`, the existing ceiling past which a live session row from a previous run is already judged "almost certainly not something the user is still in".

2. **Home's bare-day card branches on the live workout.** While a session holds derivation, the card says "A workout is still running" and points at the session bar pinned directly below it (the door back into the session), instead of claiming nothing was recorded and offering a sync that cannot help. The card clears itself: finishing the workout releases the hold, the derive lands, `insightsRevision` ticks, and `RevisionReload` re-reads. Read via `context.select` (not `watch`) so the 1 Hz live tick doesn't rebuild Home; in goldens (no `AppState`) it resolves to false, so existing goldens are byte-identical.

## Tests

- `workout_reliability_test.dart`: the hold is time-capped (a parked job runs past the cap with the workout still live, and later jobs run too), and ending a workout re-arms the cap for the next session. Existing gate tests unchanged and green.
- `ui2_wiring_r2_test.dart`: a bare day during a live workout renders the workout card and neither "Nothing recorded for today" nor "Sync the band".

`flutter analyze` clean; full suite green (2971 passed, `--concurrency=1`) against the pinned protocol SHA.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a six-hour hold limit for live workouts, allowing data calculations to resume automatically if a workout remains active beyond the limit.
  * Added a home-screen status card explaining when values will be calculated after a workout ends.
  * Home-screen workout status now reflects the currently active session.

* **Bug Fixes**
  * Cleared workout hold status correctly when workouts end or the app is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
