### PR TITLE
feat(workout): "Still working out?" nudge for a forgotten live session

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -328,6 +328,10 @@ ShellDomain domainForRoute(String route) => switch (routePath(route)) {
       kRouteRecovery => ShellDomain.home,
       kRouteSteps => ShellDomain.home,
       kRouteWorkoutSuggestion => ShellDomain.workout,
+      // The forgotten-workout nudge. The Workouts tab is the destination
+      // itself — the live session bar with its finish control is pinned to
+      // the shell there — so screenForRoute stays null for it.
+      kRouteWorkoutIdle => ShellDomain.workout,
       // Emitted by the battery forecast (`app_state.dart`) and the weekly
       // recap (`notification_center.dart`), and declared in `tap_router`
       // alongside every other deep link — see the note below.

--- a/lib/notify/notification_event.dart
+++ b/lib/notify/notification_event.dart
@@ -112,6 +112,19 @@ NotifClass? classOf(NotificationEvent e) => switch (e.category) {
           when e.priority == NotifPriority.normal &&
               routePath(e.route ?? '') == kRouteSteps =>
         NotifClass.prompt,
+      // Same mechanism, one more route-keyed sanction: the forgotten-workout
+      // nudge ("Still working out?" — WorkoutIdleWatch). A report about
+      // something measured — an open session whose trailing 20 minutes were
+      // all rest or absence — asking the user to act on a state only they can
+      // resolve, so it is a prompt exactly like the detected workout. At most
+      // once per session, enforced by its dedupeKey. No switch of its own: it
+      // reports on a session the user started, so the reminders category
+      // toggle is its off switch, the way recovery-ready rides
+      // recoveryEnabled.
+      NotifCategory.reminders
+          when e.priority == NotifPriority.normal &&
+              routePath(e.route ?? '') == kRouteWorkoutIdle =>
+        NotifClass.prompt,
       NotifCategory.reminders || NotifCategory.recovery => null,
     };
 

--- a/lib/notify/tap_router.dart
+++ b/lib/notify/tap_router.dart
@@ -120,6 +120,12 @@ const Map<String, int> _tabRoutes = {
   '/heart': 2,
   '/body': 3,
   '/workouts': 4,
+  // The forgotten-workout nudge. The Workouts tab IS its destination — the
+  // live session bar with the finish control is pinned to the shell there and
+  // `screenForRoute` has nothing to push — so it belongs in the tab table,
+  // not `_screenRoutes`. (It keeps its own path because `classOf`'s sanction
+  // is route-keyed — see kRouteWorkoutIdle above.)
+  kRouteWorkoutIdle: 4,
 };
 
 // Sub-screen routes → the shell tab they sit on top of. Most briefing/journal
@@ -142,7 +148,6 @@ const Map<String, int> _screenRoutes = {
   // request at all, and the shell then falls back to the tab index.
   kRouteMeds: 0,
   kRouteWorkoutSuggestion: 4,
-  kRouteWorkoutIdle: 4,
   kRouteProfile: 0,
   kRouteRecap: 1, // 1|2|3 all fold into Health — see domainForTab
 };

--- a/lib/notify/tap_router.dart
+++ b/lib/notify/tap_router.dart
@@ -58,6 +58,14 @@ const String kRouteSteps = '/today/steps';
 String workoutSuggestionRoute(String id) =>
     Uri(path: kRouteWorkoutSuggestion, queryParameters: {'id': id}).toString();
 
+/// The forgotten-workout nudge ("Still working out?" — see
+/// `WorkoutIdleWatch`). Lands on the Workouts tab: the live session bar and
+/// its finish control are what the notification is about. A dedicated path
+/// rather than the bare `/workouts` tab route, because `classOf`'s sanction
+/// for it is route-keyed and the tab route must not open the
+/// reminders-at-normal pair for everything that names it.
+const String kRouteWorkoutIdle = '/workouts/idle';
+
 /// A deep link's path, without the `?id=` a route may carry.
 ///
 /// EVERY route comparison goes through this. The tables below, `classOf`,
@@ -134,6 +142,7 @@ const Map<String, int> _screenRoutes = {
   // request at all, and the shell then falls back to the tab index.
   kRouteMeds: 0,
   kRouteWorkoutSuggestion: 4,
+  kRouteWorkoutIdle: 4,
   kRouteProfile: 0,
   kRouteRecap: 1, // 1|2|3 all fold into Health — see domainForTab
 };

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -101,6 +101,7 @@ import '../telemetry/telemetry_service.dart';
 import '../telemetry/health_uploader.dart';
 import '../widget/widget_service.dart';
 import '../sync/file_log.dart';
+import 'workout_idle.dart';
 import 'package:uuid/uuid.dart';
 
 /// The onboarding/app gate states, in order. See [AppState.route].
@@ -5578,6 +5579,42 @@ class AppState extends ChangeNotifier {
     }
   }
 
+  /// Ask about a session that has gone quiet — the [WorkoutIdleWatch] ask.
+  ///
+  /// Once per session EVER, belt and braces: the watch stops on
+  /// [WorkoutIdleWatch.confirmFired], and the dedupeKey is claimed
+  /// persistently by FiredKeyStore, so even a session resumed after a crash
+  /// (same id) cannot re-fire. `confirmFired` only on a real present — a drop
+  /// (quiet hours, muted reminders) releases the key and leaves the watch's
+  /// retry loop running, which is what turns an overnight ask into the
+  /// morning nudge instead of a loss.
+  Future<void> _nudgeIdleWorkout(LiveWorkoutState w) async {
+    try {
+      final id = w.workoutId ?? 'w${w.startTime.millisecondsSinceEpoch}';
+      final fired = await NotificationCenter.instance.emit(
+        NotificationEvent(
+          dedupeKey: '$id:workout_idle',
+          category: NotifCategory.reminders,
+          // NORMAL: the prompt sanction in classOf requires it, same as the
+          // movement and detected-workout prompts.
+          priority: NotifPriority.normal,
+          title: 'Still working out?',
+          body: 'Nothing above resting effort has been recorded for '
+              '${w.idleWatch.nudgeAfter.inMinutes} minutes. If the session '
+              'is over, finish it from the Workout tab.',
+          date: todayLabel(),
+          route: kRouteWorkoutIdle,
+        ),
+      );
+      if (fired) {
+        w.idleWatch.confirmFired();
+        _log('[workout] idle nudge fired for $id');
+      }
+    } catch (e) {
+      _log('[workout] idle nudge skipped: $e');
+    }
+  }
+
   void _tickWorkout() {
     final w = activeWorkout;
     if (w == null) return;
@@ -5597,6 +5634,20 @@ class AppState extends ChangeNotifier {
       // Per-zone time: one tick ≈ one second in the current zone (persisted as
       // zone_min at stop — this is what feeds the Time-in-Zones bar).
       if (hr > 0) w.zoneSeconds[_zoneFor(hr)] += 1;
+    }
+
+    // Forgotten-session watch: judged against the SAME gate calories bill
+    // with, so "quiet" here means exactly "billed as rest there" (null when
+    // the anchors cannot define one — then only absence counts, see
+    // WorkoutIdleWatch). The ask is a notification, once per session; the
+    // session itself is never touched — there is deliberately no auto-stop.
+    final wRhr = w.restingHr;
+    final wMax = w.hrMax;
+    final idleGate = (wRhr != null && wMax != null)
+        ? ana.Calories.activeGateHr(wMax, wRhr)
+        : null;
+    if (w.idleWatch.onTick(DateTime.now(), hr: hr, gate: idleGate)) {
+      unawaited(_nudgeIdleWorkout(w));
     }
 
     // Neither strain NOR calories is accrued here. `accrueHr` (called above)
@@ -5903,7 +5954,14 @@ class LiveWorkoutState {
     this.hrMax,
     this.zoneSet,
     this.restingHr,
-  }) : _hrPeak = RollingMaxHr(age: age);
+  })  : _hrPeak = RollingMaxHr(age: age),
+        idleWatch = WorkoutIdleWatch(startedAt: startTime);
+
+  /// The forgotten-session watch — see [WorkoutIdleWatch]. Anchored on
+  /// [startTime], which for a session the reconcile path rehydrated is the
+  /// ORIGINAL start hours ago: the most forgotten a workout can be is exactly
+  /// when the first tick should already be allowed to ask.
+  final WorkoutIdleWatch idleWatch;
 
   /// Feed a live HR sample; updates the spike-suppressed [maxHrSeen], the
   /// per-minute accumulator behind strain, the per-bpm second counts behind

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -5265,6 +5265,15 @@ class AppState extends ChangeNotifier {
             type: (row['type'] as String?) ?? 'other',
             age: (user?['age'] as num?)?.round(),
             profile: Profile.fromMap(user),
+            // The same ceiling startWorkout pins. Without it the resumed
+            // session's idle gate is null, and WorkoutIdleWatch then counts
+            // ANY positive reading as active — a forgotten session idling at
+            // resting heart rate would never be asked about after a restart,
+            // the exact case the watch exists for.
+            hrMax: estimatedMaxHr(
+              (user?['age'] as num?),
+              engine.linkDeviceFamily,
+            ),
             restingHr: _liveRestingHr,
           );
           // Without this, `workoutStepsMeasured` (gated on _workoutRawBase

--- a/lib/state/workout_idle.dart
+++ b/lib/state/workout_idle.dart
@@ -1,0 +1,84 @@
+// workout_idle.dart — PURE policy: when has an open live workout gone quiet
+// for long enough that the user probably forgot to finish it?
+//
+// The failure this exists for: a session started and never stopped. The band
+// keeps recording rest, `startWorkout` refuses every later workout while one
+// is open, and the session counts as a live consumer so the full 100 Hz
+// streams stay armed all night. Nothing in the app said anything — the first
+// sign was Home going bare the next morning.
+//
+// The policy only ever ASKS. There is deliberately no auto-stop: ending a
+// session writes a record only the user can vouch for, and a long stretch at
+// resting heart rate is also what yin yoga, a lunch break mid-hike, or a
+// phone left on the kitchen counter look like. The watch reports a measured
+// quiet stretch and leaves the decision where it belongs.
+
+/// Tracks the trailing quiet stretch of one live session and decides when to
+/// ask "Still working out?".
+///
+/// Fed once per 1 Hz workout tick. A tick is ACTIVE when it carries a real
+/// reading (positive bpm) at or above the calorie pipeline's activity gate —
+/// the same `Calories.activeGateHr` line that separates a bout from rest, so
+/// "quiet" here means exactly "billed as rest there". With no gate (a profile
+/// without calorie anchors), intensity cannot be judged and any real reading
+/// counts as active: a worn strap is never nudged on a guess, and only
+/// absence — off skin, or the link gone — builds the streak.
+///
+/// Asking is retried: the flagship case is an evening session forgotten
+/// overnight, whose first ask lands inside the default 22:00–07:00 quiet
+/// window and is dropped by the notification gate. [onTick] keeps returning
+/// true every [retryEvery] until the caller reports a presented notification
+/// via [confirmFired] — which ends it for good: one nudge per session, ever.
+class WorkoutIdleWatch {
+  WorkoutIdleWatch({
+    required DateTime startedAt,
+    this.nudgeAfter = const Duration(minutes: 20),
+    this.retryEvery = const Duration(minutes: 10),
+  }) : _lastActive = startedAt;
+
+  /// Quiet time before the first ask. Twenty minutes is long enough that
+  /// rest between sets and a water stop never trigger it, and short enough
+  /// that a genuinely forgotten session is asked about while the user still
+  /// remembers starting it.
+  final Duration nudgeAfter;
+
+  /// Backoff between unconfirmed asks — a 1 Hz tick loop must not hammer the
+  /// notification gate while quiet hours are dropping the event.
+  final Duration retryEvery;
+
+  DateTime _lastActive;
+  DateTime? _lastAsk;
+  bool _fired = false;
+
+  /// When the watch last asked, or null if it never has. Read by the wiring
+  /// test; the emit site keys off [onTick]'s return instead.
+  DateTime? get lastAskAt => _lastAsk;
+
+  /// Feed one tick. Returns true when the caller should try to nudge NOW.
+  ///
+  /// [hr] is this second's live reading (null when the band is stale or
+  /// dropped — the workout tick already refuses those); [gate] is
+  /// `Calories.activeGateHr` for this session's anchors, or null when the
+  /// anchors cannot define one.
+  bool onTick(DateTime now, {required int? hr, required num? gate}) {
+    final active = hr != null && hr > 0 && (gate == null || hr >= gate);
+    if (active) {
+      _lastActive = now;
+      // A real bout after an ask starts a fresh story: a NEW quiet stretch
+      // asks at its own threshold rather than inheriting the old backoff.
+      _lastAsk = null;
+      return false;
+    }
+    if (_fired) return false;
+    if (now.difference(_lastActive) < nudgeAfter) return false;
+    final ask = _lastAsk;
+    if (ask != null && now.difference(ask) < retryEvery) return false;
+    _lastAsk = now;
+    return true;
+  }
+
+  /// The nudge actually reached the shade — stop asking, permanently. Only a
+  /// PRESENTED notification confirms; a drop (quiet hours, muted category)
+  /// leaves the retry loop running so the ask survives the night.
+  void confirmFired() => _fired = true;
+}

--- a/test/app_state_regressions_test.dart
+++ b/test/app_state_regressions_test.dart
@@ -161,6 +161,31 @@ void main() {
       await app.debugReconcileOrphanedLiveWorkout();
       expect(app.activeWorkout?.workoutId, 'resumable');
     });
+
+    test('a resumed session keeps its ceiling, so the idle gate exists',
+        () async {
+      final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      await LocalDb.putSession({
+        'id': 'resumable-gated',
+        'start_ts': nowSec - 300,
+        'end_ts': null,
+        'type': 'run',
+        'status': 'live',
+        'source': 'manual',
+        'created_at': (nowSec - 300) * 1000,
+      });
+
+      final app = AppState.forTesting();
+      addTearDown(app.dispose);
+      app.user = {'age': 30};
+      await app.debugReconcileOrphanedLiveWorkout();
+
+      expect(app.activeWorkout?.hrMax, closeTo(208.0 - 0.7 * 30, 1e-9),
+          reason: 'without the ceiling the idle gate is null and '
+              'WorkoutIdleWatch counts any positive reading as active — a '
+              'forgotten session sitting at resting HR would never be asked '
+              'about after an app restart, the exact case the watch is for');
+    });
   });
 
   // ── 9. a fired alarm must be cleared from state AND prefs ──────────────────

--- a/test/app_state_regressions_test.dart
+++ b/test/app_state_regressions_test.dart
@@ -339,5 +339,36 @@ void main() {
           reason: 'no zone-second for a second with no measurement');
       expect(w.maxHrSeen, peak, reason: 'the peak is untouched by an absence');
     });
+
+    test('the tick consults the idle watch — a quiet session asks', () {
+      // The wiring, not the policy (workout_idle_test.dart owns the policy):
+      // a session 30 minutes old with no live HR must have produced an ask by
+      // the end of one tick, and a session with real HR must not have.
+      final app = connected(null);
+      addTearDown(app.dispose);
+      final w = LiveWorkoutState(
+        startTime: DateTime.now().subtract(const Duration(minutes: 30)),
+        targetKcal: 300,
+        workoutId: 'w1',
+        type: 'run',
+      );
+      app.activeWorkout = w;
+      app.debugTickWorkout();
+      expect(w.idleWatch.lastAskAt, isNotNull,
+          reason: '30 quiet minutes into an open session, the watch asks');
+
+      final active = connected(150);
+      addTearDown(active.dispose);
+      final w2 = LiveWorkoutState(
+        startTime: DateTime.now().subtract(const Duration(minutes: 30)),
+        targetKcal: 300,
+        workoutId: 'w2',
+        type: 'run',
+      );
+      active.activeWorkout = w2;
+      active.debugTickWorkout();
+      expect(w2.idleWatch.lastAskAt, isNull,
+          reason: 'a real reading (no gate → any reading) is activity');
+    });
   });
 }

--- a/test/notification_workout_idle_gate_test.dart
+++ b/test/notification_workout_idle_gate_test.dart
@@ -83,5 +83,9 @@ void main() {
   test('the tap lands on the Workouts tab, where the live session bar is', () {
     final t = resolveTapRoute(kRouteWorkoutIdle);
     expect(t.tab, 4);
+    expect(t.screen, isNull,
+        reason: 'the tab IS the destination — this route has no sub-screen '
+            'to push (app.dart\'s screenForRoute answers null for it), so it '
+            'is a tab route, not a screen route');
   });
 }

--- a/test/notification_workout_idle_gate_test.dart
+++ b/test/notification_workout_idle_gate_test.dart
@@ -1,0 +1,87 @@
+// The gate contract for the forgotten-workout nudge (kRouteWorkoutIdle).
+//
+// Same shape as the movement prompt's gate test, and for the same reason: the
+// reminders-at-normal pair is exactly the pair every one of the deleted
+// nudges would arrive on, so a new event on it must be sanctioned by ROUTE,
+// and both directions of that keying are worth pinning — the idle route gets
+// through, and nothing else rides in with it. Unlike the movement prompt this
+// one has no switch of its own: it reports on a session the USER started (a
+// measured quiet stretch inside it), so the reminders category toggle is its
+// off switch, the same way recovery-ready rides recoveryEnabled.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:openstrap_edge/notify/notification_event.dart';
+import 'package:openstrap_edge/notify/notification_prefs.dart';
+import 'package:openstrap_edge/notify/tap_router.dart';
+
+NotificationEvent idleEvent(
+    {NotifPriority priority = NotifPriority.normal, String? route}) {
+  return NotificationEvent(
+    dedupeKey: 'w123:workout_idle',
+    category: NotifCategory.reminders,
+    priority: priority,
+    title: 'Still working out?',
+    body: 'test',
+    date: '2026-08-25',
+    route: route ?? kRouteWorkoutIdle,
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(const {});
+  });
+
+  group('classOf', () {
+    test('the idle nudge is a prompt', () {
+      expect(classOf(idleEvent()), NotifClass.prompt);
+      // An id-carrying payload resolves through routePath.
+      expect(classOf(idleEvent(route: '$kRouteWorkoutIdle?id=w123')),
+          NotifClass.prompt);
+    });
+
+    test('a low-priority event on the same route stays dropped', () {
+      expect(classOf(idleEvent(priority: NotifPriority.low)), isNull);
+    });
+
+    test('other reminders events do not ride in on the new sanction', () {
+      NotificationEvent ev(String route) => NotificationEvent(
+            dedupeKey: '2026-08-25:x',
+            category: NotifCategory.reminders,
+            title: 'x',
+            body: '',
+            date: '2026-08-25',
+            route: route,
+          );
+      expect(classOf(ev('/workouts')), isNull);
+      expect(classOf(ev('${kRouteWorkoutIdle}X')), isNull); // prefix games fail
+    });
+  });
+
+  group('shouldFireOs', () {
+    test('fires by default outside quiet hours — reminders default on', () async {
+      final prefs = await NotificationPrefs.load();
+      expect(prefs.shouldFireOs(idleEvent(), 12 * 60), isTrue);
+    });
+
+    test('the reminders category toggle is its off switch', () async {
+      final prefs =
+          (await NotificationPrefs.load()).copyWith(remindersEnabled: false);
+      expect(prefs.shouldFireOs(idleEvent(), 12 * 60), isFalse);
+    });
+
+    test('quiet hours drop it — it is not the alarm', () async {
+      final prefs = await NotificationPrefs.load();
+      // Default quiet window opens at 22:00. The emit site retries, so a
+      // dropped overnight ask becomes the morning nudge rather than a loss.
+      expect(prefs.shouldFireOs(idleEvent(), 23 * 60), isFalse);
+    });
+  });
+
+  test('the tap lands on the Workouts tab, where the live session bar is', () {
+    final t = resolveTapRoute(kRouteWorkoutIdle);
+    expect(t.tab, 4);
+  });
+}

--- a/test/workout_idle_test.dart
+++ b/test/workout_idle_test.dart
@@ -1,0 +1,108 @@
+// The idle watch behind the "Still working out?" nudge (forgotten sessions).
+//
+// The reported bug this feature answers: a workout started and never finished
+// keeps recording rest for hours — the session refuses every later workout,
+// holds the full live streams armed all night, and (before the derive-hold
+// cap) blanked Home. There is deliberately NO auto-stop: the watch only ever
+// asks, and only the user ends a session. So the contract worth pinning is
+// the asking itself — when it speaks up, when it stays quiet, and that a
+// dropped ask (quiet hours) is retried rather than lost.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/state/workout_idle.dart';
+
+void main() {
+  final t0 = DateTime(2026, 8, 25, 18, 0);
+  DateTime at(int min) => t0.add(Duration(minutes: min));
+
+  WorkoutIdleWatch watch() => WorkoutIdleWatch(startedAt: t0);
+
+  group('going quiet', () {
+    test('a session quiet from the start asks at the threshold, not before',
+        () {
+      final w = watch();
+      expect(w.onTick(at(19), hr: null, gate: 100), isFalse);
+      expect(w.onTick(at(20), hr: null, gate: 100), isTrue);
+    });
+
+    test('an active sample resets the streak', () {
+      final w = watch();
+      expect(w.onTick(at(10), hr: 140, gate: 100), isFalse);
+      expect(w.onTick(at(29), hr: null, gate: 100), isFalse,
+          reason: 'only 19 quiet minutes since the last active sample');
+      expect(w.onTick(at(30), hr: null, gate: 100), isTrue);
+    });
+
+    test('a reading below the activity gate is rest, not activity', () {
+      final w = watch();
+      // 20 minutes of measured-at-rest wrist is exactly the forgotten case —
+      // the strap is worn, the workout is over.
+      expect(w.onTick(at(10), hr: 62, gate: 100), isFalse);
+      expect(w.onTick(at(20), hr: 62, gate: 100), isTrue);
+    });
+
+    test('with no gate, any real reading counts as active', () {
+      // No calorie anchors → no gate → intensity cannot be judged. A worn
+      // strap must not be nudged on a guess; only absence counts as quiet.
+      final w = watch();
+      expect(w.onTick(at(19), hr: 62, gate: null), isFalse);
+      expect(w.onTick(at(38), hr: null, gate: null), isFalse,
+          reason: 'the 62 bpm at minute 19 reset the streak');
+      expect(w.onTick(at(39), hr: null, gate: null), isTrue,
+          reason: '20 quiet minutes since that reading');
+    });
+
+    test('a non-positive reading is off-skin, not a heart rate', () {
+      // Same rule accrueHr applies: 0 is not a measurement. It must not
+      // count as activity even with no gate to compare against.
+      final w = watch();
+      expect(w.onTick(at(10), hr: 0, gate: null), isFalse);
+      expect(w.onTick(at(20), hr: 0, gate: null), isTrue);
+    });
+
+    test('a session resumed long after its start may ask on the first tick',
+        () {
+      // The reconcile path rehydrates a crashed session with its ORIGINAL
+      // start time, hours old. That is the most forgotten a workout can be.
+      final w = watch();
+      expect(w.onTick(at(300), hr: null, gate: 100), isTrue);
+    });
+  });
+
+  group('asking is retried until it lands, then never again', () {
+    test('an unconfirmed ask backs off, then re-asks', () {
+      // The flagship scenario is an evening workout forgotten overnight —
+      // which lands the first ask inside default quiet hours (22:00–07:00),
+      // where the notification gate drops it. A fire-and-forget ask would be
+      // silently lost for the whole night; the retry is what turns it into
+      // the morning nudge.
+      final w = watch();
+      expect(w.onTick(at(20), hr: null, gate: 100), isTrue);
+      expect(w.onTick(at(21), hr: null, gate: 100), isFalse,
+          reason: 'a 1 Hz tick loop must not hammer the notification gate');
+      expect(w.onTick(at(29), hr: null, gate: 100), isFalse);
+      expect(w.onTick(at(30), hr: null, gate: 100), isTrue,
+          reason: 'retryEvery elapsed and nothing confirmed the ask landed');
+    });
+
+    test('confirmFired ends it — one nudge per session, ever', () {
+      final w = watch();
+      expect(w.onTick(at(20), hr: null, gate: 100), isTrue);
+      w.confirmFired();
+      expect(w.onTick(at(40), hr: null, gate: 100), isFalse);
+      // Even a fresh quiet stretch after real activity stays silent: the
+      // session was asked about once and answered.
+      expect(w.onTick(at(41), hr: 150, gate: 100), isFalse);
+      expect(w.onTick(at(90), hr: null, gate: 100), isFalse);
+    });
+
+    test('activity between asks resets the backoff with the streak', () {
+      final w = watch();
+      expect(w.onTick(at(20), hr: null, gate: 100), isTrue);
+      expect(w.onTick(at(25), hr: 150, gate: 100), isFalse);
+      // A new 20-minute quiet stretch asks at its own threshold — not held
+      // to the old ask's backoff clock.
+      expect(w.onTick(at(45), hr: null, gate: 100), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## The gap

A workout started and never finished fails silently. The open session refuses every later workout, counts as a live consumer so the **full 100 Hz streams stay armed all night** (`_hasLiveConsumer` blocks the background downgrade), and keeps recording rest for hours. Nothing in the app says anything — before #281 the first sign was Home going bare the next morning.

## What this adds

The asking half only — **deliberately no auto-stop**. Ending a session writes a record only the user can vouch for, and a long stretch at resting heart rate is also what yin yoga, a lunch break mid-hike, or a phone left on the kitchen counter look like. The watch reports a measured quiet stretch and leaves the decision with the user.

**`WorkoutIdleWatch`** (new pure policy, `lib/state/workout_idle.dart`, fed by the 1 Hz workout tick):

- A tick is *active* when it carries a real reading at/above `Calories.activeGateHr` — the same line that separates a bout from rest in the calorie pipeline, so "quiet" here means exactly "billed as rest there". With no gate (a profile without calorie anchors) intensity can't be judged, so any real reading counts as active and only absence — off skin, or the link gone — builds the streak: a worn strap is never nudged on a guess.
- Asks after **20 quiet minutes** ("Still working out? Nothing above resting effort has been recorded for 20 minutes…"). An unconfirmed ask retries every 10 minutes: the flagship case is an evening session forgotten overnight, whose first ask lands inside the default 22:00–07:00 quiet window and is dropped by the gate — the retry is what turns that into the morning nudge instead of a loss.
- One nudge per session, ever, belt and braces: `confirmFired` latches only on a real present, and the dedupeKey (`$id:workout_idle`) stays claimed in FiredKeyStore, so even a session resumed after a crash (same id) can't re-fire. A session rehydrated by the orphan reconcile anchors on its *original* start, so the most-forgotten session may be asked about on its first tick.

**Notification ledger**: the nudge rides the `prompt` class via a new route-keyed sanction (`kRouteWorkoutIdle = '/workouts/idle'`) — the same narrowing the movement and detected-workout prompts use, so the reminders-at-normal pair stays closed to everything else (both directions pinned in the new gate test). No switch of its own: it reports on a session the user started, so the reminders category toggle is its off switch, the way recovery-ready rides `recoveryEnabled`. The tap lands on the Workouts tab, where the live session bar and its finish control are.

## Tests

- `workout_idle_test.dart` — the policy: threshold, streak reset on activity, below-gate = rest, no-gate = absence-only, off-skin ≠ activity, resumed-old-session asks immediately, retry backoff, `confirmFired` ends it.
- `notification_workout_idle_gate_test.dart` — both directions of the sanction, the category off switch, quiet-hours drop, tap target (mirrors the movement prompt's gate test).
- `app_state_regressions_test.dart` — the tick actually consults the watch (quiet session asks, active one doesn't).

`flutter analyze` clean; full suite green (2985 passed, `--concurrency=1`) against the pinned protocol SHA.

Related: #281 (the derive-hold cap + honest Home card for the same forgotten-session scenario; independent branches, no overlapping files).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reminders when a live workout has been inactive for an extended period.
  * Reminders retry if delivery is temporarily unavailable and stop after confirmation.
  * Activity detection accounts for heart-rate readings and configured activity thresholds.
  * Workouts remain active while inactivity reminders are issued.

* **Bug Fixes**
  * Improved navigation and notification handling for forgotten workouts.
  * Tapping a forgotten-workout notification now opens the Workouts tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
