### PR TITLE
fix(sync): enforce safe Gen5 history task boundaries

### DIFF
--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -558,6 +558,10 @@ class _Session {
   /// Markers dropped by [historyTaskEnded] (diagnostics; first one logs).
   int endedMarkersDropped = 0;
 
+  /// HISTORY_END markers dropped as doc-05 duplicates because they arrived
+  /// before the current task's first HISTORY_START (diagnostics; first logs).
+  int preStartHistoryEndsDropped = 0;
+
   _Session(this.device);
 
   Future<void> teardown() async {
@@ -1272,6 +1276,26 @@ class BleEngine {
   /// told to abandon the previous one. Deliberately NOT a broad lock: only the
   /// lifecycle transition serializes on it, never packet ingestion.
   Future<void>? _historyAbortInFlight;
+
+  /// The currently executing sync-marker handler, while the serialized
+  /// drainer awaits it. Task starts wait for this too (a handler can park for
+  /// seconds inside a large durable commit, and a commit that FAILS after a
+  /// replacement task started would re-buffer the old task's rows under the
+  /// new one). See [_awaitHistoryLifecycleQuiescence].
+  Future<void>? _historyMarkerInFlight;
+
+  /// True from a task claim until that task's first HISTORY_START. Doc 05: a
+  /// task is Running-with-no-active-burst until the strap declares a burst,
+  /// and in that state a HISTORY_END is a DUPLICATE — drop, no ACK. Without
+  /// this, a late END straggling in from the previous (aborted) task during
+  /// the claim's range/clock window would carry the new generation and be
+  /// validated as part of the new task. Enforced on gen5 only, where doc 05
+  /// pins the START-first flow; the gen4 marker sequence is unpinned and its
+  /// behavior unchanged.
+  bool _historyAwaitingFirstStart = false;
+
+  bool get _dropPreStartHistory =>
+      _historyAwaitingFirstStart && (_session?.band.isGen5 ?? false);
   int _historyRequests = 0;
   int _historyCompletions = 0;
   SyncReport? _lastSyncReport;
@@ -2239,11 +2263,19 @@ class BleEngine {
           '(deferred_total=$_clockPausedOffloads).',
         );
       }
-      // The INIT drain is a new task like any other claim: leftovers of a
-      // previous session's task (queued frames, parked continuations) are
-      // stale from here — session binding already refuses most of them, the
-      // generation closes the rest.
+      // The INIT drain is a new task like any other claim, so it goes behind
+      // the same lifecycle barrier: a previous session's task-ending abort or
+      // a marker handler still parked in a commit must finish unwinding
+      // before this task arms. (Both resolve fast once their session is
+      // stale — the owner-bound write refuses immediately, and the handler
+      // re-checks staleness at every await.)
+      await _awaitHistoryLifecycleQuiescence();
+      // Leftovers of a previous session's task (queued frames, parked
+      // continuations) are stale from here — session binding already refuses
+      // most of them, the generation closes the rest. Doc 05: no burst is
+      // active until this task's first HISTORY_START.
       _historyTaskGen++;
+      _historyAwaitingFirstStart = drainOnInit;
       _setOffloadActive(drainOnInit);
       // Only a real drain spends the backfill floor; a deferred one leaves it
       // open so a foreground trigger can retry as soon as the phone corrects.
@@ -2255,6 +2287,7 @@ class BleEngine {
       // on a strap that was never asked for history and every later refresh
       // stops at the already-transmitting guard.
       if (!await sendInit(drain: drainOnInit)) {
+        _historyAwaitingFirstStart = false;
         _setOffloadActive(false);
         _lastBackfillAt = floorBeforeInit;
         _log(
@@ -2668,7 +2701,10 @@ class BleEngine {
   /// is awaited. Used by the periodic timer, continuation, and the public sync API.
   /// Returns true when an offload was actually requested (false → floored or not
   /// connected), so event-driven callers know whether to await a sync report.
-  Future<bool> _triggerBackfill(BackfillTrigger trigger) async {
+  Future<bool> _triggerBackfill(
+    BackfillTrigger trigger, {
+    bool fromMarkerHandler = false,
+  }) async {
     final d = _drain;
     if (_session?.connected != true || d == null) return false;
     if (!BackfillPolicy.shouldRun(
@@ -2692,6 +2728,7 @@ class BleEngine {
       trigger: trigger,
       reason: trigger.name,
       refreshRange: true,
+      fromMarkerHandler: fromMarkerHandler,
     );
     if (!sent) _lastBackfillAt = floorBefore;
     return sent;
@@ -2729,24 +2766,33 @@ class BleEngine {
   /// refresh that dropped out at one of the gates below asked the strap for
   /// nothing, so it must not buy the next real attempt fifteen minutes of
   /// silence.
+  /// [fromMarkerHandler] marks the one caller that runs INSIDE the serialized
+  /// marker handler (the auto-continue decision at HISTORY_COMPLETE): it must
+  /// not wait for [_historyMarkerInFlight] — that is its own future — but its
+  /// position already guarantees the handler is past every controller-mutating
+  /// await.
   Future<bool> _startHistoricalRefresh({
     required BackfillTrigger trigger,
     required String reason,
     bool refreshRange = true,
+    bool fromMarkerHandler = false,
   }) async {
-    // SERIALIZED LIFECYCLE: a task-ending abort still in flight must complete
-    // before any trigger may start the next task — otherwise range/opcode 22
-    // goes out while the band is still being told to abandon the previous
-    // task. Every waiter resumes on the same turn and the claim below is
-    // synchronous, so the first one through takes the task and the rest fall
-    // out at the already-transmitting guard: at most ONE next task.
-    while (true) {
-      final pendingAbort = _historyAbortInFlight;
-      if (pendingAbort == null) break;
-      _log('[SYNC] refresh($reason) — waiting for the in-flight history abort '
-          'to complete before starting a new task.');
-      await pendingAbort;
+    // SERIALIZED LIFECYCLE: the previous task must be QUIESCENT before any
+    // trigger may start the next one — its task-ending abort delivered (or
+    // given up), and its marker handler out of any parked commit. Otherwise
+    // range/opcode 22 goes out while the band is still being told to abandon
+    // the previous task, or an old commit failure re-buffers the old task's
+    // rows under the new one. Every waiter resumes on the same turn and the
+    // claim below is synchronous, so the first one through takes the task and
+    // the rest fall out at the already-transmitting guard: at most ONE next
+    // task.
+    if (_historyAbortInFlight != null || _historyMarkerInFlight != null) {
+      _log('[SYNC] refresh($reason) — waiting for the previous history '
+          'task\'s abort/handler to finish before starting a new one.');
     }
+    await _awaitHistoryLifecycleQuiescence(
+      includeMarkerHandler: !fromMarkerHandler,
+    );
     final d = _drain;
     final session = _session;
     if (session?.connected != true || d == null) return false;
@@ -2783,6 +2829,10 @@ class BleEngine {
     // are live traffic.
     d.startFreshTask();
     session.historyTaskEnded = false;
+    // Doc 05: the new task has no active burst until the strap's first
+    // HISTORY_START — until then a HISTORY_END is a duplicate and data
+    // packets are dropped (gen5).
+    _historyAwaitingFirstStart = true;
     // Claiming IS the generation bump: from here, leftovers of any previous
     // task (queued frames, parked continuations) are provably stale.
     _historyTaskGen++;
@@ -2818,6 +2868,9 @@ class BleEngine {
         'to the strap RTC; not draining history until they agree '
         '(deferred_total=$_clockPausedOffloads).',
       );
+      // The claim never became a task (no opcode 22): restore the idle
+      // marker/data handling — nothing is awaiting a HISTORY_START.
+      _historyAwaitingFirstStart = false;
       _setOffloadActive(false);
       return false;
     }
@@ -2841,7 +2894,10 @@ class BleEngine {
     if (!await _sendHistoricalData(owner: session)) {
       // A claim that went stale UNDER the write must not clear the state the
       // replacement task now owns.
-      if (!claimStale()) _setOffloadActive(false);
+      if (!claimStale()) {
+        _historyAwaitingFirstStart = false;
+        _setOffloadActive(false);
+      }
       return false;
     }
     _lastHistoricalSendAt = _wallSecs();
@@ -3434,6 +3490,11 @@ class BleEngine {
       // Fall through to decodeFrame so the UI gets live telemetry (state.liveHr).
     }
     if (pt == PacketType.historicalData) {
+      // Same doc-05 rule as the queued path: data packets before the task's
+      // first HISTORY_START are the previous task's stragglers — drop them
+      // (un-ACKed, the band re-delivers) instead of ingesting them into a
+      // burst window that has not opened.
+      if (_dropPreStartHistory) return;
       // Historical data flowing while no offload is marked active is a terminal
       // worth recording (an unsolicited drain / lost START marker).
       if (!_offloadActive) {
@@ -3547,17 +3608,32 @@ class BleEngine {
           final frame = entry.frame;
           // An OLD task's queued frames must never be processed as part of a
           // new one: they were counted/collected for a burst window that is
-          // over, and the band re-delivers anything un-ACKed anyway. The one
-          // exception is HISTORY_COMPLETE — like the stuck latch, it ACKs
-          // nothing and an awaitComplete() waiter must still be released.
-          if (entry.taskGen != _historyTaskGen &&
-              !(frame.packetType == PacketType.metadata &&
-                  parseMetadata(frame.inner)?.sub == SyncMeta.historyComplete)) {
-            continue;
-          }
+          // over, and the band re-delivers anything un-ACKed anyway.
+          // HISTORY_COMPLETE is no exception — a stale COMPLETE reaching the
+          // handler would record a SUCCESS terminal and run the post-offload
+          // policy for a task that ended in an abort (or worse, complete a
+          // replacement task it never belonged to). The awaitComplete()
+          // waiter it used to release is resolved at the abort boundary
+          // instead (DrainController.onTaskTerminal).
+          if (entry.taskGen != _historyTaskGen) continue;
           if (frame.packetType == PacketType.metadata) {
-            await _handleSyncMarker(frame, session);
+            // Published while awaited so a task start can wait out a handler
+            // parked mid-commit — see _awaitHistoryLifecycleQuiescence.
+            final handling = _handleSyncMarker(frame, session);
+            _historyMarkerInFlight = handling;
+            try {
+              await handling;
+            } finally {
+              if (identical(_historyMarkerInFlight, handling)) {
+                _historyMarkerInFlight = null;
+              }
+            }
           } else if (frame.packetType == PacketType.historicalData) {
+            // Doc 05: the processor drops data packets until the task's first
+            // HISTORY_START — a straggler record from the previous task must
+            // not be ingested (or tallied) into the new one. Un-ACKed, so the
+            // band re-delivers it under a real burst.
+            if (_dropPreStartHistory) continue;
             _ingestHistoricalFrame(frame);
           } else {
             // A count member that was already processed inline
@@ -4204,6 +4280,11 @@ class BleEngine {
     // frames, ACK retries) are stale from this moment.
     _historyTaskGen++;
     _setHpsTerminal(kind, reason: reason);
+    // Release any awaitComplete()/runSync() waiter promptly with an
+    // incomplete report — the latch above drops every post-terminal marker
+    // (HISTORY_COMPLETE included), so nothing else would ever resolve it
+    // short of the 60 s idle window.
+    _drain?.onTaskTerminal();
     _log('[SYNC] history task terminal ($reason) — sending one best-effort '
         'abort; the band keeps its checkpoint and a later task resumes from '
         'it.');
@@ -4215,8 +4296,26 @@ class BleEngine {
       if (identical(_historyAbortInFlight, boundary)) {
         _historyAbortInFlight = null;
       }
-      // Release the task only now — the abort boundary is complete.
-      _setOffloadActive(false);
+      // Release the task only now — the abort boundary is complete. But only
+      // when the ending session still owns the engine's offload state: a
+      // replacement session's INIT pre-arms `_offloadActive` for ITS drain,
+      // and an old abort unwinding after the swap must not clear that claim.
+      if (!_sessionIsStale(session)) _setOffloadActive(false);
+    }
+  }
+
+  /// Wait until the previous history task's lifecycle is quiescent: no
+  /// task-ending abort in flight and (unless the caller IS the marker
+  /// handler) no sync-marker handler still running. Loops because a new
+  /// pending future can appear while an old one is being awaited.
+  Future<void> _awaitHistoryLifecycleQuiescence({
+    bool includeMarkerHandler = true,
+  }) async {
+    while (true) {
+      final pending = _historyAbortInFlight ??
+          (includeMarkerHandler ? _historyMarkerInFlight : null);
+      if (pending == null) return;
+      await pending;
     }
   }
 
@@ -4686,11 +4785,13 @@ class BleEngine {
     // re-aborted. The idle watchdog is deliberately not re-armed either — there
     // is nothing left to wait for on this link.
     //
-    // HISTORY_COMPLETE is the one marker that must still get through: it ACKs
-    // nothing, and swallowing it left `onComplete()` unreachable once the
-    // latch was set, so every `awaitComplete()` waiter ran out its full
-    // timeout against a drain that had already ended.
-    if (session.historyStuckActive && m.sub != SyncMeta.historyComplete) {
+    // HISTORY_COMPLETE is dropped like everything else. It used to be let
+    // through so a parked `awaitComplete()` waiter could still resolve, but a
+    // post-terminal COMPLETE also recorded a SUCCESS terminal and ran the
+    // post-offload policy for a task that ended in an abort. The waiter is
+    // released at the abort boundary now (DrainController.onTaskTerminal), so
+    // the exemption's one job is gone.
+    if (session.historyStuckActive) {
       session.stuckMarkersDropped++;
       if (session.stuckMarkersDropped == 1) {
         _log(
@@ -4702,13 +4803,12 @@ class BleEngine {
       }
       return;
     }
-    // Same shape for a task that ended through the abort boundary: its
-    // stragglers (duplicate HISTORY_END, a late START) must not re-open the
-    // task, re-arm the watchdog or send anything. HISTORY_COMPLETE passes for
-    // the same reason it passes the stuck latch — it ACKs nothing and any
-    // awaitComplete() waiter must still be released. The latch clears when the
-    // next task is claimed, so this never blocks a later explicit refresh.
-    if (session.historyTaskEnded && m.sub != SyncMeta.historyComplete) {
+    // Same shape for any task that ended through the abort boundary: its
+    // stragglers (duplicate HISTORY_END, a late START, a stray COMPLETE) must
+    // not re-open the task, re-arm the watchdog, record a terminal or send
+    // anything. The latch clears when the next task is claimed, so this never
+    // blocks a later explicit refresh.
+    if (session.historyTaskEnded) {
       session.endedMarkersDropped++;
       if (session.endedMarkersDropped == 1) {
         _log(
@@ -4719,9 +4819,7 @@ class BleEngine {
       }
       return;
     }
-    // Stuck: the COMPLETE passing through above must not re-arm the watchdog
-    // it deliberately left dead.
-    if (!session.historyStuckActive) _armIdleWatchdog();
+    _armIdleWatchdog();
     _log(
       '[SYNC] META sub=${m.sub} inner='
       '${frame.inner.map((b) => b.toRadixString(16).padLeft(2, '0')).join()}',
@@ -4736,6 +4834,9 @@ class BleEngine {
         d.discardOpenChunk();
       }
       _session?.historicalRetry?.cancel();
+      // The task's first burst is declared — HISTORY_END and data frames are
+      // live traffic from here.
+      _historyAwaitingFirstStart = false;
       _burstDroppedAtStart = _recordGate.dropped;
       d?.rearm();
       // The one place a new burst is really declared — the only safe point to
@@ -4750,6 +4851,21 @@ class BleEngine {
     if (m.sub == SyncMeta.historyEnd && m.token != null) {
       final d = _drain;
       if (d == null) return;
+      // Doc 05: Running with no active burst ⇒ a HISTORY_END is a duplicate —
+      // drop it, no ACK, no validation. Between claiming a task (opcode 22)
+      // and its first HISTORY_START the only legitimate markers are that
+      // START and HISTORY_COMPLETE, so a late END straggling in from the
+      // previous task must not be judged as part of this one.
+      if (_dropPreStartHistory) {
+        session.preStartHistoryEndsDropped++;
+        if (session.preStartHistoryEndsDropped == 1) {
+          _log(
+            '[SYNC] HISTORY_END before this task\'s first HISTORY_START — '
+            'duplicate from a previous task; dropping without ACK.',
+          );
+        }
+        return;
+      }
       final tokenHex = m.token!
           .map((b) => b.toRadixString(16).padLeft(2, '0'))
           .join();
@@ -5286,7 +5402,14 @@ class BleEngine {
       _autoContinue.continued(productive: productive, now: _monotonicSecs());
       _log('[SYNC] auto-continue — more backlog remains '
           '(unproductive streak ${_autoContinue.unproductiveStreak}).');
-      await _triggerBackfill(BackfillTrigger.autoContinue);
+      // fromMarkerHandler: this runs inside the HISTORY_COMPLETE handler —
+      // waiting on _historyMarkerInFlight here would deadlock on our own
+      // future, and the handler is already past every controller-mutating
+      // await.
+      await _triggerBackfill(
+        BackfillTrigger.autoContinue,
+        fromMarkerHandler: true,
+      );
     } else {
       _autoContinue.end();
       // nothing left to continue - this offload cycle is genuinely done
@@ -6682,14 +6805,29 @@ class DrainController {
     _lastProgressAt = DateTime.now();
   }
 
+  /// The engine's task-ending abort boundary fired: this offload is over
+  /// WITHOUT a HISTORY_COMPLETE. Releases any [awaitComplete] waiter with an
+  /// incomplete report on its next tick — no HISTORY_COMPLETE is coming (the
+  /// terminal latch drops every post-terminal marker), and without this the
+  /// waiter sat out the 60 s idle window or its full timeout against a drain
+  /// that had already ended.
+  void onTaskTerminal() {
+    _taskTerminal = true;
+  }
+
+  bool _taskTerminal = false;
+
   /// Re-arm for a fresh offload over the same connection (clears the COMPLETE flag
-  /// so a new awaitComplete() blocks until the next HISTORY_COMPLETE).
+  /// so a new awaitComplete() blocks until the next HISTORY_COMPLETE, and the
+  /// task-terminal flag so it does not resolve instantly on the LAST task's
+  /// abort).
   ///
   /// Does NOT clear the poison latch — see [beginBurst]. Re-arming is US asking
   /// for another offload; the burst boundary is the BAND's to declare.
   void rearm() {
     _complete = false;
     _linkDown = false;
+    _taskTerminal = false;
     _lastProgressAt = DateTime.now();
     burstStats.reset();
     _burstTallyClosed = false;
@@ -6839,7 +6977,8 @@ class DrainController {
 
   Future<bool> flush() => commit(null);
 
-  /// Resolve once the current offload reaches HISTORY_COMPLETE, the link drops, or
+  /// Resolve once the current offload reaches HISTORY_COMPLETE, the task ends
+  /// through the abort boundary ([onTaskTerminal]), the link drops, or
   /// [timeout] elapses. Pure waiting — NO abort is ever sent (cutting the offload
   /// short is exactly what stalled the cursor). Polls the lightweight stop-evaluator
   /// every second.
@@ -6853,6 +6992,16 @@ class DrainController {
     Timer.periodic(const Duration(seconds: 1), (t) async {
       if (done.isCompleted) {
         t.cancel();
+        return;
+      }
+      if (_taskTerminal) {
+        t.cancel();
+        // Same tokenless flush as the idle path: buffered rows are banked
+        // durably (no trim token, nothing deleted from the band).
+        await flush();
+        log('[SYNC] await stop=taskTerminal — the abort boundary ended this '
+            'offload; reporting incomplete.');
+        done.complete(SyncReport(records, batches, false));
         return;
       }
       if (!isLinkUp()) _linkDown = true;

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -7098,9 +7098,14 @@ class DrainController {
         final complete = _taskGeneration != waiterGen &&
             (_supersededTaskComplete[waiterGen] ?? false);
         t.cancel();
-        // Same tokenless flush as the idle path: buffered rows are banked
-        // durably (no trim token, nothing deleted from the band).
-        await flush();
+        // Deliberately NO flush here. A superseded waiter's task is over and
+        // the REPLACEMENT task owns this controller's buffer: a tokenless
+        // commit fired from the stale waiter would snapshot the
+        // replacement's open-burst rows and could overlap its HISTORY_END
+        // token commit — letting the ACK go out before those rows are
+        // durable, which is THE commit-before-ACK violation. The terminal
+        // case needs no flush either: every abort path commits or discards
+        // its buffer before crossing the terminal boundary.
         log('[SYNC] await stop=${complete ? 'supersededComplete' : 'taskTerminal'}'
             ' — this offload ended ${complete ? 'complete (a new task claimed '
             'immediately after HISTORY_COMPLETE)' : 'without completing (abort '

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -2310,11 +2310,18 @@ class BleEngine {
     // there is no flood: hand the state back, or `_offloadActive` stays set
     // on a strap that was never asked for history and every later refresh
     // stops at the already-transmitting guard.
-    if (!await sendInit(drain: drainOnInit)) {
-      // A session that died UNDER the INIT writes: the rollback state now
-      // belongs to whatever replaced it, and the connect must not claim
-      // success for a dead link.
-      if (_sessionIsStale(session)) return false;
+    final initOk = await sendInit(drain: drainOnInit);
+    // UNCONDITIONAL staleness re-check — not only on a failed INIT. The last
+    // write can succeed and the link die before this continuation resumes;
+    // reporting success then hands the caller a READY verdict for a dead
+    // session. And whichever way INIT went, a stale continuation must not
+    // touch the rollback state its replacement now owns.
+    if (_sessionIsStale(session)) {
+      _log('[SYNC] INIT drain abandoned — the link died under the INIT '
+          'writes; not reporting connect success for a dead session.');
+      return false;
+    }
+    if (!initOk) {
       _historyAwaitingFirstStart = false;
       _setOffloadActive(false);
       _lastBackfillAt = floorBeforeInit;
@@ -2852,30 +2859,37 @@ class BleEngine {
       );
       return false;
     }
-    // A commit that FAILED after its task ended re-buffered that task's rows
-    // into this shared controller (the quiescence wait above guarantees the
-    // restore has happened by now, not mid-claim). They were never ACKed, so
-    // the band re-delivers them under this task's own bursts — discard them
-    // rather than let them ride into this task's first commit as data it
-    // never received. The discard poisons the (empty) open burst; this
-    // task's first HISTORY_START clears that latch.
-    if (d.bufferedRecords > 0 || d.bufferedArchives > 0) {
+    // A commit that FAILED after its task was ENDED BY ABORT re-buffered that
+    // task's rows into this shared controller (the quiescence wait above
+    // guarantees the restore has happened by now, not mid-claim). They were
+    // never ACKed, so the band re-delivers them under this task's own
+    // bursts — discard them rather than let them ride into this task's first
+    // commit as data it never received. The discard poisons the (empty) open
+    // burst; this task's first HISTORY_START clears that latch.
+    //
+    // Deliberately scoped to an abort-ended task: a NORMALLY completed task
+    // whose tail commit failed keeps its buffer on purpose (see the
+    // HistoryComplete tail-commit handling) — those rows re-attempt on the
+    // next commit, exactly as documented there.
+    if (session.historyTaskEnded &&
+        (d.bufferedRecords > 0 || d.bufferedArchives > 0)) {
       _log(
-        '[SYNC] refresh($reason) — discarding the previous task\'s '
+        '[SYNC] refresh($reason) — discarding the aborted previous task\'s '
         '${d.bufferedRecords} record(s) + ${d.bufferedArchives} archive(s) '
         'of leftover un-ACKed buffer before starting a new task; the band '
         're-delivers them.',
       );
       d.discardOpenChunk();
     }
-    d.rearm();
     // TASK BOUNDARY: this claim is the start of a genuinely new history task
     // (the guards above have refused every same-task re-entry), so the burst
     // validation-failure counter starts fresh HERE — before opcode 22 — and
-    // nowhere else. Doc 05: a later task must never inherit the previous
-    // task's failure slack. The previous task's terminal latch lifts for the
-    // same reason: ITS stragglers had to stay inert, but this task's markers
-    // are live traffic.
+    // nowhere else, the previous task's waiters are superseded with their
+    // recorded outcome, and the controller re-arms — one call, so the
+    // outcome snapshot can never be ordered after the reset. Doc 05: a later
+    // task must never inherit the previous task's failure slack. The
+    // previous task's terminal latch lifts for the same reason: ITS
+    // stragglers had to stay inert, but this task's markers are live traffic.
     d.startFreshTask();
     session.historyTaskEnded = false;
     // Doc 05: the new task has no active burst until the strap's first
@@ -6872,11 +6886,19 @@ class DrainController {
   bool _taskTerminal = false;
 
   /// The task a waiter belongs to. Bumped by [startFreshTask] so a waiter
-  /// armed for task N resolves (incomplete) the moment task N+1 is claimed —
-  /// even when the claim lands BETWEEN [onTaskTerminal] and the waiter's next
-  /// once-a-second tick, which would otherwise clear the terminal flag under
+  /// armed for task N resolves the moment task N+1 is claimed — even when the
+  /// claim lands BETWEEN the task's end and the waiter's next once-a-second
+  /// tick, which would otherwise reset the completion/terminal state under
   /// the old waiter and leave it parked against the replacement task.
   int _taskGeneration = 0;
+
+  /// Outcome of each superseded task, by its generation: true when it had
+  /// reached HISTORY_COMPLETE when the next claim took over (the immediate
+  /// auto-continue case), false when it ended in a terminal or simply never
+  /// completed. Without this a successful offload superseded before the
+  /// waiter's next tick was reported as `complete=false`. Pruned to the last
+  /// few generations — a waiter outlives its task by at most one tick.
+  final Map<int, bool> _supersededTaskComplete = <int, bool>{};
 
   /// Re-arm for a fresh offload over the same connection (clears the COMPLETE flag
   /// so a new awaitComplete() blocks until the next HISTORY_COMPLETE).
@@ -6933,14 +6955,19 @@ class DrainController {
   /// The one in-task reset stays where the contract puts it: a SUCCESSFUL
   /// validation ([validateBurst]).
   ///
-  /// Also the waiter boundary: the previous task's [awaitComplete] waiters are
-  /// superseded (they resolve incomplete on their next tick via
-  /// [_taskGeneration]) and a pending terminal flag is cleared so THIS task's
-  /// waiters arm cleanly.
+  /// Also the waiter boundary: the outgoing task's outcome is recorded FIRST
+  /// (so an [awaitComplete] waiter superseded before its next tick still
+  /// reports whether ITS task completed or aborted), then the generation
+  /// advances, the terminal flag clears, and the controller [rearm]s — one
+  /// call is the whole claim, so no caller can order the outcome snapshot
+  /// after the state it snapshots has been wiped.
   void startFreshTask() {
+    _supersededTaskComplete[_taskGeneration] = _complete && !_taskTerminal;
+    _supersededTaskComplete.removeWhere((g, _) => g + 8 < _taskGeneration);
     consecutiveValidationFailures = 0;
     _taskTerminal = false;
     _taskGeneration++;
+    rearm();
   }
 
   /// A HISTORY_END closes the burst's wire window: the band computed its
@@ -7063,16 +7090,22 @@ class DrainController {
         return;
       }
       // Terminal flag, OR this waiter's task was superseded by a new claim
-      // (which clears the flag) before this once-a-second tick got to see it.
-      // Either way the awaited offload is over and incomplete.
+      // (which resets the flags) before this once-a-second tick got to see
+      // it. Either way the awaited offload is over; a superseded task
+      // reports the outcome it actually reached — a COMPLETE immediately
+      // followed by an auto-continue claim is a SUCCESS, not a failure.
       if (_taskTerminal || _taskGeneration != waiterGen) {
+        final complete = _taskGeneration != waiterGen &&
+            (_supersededTaskComplete[waiterGen] ?? false);
         t.cancel();
         // Same tokenless flush as the idle path: buffered rows are banked
         // durably (no trim token, nothing deleted from the band).
         await flush();
-        log('[SYNC] await stop=taskTerminal — the abort boundary ended this '
-            'offload; reporting incomplete.');
-        done.complete(SyncReport(records, batches, false));
+        log('[SYNC] await stop=${complete ? 'supersededComplete' : 'taskTerminal'}'
+            ' — this offload ended ${complete ? 'complete (a new task claimed '
+            'immediately after HISTORY_COMPLETE)' : 'without completing (abort '
+            'boundary)'}.');
+        done.complete(SyncReport(records, batches, complete));
         return;
       }
       if (!isLinkUp()) _linkDown = true;

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -363,6 +363,10 @@ enum _HpsTerminalKind {
   timeout,
   disconnected,
 
+  /// The 15th consecutive failed validation — doc 05's terminal `Stuck`.
+  /// One abort, no fifteenth failure result, no same-session retry.
+  stuck,
+
   /// A HISTORICAL_DATA_RESULT (positive or negative) could not be delivered.
   /// The burst window is already closed on the band side, so with no result on
   /// the wire the task cannot make progress — it ends through the one abort
@@ -1240,8 +1244,28 @@ class BleEngine {
   }
 
   bool _offloadActive = false;
-  final List<Frame> _offloadFrames = [];
+  // Each queued frame carries the history-task generation it arrived under, so
+  // the serialized drainer can refuse to process an OLD task's leftovers as
+  // part of its replacement (see [_drainOffloadFrames]).
+  final List<({Frame frame, int taskGen})> _offloadFrames = [];
   bool _drainingOffloadFrames = false;
+
+  /// The history-task generation: bumped when a task is claimed
+  /// ([_startHistoricalRefresh], the INIT drain) and when one ends through the
+  /// abort boundary ([_endHistoryTaskWithAbort]). Every asynchronous
+  /// continuation that can mutate task state or write to the band captures it
+  /// before its first await and re-checks after — a continuation whose
+  /// generation is no longer current belongs to a task that is over, and it
+  /// must neither ACK, abort, clear state nor consume the new task's frames.
+  int _historyTaskGen = 0;
+
+  /// The awaited opcode-20 write of the most recent task-ending abort, while
+  /// it is still in flight. Every task start waits this out (see
+  /// [_startHistoricalRefresh]) so a replacement task cannot put
+  /// GET_DATA_RANGE/opcode 22 on the wire under a band that is still being
+  /// told to abandon the previous one. Deliberately NOT a broad lock: only the
+  /// lifecycle transition serializes on it, never packet ingestion.
+  Future<void>? _historyAbortInFlight;
   int _historyRequests = 0;
   int _historyCompletions = 0;
   SyncReport? _lastSyncReport;
@@ -2205,6 +2229,11 @@ class BleEngine {
           '(deferred_total=$_clockPausedOffloads).',
         );
       }
+      // The INIT drain is a new task like any other claim: leftovers of a
+      // previous session's task (queued frames, parked continuations) are
+      // stale from here — session binding already refuses most of them, the
+      // generation closes the rest.
+      _historyTaskGen++;
       _setOffloadActive(drainOnInit);
       // Only a real drain spends the backfill floor; a deferred one leaves it
       // open so a foreground trigger can retry as soon as the phone corrects.
@@ -2695,6 +2724,19 @@ class BleEngine {
     required String reason,
     bool refreshRange = true,
   }) async {
+    // SERIALIZED LIFECYCLE: a task-ending abort still in flight must complete
+    // before any trigger may start the next task — otherwise range/opcode 22
+    // goes out while the band is still being told to abandon the previous
+    // task. Every waiter resumes on the same turn and the claim below is
+    // synchronous, so the first one through takes the task and the rest fall
+    // out at the already-transmitting guard: at most ONE next task.
+    while (true) {
+      final pendingAbort = _historyAbortInFlight;
+      if (pendingAbort == null) break;
+      _log('[SYNC] refresh($reason) — waiting for the in-flight history abort '
+          'to complete before starting a new task.');
+      await pendingAbort;
+    }
     final d = _drain;
     final session = _session;
     if (session?.connected != true || d == null) return false;
@@ -2731,13 +2773,23 @@ class BleEngine {
     // are live traffic.
     d.startFreshTask();
     session.historyTaskEnded = false;
+    // Claiming IS the generation bump: from here, leftovers of any previous
+    // task (queued frames, parked continuations) are provably stale.
+    _historyTaskGen++;
+    final taskGen = _historyTaskGen;
+    // True once this claim is no longer the engine's live task — either the
+    // link was replaced or a terminal (idle watchdog above all) ended the task
+    // while this method was parked on an await. A stale claim must simply
+    // stop: the state it would "clean up" belongs to someone else now.
+    bool claimStale() => _sessionIsStale(session) || _historyTaskGen != taskGen;
     _setOffloadActive(true);
     if (refreshRange) {
       _log('[SYNC] refresh($reason) — polling GET_DATA_RANGE before 0x16.');
-      await _sendGetDataRange();
+      await _sendGetDataRange(owner: session);
       // INIT spaces commands by ~120 ms; keep the same cadence here so the band
       // has time to emit the range response before we request another drain.
       await Future.delayed(const Duration(milliseconds: 120));
+      if (claimStale()) return false;
     }
     // Data-safety gate: never drain-and-trim history under an untrustworthy phone
     // clock. Poll the strap RTC and compare; if the phone clock looks slow (strap
@@ -2748,7 +2800,7 @@ class BleEngine {
     // deliberately NOT issued here — pushing the strap back to the slow phone
     // would corrupt a correct RTC (see ClockPolicy.phoneClockSuspect).
     await _readClock();
-    if (_session?.connected != true) return false;
+    if (claimStale()) return false;
     if (_deferForClock) {
       _clockPausedOffloads++;
       _log(
@@ -2769,15 +2821,17 @@ class BleEngine {
         'for the 0x16 floor.',
       );
       await Future.delayed(Duration(milliseconds: (wait * 1000).ceil()));
-      if (_session?.connected != true) return false;
+      if (claimStale()) return false;
     }
     _log('[SYNC] refresh($reason) — sending SEND_HISTORICAL_DATA.');
     // `_send` swallows write failures and reports them as false. Claiming
     // success anyway leaves the strap with no request, `_offloadActive` stuck
     // true — so later refreshes bounce off the "already transmitting" guard —
     // and both rate-limit floors spent on a command that never left the phone.
-    if (!await _sendHistoricalData()) {
-      _setOffloadActive(false);
+    if (!await _sendHistoricalData(owner: session)) {
+      // A claim that went stale UNDER the write must not clear the state the
+      // replacement task now owns.
+      if (!claimStale()) _setOffloadActive(false);
       return false;
     }
     _lastHistoricalSendAt = _wallSecs();
@@ -3082,17 +3136,26 @@ class BleEngine {
   /// false only after every attempt failed — the caller must then bounce the
   /// link (the chunk is already durably committed; the band re-delivers it next
   /// session and the decoded store dedups by REPLACE).
-  Future<bool> _writeAckVerified(Uint8List ack, _Session session) async {
+  /// [taskGen] is the history-task generation the ACK belongs to — a retry
+  /// must stop the moment that task ends (abort boundary), or a parked loop
+  /// would go on writing an ended task's token between the abort and the next
+  /// task's frames.
+  Future<bool> _writeAckVerified(
+    Uint8List ack,
+    _Session session, {
+    required int taskGen,
+  }) async {
     var failures = 0;
+    bool stale() => _sessionIsStale(session) || _historyTaskGen != taskGen;
     while (true) {
-      if (_sessionIsStale(session)) return false;
+      if (stale()) return false;
       if (await _write(ack, owner: session)) return true;
       failures++;
       if (!ackRetryPolicy.shouldRetry(failures)) return false;
       _log('[SYNC] batch-ACK write failed (attempt $failures/'
           '${ackRetryPolicy.maxAttempts}) — retrying.');
       await Future.delayed(ackRetryPolicy.delayFor(failures));
-      if (_sessionIsStale(session)) return false;
+      if (stale()) return false;
     }
   }
 
@@ -3116,11 +3179,14 @@ class BleEngine {
     return false;
   }
 
-  Future<bool> _send(int opcode, List<int> payload) async {
+  /// [owner] pins the write to one session (see [_write]) — offload commands
+  /// issued from a long-parked task start pass theirs so a claim that went
+  /// stale mid-await cannot put its command onto a replacement link.
+  Future<bool> _send(int opcode, List<int> payload, {_Session? owner}) async {
     if (_refuseDangerousOpcode(opcode)) return false;
     final frame = buildCommand(
         _seq.nextLive(), opcode, payload, _session?.band ?? BandProfile.gen4);
-    final ok = await _write(frame);
+    final ok = await _write(frame, owner: owner);
     if (!ok) {
       _log('WRITE FAILED for opcode 0x${opcode.toRadixString(16)} — '
           'command not delivered.');
@@ -3187,10 +3253,10 @@ class BleEngine {
             profile: _session?.band ?? BandProfile.gen4),
       );
 
-  Future<bool> _sendGetDataRange() =>
-      _send(Cmd.getDataRange, _offloadPayload);
-  Future<bool> _sendHistoricalData() =>
-      _send(Cmd.sendHistoricalData, _offloadPayload);
+  Future<bool> _sendGetDataRange({_Session? owner}) =>
+      _send(Cmd.getDataRange, _offloadPayload, owner: owner);
+  Future<bool> _sendHistoricalData({_Session? owner}) =>
+      _send(Cmd.sendHistoricalData, _offloadPayload, owner: owner);
 
   /// Ask the strap to prompt more frequent history syncs around a wake time.
   ///
@@ -3418,7 +3484,7 @@ class BleEngine {
 
   void _enqueueOffloadFrame(Frame frame, _Session session) {
     if (_session != session || !session.connected) return; // stale session
-    _offloadFrames.add(frame);
+    _offloadFrames.add((frame: frame, taskGen: _historyTaskGen));
     // A straggler historical frame from a task that ended through the abort
     // boundary must not re-raise the offload — that is exactly the "duplicate
     // terminals hold the offload open" wedge.
@@ -3460,11 +3526,25 @@ class BleEngine {
         // Only REAL drain progress counts: event/console count members ride
         // this queue too, and gen5's console chatter alone could otherwise
         // keep a genuinely stalled offload alive past the timeout forever.
-        if (batch.any((f) => f.packetType == PacketType.historicalData)) {
+        // Stale-generation leftovers count for nothing here either.
+        if (batch.any((e) =>
+            e.taskGen == _historyTaskGen &&
+            e.frame.packetType == PacketType.historicalData)) {
           _armIdleWatchdog();
         }
-        for (final frame in batch) {
+        for (final entry in batch) {
           if (_sessionIsStale(session)) return;
+          final frame = entry.frame;
+          // An OLD task's queued frames must never be processed as part of a
+          // new one: they were counted/collected for a burst window that is
+          // over, and the band re-delivers anything un-ACKed anyway. The one
+          // exception is HISTORY_COMPLETE — like the stuck latch, it ACKs
+          // nothing and an awaitComplete() waiter must still be released.
+          if (entry.taskGen != _historyTaskGen &&
+              !(frame.packetType == PacketType.metadata &&
+                  parseMetadata(frame.inner)?.sub == SyncMeta.historyComplete)) {
+            continue;
+          }
           if (frame.packetType == PacketType.metadata) {
             await _handleSyncMarker(frame, session);
           } else if (frame.packetType == PacketType.historicalData) {
@@ -4110,26 +4190,41 @@ class BleEngine {
     session.historyTaskEnded = true;
     // Nothing further is coming that may keep this task alive.
     session.idleWatchdog?.cancel();
+    // The ended task's parked continuations (a commit mid-await, queued
+    // frames, ACK retries) are stale from this moment.
+    _historyTaskGen++;
     _setHpsTerminal(kind, reason: reason);
     _log('[SYNC] history task terminal ($reason) — sending one best-effort '
         'abort; the band keeps its checkpoint and a later task resumes from '
         'it.');
+    final boundary = _writeHistoryAbort(session, reason: reason);
+    _historyAbortInFlight = boundary;
     try {
-      // Not `_send`: the frame must be pinned to the session whose task is
-      // ending (`owner:`), exactly like the batch ACK.
-      final frame = buildCommand(
-        _seq.nextLive(),
-        Cmd.abortHistoricalTransmits,
-        const [0x00],
-        session.band,
-      );
-      if (!await _write(frame, owner: session)) {
-        _log('[SYNC] best-effort history abort ($reason) was not delivered — '
-            'continuing the terminal anyway.');
-      }
+      await boundary;
     } finally {
+      if (identical(_historyAbortInFlight, boundary)) {
+        _historyAbortInFlight = null;
+      }
       // Release the task only now — the abort boundary is complete.
       _setOffloadActive(false);
+    }
+  }
+
+  Future<void> _writeHistoryAbort(
+    _Session session, {
+    required String reason,
+  }) async {
+    // Not `_send`: the frame must be pinned to the session whose task is
+    // ending (`owner:`), exactly like the batch ACK.
+    final frame = buildCommand(
+      _seq.nextLive(),
+      Cmd.abortHistoricalTransmits,
+      const [0x00],
+      session.band,
+    );
+    if (!await _write(frame, owner: session)) {
+      _log('[SYNC] best-effort history abort ($reason) was not delivered — '
+          'continuing the terminal anyway.');
     }
   }
 
@@ -4142,23 +4237,33 @@ class BleEngine {
     if (session == null || !session.connected) return;
     session.idleWatchdog?.cancel();
     session.historicalRetry?.cancel();
-    // The drain ended on the clock, not on a HISTORY_COMPLETE. Record that as
-    // the terminal here — the only place it is knowable. It used to be attempted
-    // in `_onOffloadFinished` behind a `!complete` flag that no call site ever
-    // passed, so a timed-out drain reported whatever terminal the previous burst
-    // had left behind (usually `success`).
-    _setHpsTerminal(_HpsTerminalKind.timeout, reason: reason);
-    _setOffloadActive(false);
-    if (session.historicalRetries >= _maxHistoricalRetriesPerSession) {
+    // The drain ended on the clock, not on a HISTORY_COMPLETE — the boundary
+    // records the `timeout` terminal, which used to be attempted in
+    // `_onOffloadFinished` behind a `!complete` flag no call site ever passed,
+    // so a timed-out drain reported whatever terminal the previous burst had
+    // left behind (usually `success`).
+    //
+    // The boundary also fixes the ordering this path used to get wrong: it
+    // clears `_offloadActive` only AFTER the awaited abort write resolves, so
+    // a refresh trigger racing this abort cannot start a new task under a
+    // band that is still being told to abandon the old one.
+    final retriesExhausted =
+        session.historicalRetries >= _maxHistoricalRetriesPerSession;
+    if (!retriesExhausted) {
+      session.historicalRetries++;
+      _log('[SYNC] abort($reason) — sending ABORT_HISTORICAL.');
+    }
+    await _endHistoryTaskWithAbort(
+      session: session,
+      kind: _HpsTerminalKind.timeout,
+      reason: reason,
+    );
+    if (retriesExhausted) {
       _log('[SYNC] abort($reason) — already retried '
           '${session.historicalRetries} times this session; NOT re-arming. '
           'The strap is not draining; the reconnect path takes it from here.');
-      await _send(Cmd.abortHistoricalTransmits, const [0x00]);
       return;
     }
-    session.historicalRetries++;
-    _log('[SYNC] abort($reason) — sending ABORT_HISTORICAL.');
-    await _send(Cmd.abortHistoricalTransmits, const [0x00]);
     session.historicalRetry = Timer(
       const Duration(seconds: kHistoricalAbortRetryDelaySeconds),
       () {
@@ -4270,6 +4375,7 @@ class BleEngine {
   Future<void> _refuseHistoryEndOnShortCount({
     required DrainController d,
     required _Session session,
+    required int taskGen,
     required String tokenHex,
     required int? batchId,
     required int? expected,
@@ -4290,6 +4396,9 @@ class BleEngine {
       return;
     }
     if (_sessionIsStale(session)) return;
+    // The task ended while the commit was parked — this continuation may not
+    // send a result or an abort on behalf of a task that is over.
+    if (_historyTaskGen != taskGen) return;
 
     if (d.consecutiveValidationFailures >= kBurstValidationAttemptLimit) {
       // Terminal. One abort, no 15th failure result, and NO same-session
@@ -4323,8 +4432,11 @@ class BleEngine {
               'attempts': d.consecutiveValidationFailures,
             },
           ));
-      await _send(Cmd.abortHistoricalTransmits, const [0x00]);
-      _setOffloadActive(false);
+      await _endHistoryTaskWithAbort(
+        session: session,
+        kind: _HpsTerminalKind.stuck,
+        reason: 'burst_validation_attempts_exhausted',
+      );
       return;
     }
 
@@ -4551,6 +4663,11 @@ class BleEngine {
 
   Future<void> _handleSyncMarker(Frame frame, _Session session) async {
     if (_sessionIsStale(session)) return;
+    // The task this marker belongs to. Re-checked after every await below: a
+    // terminal (idle watchdog, failed result write) that fires while this
+    // handler is parked ends the task, and the resumed continuation must not
+    // ACK, send or mutate on behalf of a task that is over.
+    final taskGen = _historyTaskGen;
     final m = parseMetadata(frame.inner);
     if (m == null) return;
     // Terminal `Stuck`: this session's history ended
@@ -4742,6 +4859,7 @@ class BleEngine {
         await _refuseHistoryEndOnShortCount(
           d: d,
           session: session,
+          taskGen: taskGen,
           tokenHex: tokenHex,
           batchId: m.batchId,
           expected: expected,
@@ -4860,6 +4978,11 @@ class BleEngine {
       // re-delivers the chunk. Echo the 8-byte slice the band acks verbatim —
       // a mangled echo is the "Groundhog Day" re-flood bug.
       final durable = await d.commit(m.token); // raw+samples+cursor, atomic
+      // The task ended while the commit was parked (idle-watchdog abort above
+      // all): the rows are durable — that is never undone — but this
+      // continuation may not ACK for a task that is over. The band was told to
+      // abort and re-delivers the chunk on a later task; dedup-safe.
+      if (_historyTaskGen != taskGen) return;
       // RE-GATE after the await. commit() can take seconds on a large batch —
       // long enough for the link to die under us — and it now reports whether
       // the transaction actually became durable instead of swallowing the
@@ -4899,7 +5022,12 @@ class BleEngine {
       // band never trimming and re-flooding the same chunk forever. On
       // persistent failure bounce the link — the committed data is safe, and
       // the next session's re-delivery is dedup-safe (rows REPLACE by rec_ts).
-      if (!await _writeAckVerified(ack, session)) {
+      if (!await _writeAckVerified(ack, session, taskGen: taskGen)) {
+        // False for one of three reasons: the writes genuinely exhausted, the
+        // session died, or the TASK ended under the retries. Only the first is
+        // this continuation's to handle — a stale one must not touch the
+        // failure ledger, quarantine state or the abort boundary.
+        if (_sessionIsStale(session) || _historyTaskGen != taskGen) return;
         // Real per-chunk ledger row, keyed by the token itself — previously
         // every ledger write here collapsed onto one shared 'capture' row,
         // so a token that kept failing ACROSS reconnects (the "Groundhog

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -2703,6 +2703,12 @@ class BleEngine {
       return false;
     }
     d.rearm();
+    // TASK BOUNDARY: this claim is the start of a genuinely new history task
+    // (the guards above have refused every same-task re-entry), so the burst
+    // validation-failure counter starts fresh HERE — before opcode 22 — and
+    // nowhere else. Doc 05: a later task must never inherit the previous
+    // task's failure slack.
+    d.startFreshTask();
     _setOffloadActive(true);
     if (refreshRange) {
       _log('[SYNC] refresh($reason) — polling GET_DATA_RANGE before 0x16.');
@@ -4468,6 +4474,9 @@ class BleEngine {
       d?.rearm();
       // The one place a new burst is really declared — the only safe point to
       // clear the discarded-burst poison (see DrainController.beginBurst).
+      // The validation-failure counter deliberately SURVIVES this: a failed
+      // burst is re-offered behind a replacement HISTORY_START, and resetting
+      // on it meant a stuck checkpoint never reached the terminal attempt.
       d?.beginBurst();
       _setOffloadActive(true);
       return;
@@ -6415,17 +6424,37 @@ class DrainController {
   /// arrive in order, so a HISTORY_START proves the previous burst's terminal
   /// has already been handled (or is never coming) and the latch may clear.
   ///
-  /// A NEW burst also starts a FRESH validation cycle, and reopens the tally.
-  /// Without the failure reset, burst B's first attempt inherited burst A's
-  /// failure streak — and with it the two-frame slack — so a burst short by
-  /// two could be ACKed, trimming frames never tallied; and 15 different
-  /// bursts each failing once latched `historyStuck` under a log claiming one
-  /// burst failed 15 times. Marker-only re-offers of the SAME burst arrive
-  /// without a HISTORY_START, so their attempts still accumulate.
+  /// Deliberately does NOT touch [consecutiveValidationFailures]. A failed
+  /// validation makes the band re-offer the SAME checkpoint, and that re-offer
+  /// arrives WITH a replacement HISTORY_START — doc 05: a replacement START
+  /// inside a running task discards the partial accumulator but KEEPS the
+  /// failure counter. Resetting here meant a genuinely repeated bad checkpoint
+  /// could never reach the terminal 15th attempt, and the counter's real
+  /// boundary — the TASK — is [startFreshTask]. Marker-only re-offers (no
+  /// START) accumulate the same way.
   void beginBurst() {
     _trimGuard.beginBurst();
-    consecutiveValidationFailures = 0;
     _burstTallyClosed = false;
+  }
+
+  /// A genuinely NEW history task has been claimed — called by the engine
+  /// after the task claim succeeds and before opcode 22 asks the band to
+  /// transmit. Doc 05: slack is based on failures within the CURRENT task and
+  /// must never be inherited by a later one.
+  ///
+  /// The three lifecycle boundaries, which must not be conflated again:
+  ///  * [startFreshTask] — US claiming a new task: the consecutive
+  ///    validation-failure counter starts fresh (a fresh connection gets the
+  ///    same effect from its brand-new controller).
+  ///  * [rearm] — US re-arming for another offload on the same controller:
+  ///    completion latch + burst tally only. Never the failure counter, never
+  ///    the poison latch.
+  ///  * [beginBurst] — the BAND declaring a burst boundary (HISTORY_START):
+  ///    poison latch + tally. Never the failure counter.
+  /// The one in-task reset stays where the contract puts it: a SUCCESSFUL
+  /// validation ([validateBurst]).
+  void startFreshTask() {
+    consecutiveValidationFailures = 0;
   }
 
   /// A HISTORY_END closes the burst's wire window: the band computed its

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -362,6 +362,12 @@ enum _HpsTerminalKind {
   success,
   timeout,
   disconnected,
+
+  /// A HISTORICAL_DATA_RESULT (positive or negative) could not be delivered.
+  /// The burst window is already closed on the band side, so with no result on
+  /// the wire the task cannot make progress — it ends through the one abort
+  /// boundary ([BleEngine._endHistoryTaskWithAbort]).
+  resultWriteFailed,
 }
 
 class _HpsTerminal {
@@ -534,6 +540,19 @@ class _Session {
   /// is to stop that from generating traffic and log noise.
   int stuckMarkersDropped = 0;
   int stuckRefreshesRefused = 0;
+
+  /// The CURRENT history task ended through the abort boundary
+  /// ([BleEngine._endHistoryTaskWithAbort]). While set, straggler markers and
+  /// frames from that task are inert: they must not re-arm the idle watchdog,
+  /// re-raise `_offloadActive` or trigger another abort — a duplicate
+  /// HISTORY_END used to keep a wedged task alive indefinitely. Cleared when
+  /// the next task is explicitly claimed ([BleEngine._startHistoricalRefresh]);
+  /// unlike [historyStuck] it does NOT refuse that claim, so a later
+  /// explicit/scheduled task starts cleanly.
+  bool historyTaskEnded = false;
+
+  /// Markers dropped by [historyTaskEnded] (diagnostics; first one logs).
+  int endedMarkersDropped = 0;
 
   _Session(this.device);
 
@@ -2707,8 +2726,11 @@ class BleEngine {
     // (the guards above have refused every same-task re-entry), so the burst
     // validation-failure counter starts fresh HERE — before opcode 22 — and
     // nowhere else. Doc 05: a later task must never inherit the previous
-    // task's failure slack.
+    // task's failure slack. The previous task's terminal latch lifts for the
+    // same reason: ITS stragglers had to stay inert, but this task's markers
+    // are live traffic.
     d.startFreshTask();
+    session.historyTaskEnded = false;
     _setOffloadActive(true);
     if (refreshRange) {
       _log('[SYNC] refresh($reason) — polling GET_DATA_RANGE before 0x16.');
@@ -3397,7 +3419,11 @@ class BleEngine {
   void _enqueueOffloadFrame(Frame frame, _Session session) {
     if (_session != session || !session.connected) return; // stale session
     _offloadFrames.add(frame);
-    if (_offloadActive || frame.packetType == PacketType.historicalData) {
+    // A straggler historical frame from a task that ended through the abort
+    // boundary must not re-raise the offload — that is exactly the "duplicate
+    // terminals hold the offload open" wedge.
+    if ((_offloadActive || frame.packetType == PacketType.historicalData) &&
+        !session.historyTaskEnded) {
       _setOffloadActive(true);
     }
     if (_drainingOffloadFrames) return;
@@ -3984,6 +4010,10 @@ class BleEngine {
   void _armIdleWatchdog() {
     final session = _session;
     if (session == null || !session.connected) return;
+    // A terminal task has nothing left to wait for: stragglers from it (the
+    // re-offered HISTORY_END above all) must not re-arm the watchdog and keep
+    // the ended task's retry machinery alive.
+    if (session.historyTaskEnded) return;
     session.idleWatchdog?.cancel();
     session.idleWatchdog = Timer(
       const Duration(seconds: kBackfillIdleTimeoutSeconds),
@@ -4045,6 +4075,61 @@ class BleEngine {
         _highFreqReason = null;
         _highFreqUntil = null;
         return;
+    }
+  }
+
+  /// THE task-ending abort boundary. Every terminal that must tell the band to
+  /// exit history mode funnels through here, so the invariants live in one
+  /// place:
+  ///
+  ///  * AT MOST ONE abort per terminal — [_Session.historyTaskEnded] latches
+  ///    first, so a duplicate HISTORY_END (the band re-offers every ~2.5 s
+  ///    until it hears something) cannot fire a second one.
+  ///  * The abort is BEST-EFFORT and session-bound: `_write(owner:)` refuses
+  ///    it once [session] is no longer live, so an old task's abort can never
+  ///    land on a replacement link. A failed write is logged and swallowed —
+  ///    the task is terminating either way.
+  ///  * The task is RELEASED ONLY AFTER the abort boundary completes:
+  ///    `_offloadActive` stays up (refusing every refresh trigger) until the
+  ///    awaited write resolves, so a new task cannot send GET_DATA_RANGE or
+  ///    opcode 22 into the band while the abort is still in flight.
+  ///  * NO reconnect is started here. Doc 05: an ordinary terminal does not
+  ///    reconnect or resubmit; continuation comes from a later connection,
+  ///    scheduler tick or explicit trigger — which
+  ///    [_startHistoricalRefresh] permits again by clearing the latch when it
+  ///    claims the next task.
+  Future<void> _endHistoryTaskWithAbort({
+    required _Session session,
+    required _HpsTerminalKind kind,
+    required String reason,
+  }) async {
+    // A stale session's task died with its link — nothing to abort, and
+    // writing would target the replacement session.
+    if (_sessionIsStale(session)) return;
+    if (session.historyTaskEnded) return; // one abort per terminal
+    session.historyTaskEnded = true;
+    // Nothing further is coming that may keep this task alive.
+    session.idleWatchdog?.cancel();
+    _setHpsTerminal(kind, reason: reason);
+    _log('[SYNC] history task terminal ($reason) — sending one best-effort '
+        'abort; the band keeps its checkpoint and a later task resumes from '
+        'it.');
+    try {
+      // Not `_send`: the frame must be pinned to the session whose task is
+      // ending (`owner:`), exactly like the batch ACK.
+      final frame = buildCommand(
+        _seq.nextLive(),
+        Cmd.abortHistoricalTransmits,
+        const [0x00],
+        session.band,
+      );
+      if (!await _write(frame, owner: session)) {
+        _log('[SYNC] best-effort history abort ($reason) was not delivered — '
+            'continuing the terminal anyway.');
+      }
+    } finally {
+      // Release the task only now — the abort boundary is complete.
+      _setOffloadActive(false);
     }
   }
 
@@ -4243,14 +4328,51 @@ class BleEngine {
       return;
     }
 
+    // `owner:` for the same reason the batch ACK carries it — this is an
+    // offload write, and a session that died mid-await must not have its
+    // failure result land on the replacement link.
     final ok = await _write(
-      buildHistoryResultFail(_seq.nextSync(),
-          profile: _session?.band ?? BandProfile.gen4),
+      buildHistoryResultFail(_seq.nextSync(), profile: session.band),
+      owner: session,
     );
+    if (!ok) {
+      // The burst window is closed and the band never heard a result: it will
+      // re-offer this HISTORY_END every ~2.5 s, and each re-offer used to do
+      // nothing but log `write_ok=false` and re-arm the watchdog — a task
+      // wedged open indefinitely. A result we cannot deliver is TERMINAL for
+      // the task: the rows above are already committed (without the token, so
+      // nothing was trimmed), and the band keeps the checkpoint for the next
+      // task. One best-effort abort, no reconnect, and the task is released
+      // only after that abort boundary completes.
+      _log(
+        '[SYNC] FAILURE result for token=$tokenHex could not be written '
+        '(attempt ${d.consecutiveValidationFailures}/'
+        '$kBurstValidationAttemptLimit) — ending the history task.',
+      );
+      await _bestEffortLedgerWrite(() => LocalDb.upsertSyncLedgerEntry(
+            chunkId: 'batch:$tokenHex',
+            kind: 'historical_batch',
+            status: 'aborted',
+            lastError: 'failure_result_write_failed',
+            metaPatch: {
+              'batch_id': batchId,
+              'expected_burst_packets': expected,
+              'actual_burst_packets': d.currentBurstTrafficCount,
+              'dropped_this_burst': droppedThisBurst,
+              'attempts': d.consecutiveValidationFailures,
+            },
+          ));
+      await _endHistoryTaskWithAbort(
+        session: session,
+        kind: _HpsTerminalKind.resultWriteFailed,
+        reason: 'failure_result_write_failed',
+      );
+      return;
+    }
     _log(
       '[SYNC] sent FAILURE result for token=$tokenHex '
       '(attempt ${d.consecutiveValidationFailures}/'
-      '$kBurstValidationAttemptLimit, write_ok=$ok) — the band re-offers this '
+      '$kBurstValidationAttemptLimit) — the band re-offers this '
       'burst; nothing was trimmed.',
     );
     await _bestEffortLedgerWrite(() => LocalDb.upsertSyncLedgerEntry(
@@ -4449,6 +4571,23 @@ class BleEngine {
           'the re-offered marker without validating or aborting again. '
           'Further re-offers are silent; the band keeps its checkpoint and a '
           'later connection resumes from it.',
+        );
+      }
+      return;
+    }
+    // Same shape for a task that ended through the abort boundary: its
+    // stragglers (duplicate HISTORY_END, a late START) must not re-open the
+    // task, re-arm the watchdog or send anything. HISTORY_COMPLETE passes for
+    // the same reason it passes the stuck latch — it ACKs nothing and any
+    // awaitComplete() waiter must still be released. The latch clears when the
+    // next task is claimed, so this never blocks a later explicit refresh.
+    if (session.historyTaskEnded && m.sub != SyncMeta.historyComplete) {
+      session.endedMarkersDropped++;
+      if (session.endedMarkersDropped == 1) {
+        _log(
+          '[SYNC] history task already ended (abort sent) — dropping the '
+          'straggler marker; further ones are silent until a new task is '
+          'claimed.',
         );
       }
       return;
@@ -4811,20 +4950,24 @@ class BleEngine {
         }
         _log('[SYNC] BATCH-ACK FAILED after '
             '${ackRetryPolicy.maxAttempts} attempts (token=$tokenHex, '
-            'failures_for_this_token=$failCount) — '
-            '${quarantined ? "token QUARANTINED; NOT bouncing again" : "bouncing the link"}; '
-            'data is committed and the band will re-send.');
-        // ONLY bounce a session that is still OURS. _writeAckVerified also
-        // returns false when the session died under it, and tearing down then
-        // would kill the healthy session that replaced it. And never bounce for
-        // a quarantined token: the reconnect is what makes it a loop.
-        if (!quarantined && !_sessionIsStale(session)) {
-          unawaited(
-            _teardownSession(intentional: false).then((_) {
-              _setPhase(BleConnState.idle); // caller's reconnect loop takes over
-            }),
-          );
-        }
+            'failures_for_this_token=$failCount'
+            '${quarantined ? ", token QUARANTINED" : ""}) — ending the '
+            'history task; data is committed and the band re-delivers from '
+            'its un-advanced checkpoint on a later task.');
+        // The band-side task must be told it is over: without a result on the
+        // wire it re-offers this HISTORY_END forever. One best-effort abort
+        // through the common boundary — which no-ops on a stale session, so
+        // _writeAckVerified returning false because the session died under it
+        // can never abort (or previously: tear down) the replacement link.
+        // Deliberately NO link bounce here any more: the reconnect loop is
+        // what turned a persistently failing ACK write into a battery-draining
+        // storm, and the committed rows are safe either way. Nothing is marked
+        // acknowledged and no ACK/batch bookkeeping advances.
+        await _endHistoryTaskWithAbort(
+          session: session,
+          kind: _HpsTerminalKind.resultWriteFailed,
+          reason: 'ack_write_exhausted',
+        );
         return;
       }
       _chunkFailures.recordSuccess(tokenHex);

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -5546,7 +5546,16 @@ class BleEngine {
     // link swap mid-sequence must stop the tail from landing on the
     // replacement (`_write(owner:)`) and report the INIT as not written.
     final session = _session;
-    if (session == null) return false;
+    if (session == null) {
+      // No link, so nothing can be written — but the setup boost must still
+      // end here, exactly as the `finally` blocks below guarantee on every
+      // other exit from this method.
+      if (_connectSetup) {
+        _connectSetup = false;
+        unawaited(_applyLinkPriority());
+      }
+      return false;
+    }
     final band = session.band;
     if (band.isGen5) {
       // gen5 handshake: a single CLIENT_HELLO (GET_HELLO 0x91) written

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -2299,6 +2299,12 @@ class BleEngine {
     // most of them, the generation closes the rest. Doc 05: no burst is
     // active until this task's first HISTORY_START.
     _historyTaskGen++;
+    // Same claim as _startHistoricalRefresh's task boundary: the failure
+    // tally and the waiter generation belong to the TASK, not to the
+    // controller's lifetime. On a fresh connect the controller is already
+    // new and this is a no-op; it matters once a caller reuses an existing
+    // controller (debugStartInitDrain(), or a future one).
+    _drain?.startFreshTask();
     _historyAwaitingFirstStart = drainOnInit;
     _setOffloadActive(drainOnInit);
     // Only a real drain spends the backfill floor; a deferred one leaves it
@@ -2891,6 +2897,11 @@ class BleEngine {
     // previous task's terminal latch lifts for the same reason: ITS
     // stragglers had to stay inert, but this task's markers are live traffic.
     d.startFreshTask();
+    // The previous task's terminal latch, in case this claim never becomes a
+    // task (deferred for clock, or the SEND_HISTORICAL_DATA write fails) —
+    // then it must go back so that task's stragglers stay inert instead of
+    // re-arming the idle watchdog under the current generation.
+    final endedBeforeClaim = session.historyTaskEnded;
     session.historyTaskEnded = false;
     // Doc 05: the new task has no active burst until the strap's first
     // HISTORY_START — until then a HISTORY_END is a duplicate and data
@@ -2932,7 +2943,9 @@ class BleEngine {
         '(deferred_total=$_clockPausedOffloads).',
       );
       // The claim never became a task (no opcode 22): restore the idle
-      // marker/data handling — nothing is awaiting a HISTORY_START.
+      // marker/data handling — nothing is awaiting a HISTORY_START — and
+      // hand the previous task's terminal latch back.
+      session.historyTaskEnded = endedBeforeClaim;
       _historyAwaitingFirstStart = false;
       _setOffloadActive(false);
       return false;
@@ -2958,6 +2971,7 @@ class BleEngine {
       // A claim that went stale UNDER the write must not clear the state the
       // replacement task now owns.
       if (!claimStale()) {
+        session.historyTaskEnded = endedBeforeClaim;
         _historyAwaitingFirstStart = false;
         _setOffloadActive(false);
       }
@@ -5683,6 +5697,10 @@ class BleEngine {
       _log('runSync: no live link — nothing to await.');
       return SyncReport(0, 0, false);
     }
+    // Captured BEFORE awaitComplete: if a replacement task claims this
+    // controller while we're parked in the await, drain.taskGeneration moves
+    // on and this waiter's own generation is what tells the difference below.
+    final waiterGen = drain.taskGeneration;
     final report = await drain.awaitComplete(
       isLinkUp: () => session.connected,
       timeout: timeout,
@@ -5710,7 +5728,12 @@ class BleEngine {
         'strap_history_newest_ts': _strapHistoryNewestTs,
       },
     );
-    if (!report.complete) _setOffloadActive(false);
+    // Only the task this waiter belonged to may release the offload claim —
+    // a replacement task has already pre-armed `_offloadActive` for its own
+    // drain by the time a superseded waiter's tick resolves.
+    if (!report.complete && drain.taskGeneration == waiterGen) {
+      _setOffloadActive(false);
+    }
     // OUTBOUND automation event (Android only — see TaskerBridge.emitEvent for
     // why iOS gets no equivalent). Only on a COMPLETE offload: "sync finished"
     // must mean the strap actually drained, not that a link dropped mid-drain.
@@ -6900,6 +6923,11 @@ class DrainController {
   /// tick, which would otherwise reset the completion/terminal state under
   /// the old waiter and leave it parked against the replacement task.
   int _taskGeneration = 0;
+
+  /// The current task's generation — so a caller holding a waiter's own
+  /// generation (captured before [awaitComplete]) can tell whether the task
+  /// it waited on is still the live one before acting on the outcome.
+  int get taskGeneration => _taskGeneration;
 
   /// Outcome of each superseded task, by its generation: true when it had
   /// reached HISTORY_COMPLETE when the next claim took over (the immediate

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -2249,58 +2249,91 @@ class BleEngine {
       );
       _setPhase(BleConnState.listening);
       _log('Connected + subscribed — listening (history + live).');
-      // INIT seq4 IS SEND_HISTORICAL_DATA, so it needs the SAME data-safety gate
-      // as _startHistoricalRefresh — without it every fresh connection drains
-      // and trims under exactly the untrustworthy phone clock we refuse to drain
-      // under there, which is the common case (a dead-battery reboot lands a bad
-      // clock and a reconnect together).
-      final drainOnInit = !_deferForClock;
-      if (!drainOnInit) {
-        _clockPausedOffloads++;
-        _log(
-          '[SYNC] INIT drain DEFERRED — phone clock appears wrong relative to '
-          'the strap RTC; not draining history until they agree '
-          '(deferred_total=$_clockPausedOffloads).',
-        );
-      }
-      // The INIT drain is a new task like any other claim, so it goes behind
-      // the same lifecycle barrier: a previous session's task-ending abort or
-      // a marker handler still parked in a commit must finish unwinding
-      // before this task arms. (Both resolve fast once their session is
-      // stale — the owner-bound write refuses immediately, and the handler
-      // re-checks staleness at every await.)
-      await _awaitHistoryLifecycleQuiescence();
-      // Leftovers of a previous session's task (queued frames, parked
-      // continuations) are stale from here — session binding already refuses
-      // most of them, the generation closes the rest. Doc 05: no burst is
-      // active until this task's first HISTORY_START.
-      _historyTaskGen++;
-      _historyAwaitingFirstStart = drainOnInit;
-      _setOffloadActive(drainOnInit);
-      // Only a real drain spends the backfill floor; a deferred one leaves it
-      // open so a foreground trigger can retry as soon as the phone corrects.
-      final floorBeforeInit = _lastBackfillAt;
-      if (drainOnInit) _lastBackfillAt = _wallSecs();
-      // Both are pre-armed above because seq4 IS the drain trigger and the
-      // flood can start before the write even returns. If INIT did not go out
-      // there is no flood: hand the state back, or `_offloadActive` stays set
-      // on a strap that was never asked for history and every later refresh
-      // stops at the already-transmitting guard.
-      if (!await sendInit(drain: drainOnInit)) {
-        _historyAwaitingFirstStart = false;
-        _setOffloadActive(false);
-        _lastBackfillAt = floorBeforeInit;
-        _log(
-          '[SYNC] INIT did not fully write — no history was requested; '
-          'clearing offload state so a later refresh can retry.',
-        );
-      }
-      return true;
+      return await _startInitDrain(session);
     } catch (e) {
       _log('connect setup failed: $e');
       await _failConnect();
       return false;
     }
+  }
+
+  /// The INIT drain claim — the tail of [_doConnect], lifted out so its
+  /// lifecycle rules are testable: wait for the previous task's quiescence,
+  /// re-check the session, arm the task state, fire INIT, and roll back if
+  /// INIT never went out. Returns whether connect setup may report success —
+  /// false only when [session] died along the way (no INIT traffic goes out
+  /// then; the disconnect path owns the cleanup).
+  Future<bool> _startInitDrain(_Session session) async {
+    // INIT seq4 IS SEND_HISTORICAL_DATA, so it needs the SAME data-safety gate
+    // as _startHistoricalRefresh — without it every fresh connection drains
+    // and trims under exactly the untrustworthy phone clock we refuse to drain
+    // under there, which is the common case (a dead-battery reboot lands a bad
+    // clock and a reconnect together).
+    final drainOnInit = !_deferForClock;
+    if (!drainOnInit) {
+      _clockPausedOffloads++;
+      _log(
+        '[SYNC] INIT drain DEFERRED — phone clock appears wrong relative to '
+        'the strap RTC; not draining history until they agree '
+        '(deferred_total=$_clockPausedOffloads).',
+      );
+    }
+    // The INIT drain is a new task like any other claim, so it goes behind
+    // the same lifecycle barrier: a previous session's task-ending abort or
+    // a marker handler still parked in a commit must finish unwinding
+    // before this task arms. (Both resolve fast once their session is
+    // stale — the owner-bound write refuses immediately, and the handler
+    // re-checks staleness at every await.)
+    await _awaitHistoryLifecycleQuiescence();
+    // The wait can park for as long as an old commit takes — re-check that
+    // THIS link survived it. A stale connect continuation must not mutate
+    // the task state a replacement session now owns, run INIT against a dead
+    // link, or report the connect as successful.
+    if (_sessionIsStale(session)) {
+      _log('[SYNC] INIT drain abandoned — the link died while waiting for '
+          'the previous history task to unwind.');
+      return false;
+    }
+    // Leftovers of a previous session's task (queued frames, parked
+    // continuations) are stale from here — session binding already refuses
+    // most of them, the generation closes the rest. Doc 05: no burst is
+    // active until this task's first HISTORY_START.
+    _historyTaskGen++;
+    _historyAwaitingFirstStart = drainOnInit;
+    _setOffloadActive(drainOnInit);
+    // Only a real drain spends the backfill floor; a deferred one leaves it
+    // open so a foreground trigger can retry as soon as the phone corrects.
+    final floorBeforeInit = _lastBackfillAt;
+    if (drainOnInit) _lastBackfillAt = _wallSecs();
+    // Both are pre-armed above because seq4 IS the drain trigger and the
+    // flood can start before the write even returns. If INIT did not go out
+    // there is no flood: hand the state back, or `_offloadActive` stays set
+    // on a strap that was never asked for history and every later refresh
+    // stops at the already-transmitting guard.
+    if (!await sendInit(drain: drainOnInit)) {
+      // A session that died UNDER the INIT writes: the rollback state now
+      // belongs to whatever replaced it, and the connect must not claim
+      // success for a dead link.
+      if (_sessionIsStale(session)) return false;
+      _historyAwaitingFirstStart = false;
+      _setOffloadActive(false);
+      _lastBackfillAt = floorBeforeInit;
+      _log(
+        '[SYNC] INIT did not fully write — no history was requested; '
+        'clearing offload state so a later refresh can retry.',
+      );
+    }
+    return true;
+  }
+
+  /// Drive the real INIT-drain claim ([_startInitDrain]) for the CURRENT
+  /// session — the lifecycle barrier, the post-wait staleness re-check and
+  /// the arm/rollback rules sit behind a real connect otherwise.
+  @visibleForTesting
+  Future<bool> debugStartInitDrain() {
+    final session = _session;
+    if (session == null) return Future.value(false);
+    return _startInitDrain(session);
   }
 
   // ── bootstrap ────────────────────────────────────
@@ -2818,6 +2851,22 @@ class BleEngine {
         '[SYNC] refresh($reason) dropped — strap is already transmitting history.',
       );
       return false;
+    }
+    // A commit that FAILED after its task ended re-buffered that task's rows
+    // into this shared controller (the quiescence wait above guarantees the
+    // restore has happened by now, not mid-claim). They were never ACKed, so
+    // the band re-delivers them under this task's own bursts — discard them
+    // rather than let them ride into this task's first commit as data it
+    // never received. The discard poisons the (empty) open burst; this
+    // task's first HISTORY_START clears that latch.
+    if (d.bufferedRecords > 0 || d.bufferedArchives > 0) {
+      _log(
+        '[SYNC] refresh($reason) — discarding the previous task\'s '
+        '${d.bufferedRecords} record(s) + ${d.bufferedArchives} archive(s) '
+        'of leftover un-ACKed buffer before starting a new task; the band '
+        're-delivers them.',
+      );
+      d.discardOpenChunk();
     }
     d.rearm();
     // TASK BOUNDARY: this claim is the start of a genuinely new history task
@@ -5479,7 +5528,12 @@ class BleEngine {
   /// `_offloadActive` set behind it wedges every later refresh on the
   /// already-transmitting guard.
   Future<bool> sendInit({bool drain = true}) async {
-    final band = _session?.band ?? BandProfile.gen4;
+    // Every INIT write is pinned to the session current when INIT began — a
+    // link swap mid-sequence must stop the tail from landing on the
+    // replacement (`_write(owner:)`) and report the INIT as not written.
+    final session = _session;
+    if (session == null) return false;
+    final band = session.band;
     if (band.isGen5) {
       // gen5 handshake: a single CLIENT_HELLO (GET_HELLO 0x91) written
       // with-response opens the just-works bond, then the offload is driven by
@@ -5521,13 +5575,13 @@ class BleEngine {
         // steps back down mid-drain, maintenance traffic resumes, and the
         // offload branches all take the not-offloading path.
         if (ok) {
-          ok = await _sendGetDataRange();
+          ok = await _sendGetDataRange(owner: session);
           await Future.delayed(const Duration(milliseconds: 120));
         }
         if (!drain) {
           _log('gen5 INIT: skipping the drain (phone clock suspect).');
         } else if (ok) {
-          ok = await _sendHistoricalData();
+          ok = await _sendHistoricalData(owner: session);
         }
         if (!ok) {
           _log('gen5 INIT write failed — abandoning the remaining packets.');
@@ -5546,7 +5600,7 @@ class BleEngine {
     var allWritten = true;
     try {
       for (final pkt in pkts) {
-        if (!await _write(pkt)) {
+        if (!await _write(pkt, owner: session)) {
           // Stop at the first failure: the packets are a sequence, and the
           // strap will not act on the tail of one whose head never arrived.
           allWritten = false;
@@ -6817,17 +6871,23 @@ class DrainController {
 
   bool _taskTerminal = false;
 
+  /// The task a waiter belongs to. Bumped by [startFreshTask] so a waiter
+  /// armed for task N resolves (incomplete) the moment task N+1 is claimed —
+  /// even when the claim lands BETWEEN [onTaskTerminal] and the waiter's next
+  /// once-a-second tick, which would otherwise clear the terminal flag under
+  /// the old waiter and leave it parked against the replacement task.
+  int _taskGeneration = 0;
+
   /// Re-arm for a fresh offload over the same connection (clears the COMPLETE flag
-  /// so a new awaitComplete() blocks until the next HISTORY_COMPLETE, and the
-  /// task-terminal flag so it does not resolve instantly on the LAST task's
-  /// abort).
+  /// so a new awaitComplete() blocks until the next HISTORY_COMPLETE).
   ///
-  /// Does NOT clear the poison latch — see [beginBurst]. Re-arming is US asking
-  /// for another offload; the burst boundary is the BAND's to declare.
+  /// Does NOT clear the poison latch (see [beginBurst]) and does NOT clear
+  /// the task-terminal flag ([startFreshTask] owns that): rearm also runs on
+  /// every HISTORY_START, and a burst boundary must never be able to swallow
+  /// a pending terminal out from under a parked waiter.
   void rearm() {
     _complete = false;
     _linkDown = false;
-    _taskTerminal = false;
     _lastProgressAt = DateTime.now();
     burstStats.reset();
     _burstTallyClosed = false;
@@ -6872,8 +6932,15 @@ class DrainController {
   ///    poison latch + tally. Never the failure counter.
   /// The one in-task reset stays where the contract puts it: a SUCCESSFUL
   /// validation ([validateBurst]).
+  ///
+  /// Also the waiter boundary: the previous task's [awaitComplete] waiters are
+  /// superseded (they resolve incomplete on their next tick via
+  /// [_taskGeneration]) and a pending terminal flag is cleared so THIS task's
+  /// waiters arm cleanly.
   void startFreshTask() {
     consecutiveValidationFailures = 0;
+    _taskTerminal = false;
+    _taskGeneration++;
   }
 
   /// A HISTORY_END closes the burst's wire window: the band computed its
@@ -6988,13 +7055,17 @@ class DrainController {
   }) async {
     final evaluator = DrainStopEvaluator(timeout: timeout);
     final start = DateTime.now();
+    final waiterGen = _taskGeneration;
     final done = Completer<SyncReport>();
     Timer.periodic(const Duration(seconds: 1), (t) async {
       if (done.isCompleted) {
         t.cancel();
         return;
       }
-      if (_taskTerminal) {
+      // Terminal flag, OR this waiter's task was superseded by a new claim
+      // (which clears the flag) before this once-a-second tick got to see it.
+      // Either way the awaited offload is over and incomplete.
+      if (_taskTerminal || _taskGeneration != waiterGen) {
         t.cancel();
         // Same tokenless flush as the idle path: buffered rows are banked
         // durably (no trim token, nothing deleted from the band).

--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -1039,11 +1039,17 @@ class BleEngine {
   ///
   /// [onWrite] receives every outgoing frame and returns whether the write
   /// "succeeded", so a test can also assert the failed-write paths.
+  ///
+  /// [onCommit] wires the atomic safe-trim sink, which is what production
+  /// always has — without it the HISTORY_END path refuses every ACK as
+  /// non-trimmable, so the commit-before-ACK ordering and the result-write
+  /// failure paths are unreachable.
   @visibleForTesting
   void debugInstallFakeLink({
     required Future<bool> Function(Uint8List frame) onWrite,
     BandProfile band = BandProfile.gen4,
     ArchiveSink? onArchive,
+    CommitSyncBatchSink? onCommit,
   }) {
     final session = _Session(
       BluetoothDevice(remoteId: const DeviceIdentifier('AA:BB:CC:DD:EE:FF')),
@@ -1056,7 +1062,7 @@ class BleEngine {
     _drain = DrainController(
       onRecord: _storeRecord,
       onRecordsBatch: null,
-      onCommit: null,
+      onCommit: onCommit,
       onArchive: onArchive,
       log: _log,
     );
@@ -1683,6 +1689,10 @@ class BleEngine {
     'history_stuck': _session?.historyStuck ?? false,
     'stuck_markers_dropped': _session?.stuckMarkersDropped ?? 0,
     'stuck_refreshes_refused': _session?.stuckRefreshesRefused ?? 0,
+    // Terminal-task latch (abort boundary) and the straggler traffic it has
+    // absorbed since — the ended-task counterpart of the stuck counters.
+    'history_task_ended': _session?.historyTaskEnded ?? false,
+    'ended_markers_dropped': _session?.endedMarkersDropped ?? 0,
     // Band-reboot signal — see CounterRegressionDetector. Observability only;
     // recovery already happens automatically at the DB layer.
     'counter_regressions_total': _counterRegression.regressions,

--- a/test/gen5_wiring_test.dart
+++ b/test/gen5_wiring_test.dart
@@ -1384,7 +1384,8 @@ void _burstOrdering() {
   group('#260 review — burst boundaries the gate must respect', () {
     final ts = _wallNow() - 3600;
 
-    test('a new HISTORY_START starts a fresh validation cycle', () async {
+    test('a replacement HISTORY_START keeps the task\'s failure counter',
+        () async {
       final b = _Burst();
       // Burst A fails three times (slack stays 0 through attempt 3).
       b.rx(_historyStart());
@@ -1395,17 +1396,21 @@ void _burstOrdering() {
       }
       expect(b.shortLines, hasLength(3));
 
-      // Burst B delivers 1 frame against expected 3. With burst A's three
-      // failures inherited, attempt 4's slack of 2 would ACCEPT 1/3 and let
-      // the band trim two frames never tallied. A fresh burst's first
-      // attempt demands every frame.
+      // The band re-offers its checkpoint behind a replacement HISTORY_START,
+      // still inside the SAME task. Doc 05: the replacement discards the
+      // partial accumulator but KEEPS the failure counter — so this delivery,
+      // 1 frame against expected 3, is judged at attempt 4 with the task's
+      // two-packet slack and passes. (This test used to pin the inverse —
+      // a reset on every START — which meant a genuinely repeated bad
+      // checkpoint could never reach the terminal 15th attempt. The FRESH
+      // boundary is the TASK: see history_task_safety_test.dart.)
       b.rx(_historyStart());
       b.rx(_gen5V18Inner(ts: ts + 1, counter: 4101));
       b.rx(_historyEnd(expected: 3, token: 0x8621));
       await pumpEventQueue();
-      expect(b.shortLines, hasLength(4),
-          reason: 'burst B is judged at attempt one, slack zero');
-      expect(b.acceptedCounts, isEmpty);
+      expect(b.shortLines, hasLength(3),
+          reason: 'attempt 4 of the task carries slack 2 — 1/3 passes');
+      expect(b.acceptedCounts, [1]);
     });
 
     test('chatter after HISTORY_END cannot push a short burst over the line',

--- a/test/gen5_wiring_test.dart
+++ b/test/gen5_wiring_test.dart
@@ -1365,19 +1365,40 @@ void _burstOrdering() {
       expect(b.acceptedCounts.last, 1);
     });
 
-    test('HISTORY_COMPLETE still completes the drain after Stuck', () async {
+    test(
+        'the Stuck terminal itself releases the drain waiter; a straggler '
+        'COMPLETE is inert', () async {
       final b = _Burst();
       await stuckAfterFifteen(b);
       expect(b.engine.historyStuckThisSession, isTrue);
 
+      // COMPLETE used to be let through the latch so a parked awaitComplete()
+      // waiter could still resolve — but it also recorded a SUCCESS terminal
+      // for a task that ended in an abort. The waiter now resolves at the
+      // abort boundary (DrainController.onTaskTerminal), promptly and as
+      // INCOMPLETE. (runSync's own ledger write throws in the test host —
+      // the report is published to the snapshot before it.)
+      await b.engine
+          .runSync(timeout: const Duration(seconds: 30))
+          .catchError((_) => SyncReport(0, 0, false));
+      expect(
+        b.logs.any((l) => l.contains('await stop=taskTerminal')),
+        isTrue,
+        reason: 'the waiter must resolve on the terminal, not sit out the '
+            '60 s idle window or its full timeout',
+      );
+      expect(b.engine.offloadSnapshot['last_report_complete'], isFalse);
+
+      // And the straggler COMPLETE from the ended task is dropped like every
+      // other post-terminal marker — it must not overwrite the Stuck
+      // terminal with success or run the post-offload policy.
       b.rx(_historyComplete());
       await pumpEventQueue();
       expect(
         b.logs.any((l) => l.contains('HistoryComplete — backlog drained')),
-        isTrue,
-        reason: 'COMPLETE ACKs nothing and must not be swallowed by the '
-            'latch, or every awaitComplete waiter runs out its timeout',
+        isFalse,
       );
+      expect(b.engine.offloadSnapshot['last_hps_terminal'], 'stuck');
     });
   });
 

--- a/test/history_task_safety_test.dart
+++ b/test/history_task_safety_test.dart
@@ -251,6 +251,35 @@ void main() {
       expect(d.validateBurst(expectedPacketCount: 0), isTrue);
       expect(d.consecutiveValidationFailures, 0);
     });
+
+    test('onTaskTerminal resolves awaitComplete promptly and incomplete; '
+        'rearm re-arms the waiter for the next task', () {
+      fakeAsync((async) {
+        final d = drain();
+        SyncReport? report;
+        d.awaitComplete(isLinkUp: () => true).then((r) => report = r);
+        async.elapse(const Duration(seconds: 3));
+        expect(report, isNull, reason: 'healthy offload keeps waiting');
+
+        d.onTaskTerminal();
+        async.elapse(const Duration(seconds: 2));
+        expect(report, isNotNull,
+            reason: 'the abort boundary must release the waiter — not the '
+                '60 s idle window, not the full timeout');
+        expect(report!.complete, isFalse);
+
+        // A fresh claim (rearm) clears the terminal: the NEXT waiter parks
+        // normally instead of resolving instantly on the LAST task's abort.
+        d.rearm();
+        SyncReport? next;
+        d.awaitComplete(isLinkUp: () => true).then((r) => next = r);
+        async.elapse(const Duration(seconds: 3));
+        expect(next, isNull);
+        d.onComplete();
+        async.elapse(const Duration(seconds: 2));
+        expect(next?.complete, isTrue);
+      });
+    });
   });
 
   group('T1 — a later task never inherits the previous task\'s slack', () {
@@ -273,10 +302,15 @@ void main() {
       r.rx(_historyComplete());
       await pumpEventQueue();
 
-      // Task B is explicitly claimed and delivers 1 frame against expected 3.
-      // With task A's three failures inherited, the slack of 2 would ACCEPT
-      // 1/3 and let the band trim two frames never tallied.
+      // Task B is explicitly claimed and its first burst delivers 1 frame
+      // against expected 3 (behind its own HISTORY_START — before that first
+      // START a HISTORY_END is a doc-05 duplicate and is dropped). With task
+      // A's three failures inherited, the slack of 2 would ACCEPT 1/3 and
+      // let the band trim two frames never tallied — and a HISTORY_START no
+      // longer resets the counter, so only the task claim stands between
+      // burst B and that inherited slack.
       expect(await r.engine.debugStartHistoricalRefresh(), isTrue);
+      r.rx(_historyStart());
       r.rx(_gen5V18Inner(ts: ts + 10, counter: 101));
       r.rx(_historyEnd(expected: 3, token: 0x9101));
       await pumpEventQueue();
@@ -403,6 +437,17 @@ void main() {
       expect(r.engine.offloadActive, isFalse,
           reason: 'stragglers must not re-open the task');
 
+      // A straggler HISTORY_COMPLETE is inert too: it must not record a
+      // SUCCESS terminal over the abort or run the post-offload policy.
+      r.rx(_historyComplete());
+      await pumpEventQueue();
+      expect(
+        r.logs.any((l) => l.contains('HistoryComplete — backlog drained')),
+        isFalse,
+      );
+      expect(r.engine.offloadSnapshot['last_hps_reason'],
+          'failure_result_write_failed');
+
       // A later explicit task starts cleanly once the write path recovers.
       r.failFailureResults = false;
       expect(await r.engine.debugStartHistoricalRefresh(), isTrue);
@@ -514,22 +559,29 @@ void main() {
         pump();
         expect(r.successResults, isEmpty, reason: 'commit still parked');
 
-        // Three more frames arrive and queue up BEHIND the parked marker —
-        // they belong to the old task.
+        // Three more frames AND a COMPLETE arrive and queue up BEHIND the
+        // parked marker — they belong to the old task.
         r.rx(_gen5V18Inner(ts: ts + 1, counter: 801));
         r.rx(_gen5V18Inner(ts: ts + 2, counter: 802));
         r.rx(_gen5V18Inner(ts: ts + 3, counter: 803));
+        r.rx(_historyComplete());
 
         // The idle watchdog ends the task while the commit is parked.
         async.elapse(const Duration(seconds: 61));
         expect(r.aborts, hasLength(1));
 
         // The parked commit resolves — the old continuation resumes into a
-        // task that is over. It must NOT ACK.
+        // task that is over. It must NOT ACK, and the old task's queued
+        // COMPLETE must not record a success terminal for it.
         held.complete();
         pump();
         expect(r.successResults, isEmpty,
             reason: 'a stale continuation may not echo the trim token');
+        expect(
+          r.logs.any((l) => l.contains('HistoryComplete — backlog drained')),
+          isFalse,
+          reason: 'a stale-generation COMPLETE is dropped, not completed',
+        );
 
         // A replacement task starts; the old task's queued frames must not
         // be counted into its burst window.
@@ -549,6 +601,90 @@ void main() {
             reason: 'the old task\'s three leftover frames counted for '
                 'nothing in the new window');
       });
+    });
+
+    test('a task claim waits for a marker handler still parked in a commit, '
+        'not only for the abort', () {
+      fakeAsync((async) {
+        void pump() => async.elapse(Duration.zero);
+        final r = _Rig();
+        r.holdCommit = Completer<void>();
+        final held = r.holdCommit!;
+
+        r.rx(_historyStart());
+        r.rx(_gen5V18Inner(ts: ts, counter: 850));
+        r.rx(_historyEnd(expected: 1, token: 0x9850));
+        pump();
+
+        // The watchdog ends the task; its abort completes immediately, but
+        // the marker handler is STILL parked inside the held commit.
+        async.elapse(const Duration(seconds: 61));
+        expect(r.aborts, hasLength(1));
+
+        // A claim during that window must wait for full quiescence — if it
+        // ran now, a later commit FAILURE would re-buffer the old task's rows
+        // into the controller the new task is already using.
+        var claimed = false;
+        r.engine.debugStartHistoricalRefresh().then((v) => claimed = v);
+        pump();
+        expect(claimed, isFalse,
+            reason: 'the old task\'s handler has not unwound yet');
+        expect(r.drainRequests, isEmpty,
+            reason: 'no opcode 22 before the old task is quiescent');
+
+        held.complete();
+        pump();
+        expect(claimed, isTrue);
+        expect(r.drainRequests, hasLength(1));
+      });
+    });
+  });
+
+  group('T3b — a new task has no active burst until its first START', () {
+    test('a HISTORY_END before the task\'s first HISTORY_START is a doc-05 '
+        'duplicate — dropped, never validated, no ACK', () async {
+      final r = _Rig();
+      expect(await r.engine.debugStartHistoricalRefresh(), isTrue);
+
+      // A late END straggling in from a previous task, inside the window
+      // between opcode 22 and the strap's first START.
+      r.rx(_historyEnd(expected: 3, token: 0x9350));
+      await pumpEventQueue();
+      expect(r.shortLines, isEmpty, reason: 'never judged by the count gate');
+      expect(r.failureResults, isEmpty);
+      expect(r.successResults, isEmpty);
+      expect(
+        r.logs.any((l) => l.contains('before this task\'s first '
+            'HISTORY_START')),
+        isTrue,
+      );
+
+      // The real task then proceeds normally.
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts, counter: 350));
+      r.rx(_historyEnd(expected: 1, token: 0x9351));
+      await pumpEventQueue();
+      expect(r.successResults, hasLength(1));
+    });
+
+    test('historical data before the first START is dropped, not ingested '
+        'into the coming burst', () async {
+      final r = _Rig();
+      expect(await r.engine.debugStartHistoricalRefresh(), isTrue);
+
+      // Two stragglers from the previous task…
+      r.rx(_gen5V18Inner(ts: ts, counter: 360));
+      r.rx(_gen5V18Inner(ts: ts + 1, counter: 361));
+      // …then the real burst: START + one frame, expected 1.
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts + 2, counter: 362));
+      r.rx(_historyEnd(expected: 1, token: 0x9360));
+      await pumpEventQueue();
+
+      expect(r.successResults, hasLength(1),
+          reason: '1/1 — the stragglers neither inflated the tally…');
+      expect(r.committedRows, [1],
+          reason: '…nor were they buffered into the burst\'s commit');
     });
   });
 
@@ -579,6 +715,35 @@ void main() {
             reason: 'the stale continuation stops silently — it does not '
                 'run the failure bookkeeping for a session it no longer owns');
       });
+    });
+
+    test('an old task\'s abort unwinding after session replacement does not '
+        'release offload state it no longer owns', () async {
+      final r = _Rig()..failFailureResults = true;
+      r.holdAbort = Completer<bool>();
+
+      // Terminal on session A with the abort write parked open.
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts, counter: 950));
+      r.rx(_historyEnd(expected: 3, token: 0x9950));
+      await pumpEventQueue();
+      expect(r.aborts, hasLength(1), reason: 'abort issued and parked');
+
+      // The link is replaced while that write is in flight, and the
+      // replacement session's own drain traffic raises the offload state
+      // (in production, INIT pre-arms it the same way).
+      r.connect();
+      r.rx(_gen5V18Inner(ts: ts + 1, counter: 951));
+      await pumpEventQueue();
+      expect(r.engine.offloadActive, isTrue);
+
+      // The old abort finally resolves — its boundary must not clear the
+      // NEW session's claim on the way out.
+      r.holdAbort!.complete(true);
+      r.holdAbort = null;
+      await pumpEventQueue();
+      expect(r.engine.offloadActive, isTrue,
+          reason: 'the ending task may only release state it still owns');
     });
   });
 

--- a/test/history_task_safety_test.dart
+++ b/test/history_task_safety_test.dart
@@ -1,0 +1,635 @@
+// Adversarial history-task boundaries — the Gen5 task lifecycle under
+// validation retries, failed HISTORICAL_DATA_RESULT writes, terminal aborts,
+// concurrent refresh triggers and stale continuations.
+//
+// Contract under test (doc 05, follow-up ledger items 4–7):
+//  - the consecutive validation-failure counter lives on the TASK: a new task
+//    starts fresh, a replacement HISTORY_START keeps it, success resets it;
+//  - a HISTORICAL_DATA_RESULT the phone cannot write is TERMINAL for the task:
+//    one best-effort abort, no reconnect loop, and the already-committed rows
+//    stay committed (without the trim token);
+//  - a new task must not start while an abort is still in flight, and an old
+//    task's parked continuations/queued frames can neither ACK, abort nor
+//    mutate the task that replaced them;
+//  - Gen4 is untouched: its count gate stays advisory and its ACK bytes are
+//    identical.
+//
+// Everything drives the REAL receive path (FrameRoutePolicy → serialized
+// offload queue → _handleSyncMarker) over a stubbed GATT write with the real
+// atomic-commit sink shape — not re-implemented policy logic.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ble/ble_engine.dart';
+import 'package:openstrap_protocol/openstrap_protocol.dart';
+
+int _wallNow() => DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+Uint8List _historyStart() =>
+    Uint8List.fromList(<int>[PacketType.metadata, 0x01, SyncMeta.historyStart]);
+
+Uint8List _historyComplete() => Uint8List.fromList(
+    <int>[PacketType.metadata, 0x03, SyncMeta.historyComplete]);
+
+/// A type-49 METADATA HISTORY_END inner: `expected_count` u32 @9 and the
+/// 8-byte trim token @13:21 the result echoes verbatim.
+Uint8List _historyEnd({required int expected, required int token}) {
+  final inner = Uint8List(24);
+  inner[0] = PacketType.metadata;
+  inner[1] = 0x02;
+  inner[2] = SyncMeta.historyEnd;
+  final v = ByteData.sublistView(inner);
+  v.setUint32(3, 1786000000, Endian.little); // strap clock
+  v.setUint32(9, expected, Endian.little);
+  v.setUint32(13, token, Endian.little); // marker A
+  v.setUint32(17, 0x18, Endian.little); // marker B / batch id
+  return inner;
+}
+
+/// The verbatim 8 bytes a success result for [token] must echo.
+List<int> _tokenBytes(int token) {
+  final b = Uint8List(8);
+  ByteData.sublistView(b)
+    ..setUint32(0, token, Endian.little)
+    ..setUint32(4, 0x18, Endian.little);
+  return b;
+}
+
+Uint8List _gen5V18Inner({required int ts, required int counter}) {
+  final inner = Uint8List(kGen5V18InnerLen);
+  final v = ByteData.sublistView(inner);
+  inner[0] = PacketType.historicalData;
+  inner[1] = 18;
+  inner[2] = 0x80;
+  v.setUint32(3, counter, Endian.little);
+  v.setUint32(7, ts, Endian.little);
+  inner[14] = 64; // heart rate
+  v.setFloat32(33, 0.5, Endian.little); // dynamic acceleration
+  v.setFloat32(45, 1.0, Endian.little); // gravity z → |g| = 1.0
+  return inner;
+}
+
+/// A gen4 v24 historical inner (the trusted decode path — no gate applies).
+Uint8List _gen4V24Inner({required int ts, required int counter}) {
+  final inner = Uint8List(89);
+  inner[0] = PacketType.historicalData;
+  inner[1] = 24;
+  final view = ByteData.sublistView(inner);
+  view.setUint32(3, counter, Endian.little);
+  view.setUint32(7, ts, Endian.little);
+  return inner;
+}
+
+/// A type-48 EVENT inner (envelope per protocol's `_envelopeBody`).
+Uint8List _eventInner(int id, List<int> body, {int ts = 1786000000}) {
+  final inner = Uint8List(12 + body.length);
+  inner[0] = PacketType.event;
+  inner[1] = 0x07;
+  final view = ByteData.sublistView(inner);
+  view.setUint16(2, id, Endian.little);
+  view.setUint32(4, ts, Endian.little);
+  view.setUint16(8, 0, Endian.little);
+  view.setUint16(10, body.length, Endian.little);
+  inner.setRange(12, inner.length, body);
+  return inner;
+}
+
+/// One outgoing command, decoded far enough to identify: opcode + first body
+/// byte (a HISTORICAL_DATA_RESULT is `01` for success, `00` for failure).
+class _Cmd {
+  final int opcode;
+  final int body0;
+  final List<int> body;
+  _Cmd(this.opcode, this.body0, this.body);
+}
+
+/// A fake gen5/gen4 link with the real safe-trim commit sink and a
+/// configurable transport: individual result polarities can be failed, the
+/// abort write can be held open, and GET_CLOCK is answered with a healthy
+/// correlated reply so `_startHistoricalRefresh` runs end to end.
+class _Rig {
+  final BandProfile band;
+  final logs = <String>[];
+
+  /// Every write ATTEMPT that reached the transport, in order (the hook runs
+  /// after the engine's session/owner guards — a stale-session write never
+  /// appears here).
+  final writes = <_Cmd>[];
+
+  /// Ordering probe: `commit:<token|null>` and `write:<opcode>:<body0>`.
+  final events = <String>[];
+  final committedTokens = <String?>[];
+  final committedRows = <int>[];
+
+  bool failFailureResults = false;
+  bool failSuccessResults = false;
+  bool answerClock = true;
+
+  /// When set, abort (opcode 20) writes park on this future.
+  Completer<bool>? holdAbort;
+
+  /// When set, the NEXT commit parks on this future (then completes normally).
+  Completer<void>? holdCommit;
+
+  late final BleEngine engine;
+
+  _Rig({this.band = BandProfile.gen5}) {
+    engine = BleEngine(
+      onRecord: (_, _) async {},
+      onState: (_) {},
+      log: logs.add,
+    );
+    connect();
+  }
+
+  /// Stand up a fresh session on the same engine (a reconnect, as far as
+  /// everything session-scoped is concerned).
+  void connect() => engine.debugInstallFakeLink(
+        band: band,
+        onCommit: (raws, samples, token, {archives, deviceFamily}) async {
+          final hold = holdCommit;
+          if (hold != null) {
+            holdCommit = null;
+            await hold.future;
+          }
+          events.add('commit:$token');
+          committedTokens.add(token);
+          committedRows.add(raws.length + (archives ?? const []).length);
+        },
+        onWrite: (f) async {
+          final p = parseFrame(f, profile: band);
+          if (p == null || !p.valid) return true;
+          final opcode = p.inner[2];
+          final body = p.inner.sublist(3);
+          final body0 = body.isEmpty ? -1 : body[0];
+          writes.add(_Cmd(opcode, body0, body));
+          events.add('write:$opcode:$body0');
+          if (opcode == Cmd.getClock && answerClock) {
+            final seq = p.inner[1];
+            scheduleMicrotask(() => engine.debugAbsorbDecoded(
+                  Decoded('cmd_response', {
+                    'opcode': Cmd.getClock,
+                    'req_seq': seq,
+                    'cmd_status': 1,
+                    'clock_epoch': _wallNow(),
+                  }),
+                ));
+          }
+          if (opcode == Cmd.abortHistoricalTransmits && holdAbort != null) {
+            return holdAbort!.future;
+          }
+          if (opcode == Cmd.historicalDataResult) {
+            if (body0 == 0x00 && failFailureResults) return false;
+            if (body0 == 0x01 && failSuccessResults) return false;
+          }
+          return true;
+        },
+      );
+
+  void rx(Uint8List inner, {String role = 'data'}) =>
+      engine.debugReceiveFrame(Frame(inner, true, true), role: role);
+
+  List<_Cmd> get failureResults => writes
+      .where((c) => c.opcode == Cmd.historicalDataResult && c.body0 == 0x00)
+      .toList();
+  List<_Cmd> get successResults => writes
+      .where((c) => c.opcode == Cmd.historicalDataResult && c.body0 == 0x01)
+      .toList();
+  List<_Cmd> get aborts =>
+      writes.where((c) => c.opcode == Cmd.abortHistoricalTransmits).toList();
+  List<_Cmd> get drainRequests =>
+      writes.where((c) => c.opcode == Cmd.sendHistoricalData).toList();
+  List<_Cmd> get rangePolls =>
+      writes.where((c) => c.opcode == Cmd.getDataRange).toList();
+
+  List<String> get shortLines =>
+      logs.where((l) => l.contains('Burst packet-count SHORT')).toList();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final ts = _wallNow() - 3600;
+
+  group('DrainController — the three lifecycle boundaries', () {
+    DrainController drain() => DrainController(
+          onRecord: (sample, raw) async {},
+          onRecordsBatch: null,
+          onCommit: (raws, samples, token, {archives, deviceFamily}) async {},
+          onArchive: null,
+          log: (_) {},
+        );
+
+    test('startFreshTask resets the failure counter', () {
+      final d = drain();
+      d.consecutiveValidationFailures = 7;
+      d.startFreshTask();
+      expect(d.consecutiveValidationFailures, 0);
+    });
+
+    test('beginBurst (replacement HISTORY_START) KEEPS the failure counter '
+        'while rearm keeps it too', () {
+      final d = drain();
+      d.consecutiveValidationFailures = 4;
+      d.rearm();
+      d.beginBurst();
+      expect(d.consecutiveValidationFailures, 4,
+          reason: 'doc 05: a replacement START discards the partial '
+              'accumulator but keeps the failure counter');
+    });
+
+    test('successful validation resets the counter (the one in-task reset)',
+        () {
+      final d = drain();
+      // Two failures against an empty tally…
+      expect(d.validateBurst(expectedPacketCount: 5), isFalse);
+      expect(d.validateBurst(expectedPacketCount: 5), isFalse);
+      expect(d.consecutiveValidationFailures, 2);
+      // …then a burst that matches.
+      expect(d.validateBurst(expectedPacketCount: 0), isTrue);
+      expect(d.consecutiveValidationFailures, 0);
+    });
+  });
+
+  group('T1 — a later task never inherits the previous task\'s slack', () {
+    test(
+        'three failures in task A do not grant task B\'s first burst the '
+        'two-packet slack', () async {
+      final r = _Rig();
+      // Task A: one short burst, judged three times via marker-only
+      // re-offers — the counter climbs to 3 (slack would be 2 from here).
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts, counter: 100));
+      for (var i = 0; i < 3; i++) {
+        r.rx(_historyEnd(expected: 5, token: 0x9100));
+        await pumpEventQueue();
+      }
+      expect(r.shortLines, hasLength(3));
+
+      // Task A hands over (COMPLETE) — nothing about completion touches the
+      // counter.
+      r.rx(_historyComplete());
+      await pumpEventQueue();
+
+      // Task B is explicitly claimed and delivers 1 frame against expected 3.
+      // With task A's three failures inherited, the slack of 2 would ACCEPT
+      // 1/3 and let the band trim two frames never tallied.
+      expect(await r.engine.debugStartHistoricalRefresh(), isTrue);
+      r.rx(_gen5V18Inner(ts: ts + 10, counter: 101));
+      r.rx(_historyEnd(expected: 3, token: 0x9101));
+      await pumpEventQueue();
+
+      expect(r.shortLines, hasLength(4),
+          reason: 'task B\'s first burst is judged at attempt 1, slack 0');
+      expect(r.shortLines.last, contains('attempt 1,'));
+      expect(r.successResults, isEmpty,
+          reason: 'nothing may be ACKed on inherited slack');
+    });
+
+    test('a replacement HISTORY_START keeps the counter and resets the tally',
+        () async {
+      final r = _Rig();
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts, counter: 200));
+      r.rx(_gen5V18Inner(ts: ts + 1, counter: 201));
+      r.rx(_historyEnd(expected: 9, token: 0x9200));
+      await pumpEventQueue();
+      expect(r.shortLines, hasLength(1));
+      expect(r.shortLines.last, contains('attempt 1,'));
+      expect(r.shortLines.last, contains('traffic=2'));
+
+      // Replacement START inside the same task: the partial accumulator/tally
+      // is discarded, the failure count is not.
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts + 2, counter: 202));
+      r.rx(_gen5V18Inner(ts: ts + 3, counter: 203));
+      r.rx(_gen5V18Inner(ts: ts + 4, counter: 204));
+      r.rx(_historyEnd(expected: 9, token: 0x9200));
+      await pumpEventQueue();
+
+      expect(r.shortLines, hasLength(2));
+      expect(r.shortLines.last, contains('attempt 2,'),
+          reason: 'the failure count survived the replacement START');
+      expect(r.shortLines.last, contains('traffic=3'),
+          reason: 'the tally did not — only the new delivery is counted');
+    });
+
+    test('a successful validation resets the counter mid-task', () async {
+      final r = _Rig();
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts, counter: 300));
+      r.rx(_historyEnd(expected: 3, token: 0x9300));
+      await pumpEventQueue();
+      r.rx(_historyEnd(expected: 3, token: 0x9300));
+      await pumpEventQueue();
+      expect(r.shortLines, hasLength(2)); // attempts 1 and 2
+
+      // The band re-offers complete this time — success.
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts + 1, counter: 301));
+      r.rx(_gen5V18Inner(ts: ts + 2, counter: 302));
+      r.rx(_historyEnd(expected: 2, token: 0x9301));
+      await pumpEventQueue();
+      expect(r.successResults, hasLength(1));
+
+      // The next short burst is judged at attempt 1 again.
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts + 3, counter: 303));
+      r.rx(_historyEnd(expected: 3, token: 0x9302));
+      await pumpEventQueue();
+      expect(r.shortLines, hasLength(3));
+      expect(r.shortLines.last, contains('attempt 1,'));
+    });
+  });
+
+  group('T4 — the fifteenth failure', () {
+    test('attempts 1–14 send the negative result; attempt 15 sends exactly '
+        'one abort and no fifteenth result', () async {
+      final r = _Rig();
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts, counter: 400));
+      for (var i = 1; i <= kBurstValidationAttemptLimit; i++) {
+        r.rx(_historyEnd(expected: 5, token: 0x9400));
+        await pumpEventQueue();
+      }
+      expect(r.failureResults, hasLength(kBurstValidationAttemptLimit - 1));
+      expect(r.aborts, hasLength(1));
+      expect(r.engine.offloadSnapshot['last_hps_terminal'], 'stuck');
+      expect(r.engine.offloadSnapshot['history_task_ended'], isTrue);
+      expect(r.engine.offloadActive, isFalse,
+          reason: 'the task is released after the abort boundary');
+
+      // The terminal is emitted once: further re-offers are inert.
+      final before = r.writes.length;
+      r.rx(_historyEnd(expected: 5, token: 0x9400));
+      await pumpEventQueue();
+      expect(r.writes.length, before);
+    });
+  });
+
+  group('T5 — a failed negative-result write is terminal', () {
+    test(
+        'rows stay committed without the token, one abort goes out, no '
+        'success ACK ever, and a later task starts cleanly', () async {
+      final r = _Rig()..failFailureResults = true;
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts, counter: 500));
+      r.rx(_historyEnd(expected: 3, token: 0x9500));
+      await pumpEventQueue();
+
+      // The received row was preserved — committed WITHOUT the trim token.
+      expect(r.committedTokens, [null]);
+      expect(r.committedRows, [1]);
+      expect(r.successResults, isEmpty,
+          reason: 'a failed burst must never be ACKed');
+      expect(r.failureResults, hasLength(1),
+          reason: 'one attempt reached the transport and failed');
+      expect(r.aborts, hasLength(1), reason: 'exactly one best-effort abort');
+      expect(r.engine.offloadSnapshot['last_hps_reason'],
+          'failure_result_write_failed');
+      expect(r.engine.offloadActive, isFalse);
+
+      // Duplicate HISTORY_END markers after terminal are inert: no watchdog
+      // re-arm, no further validation, no traffic.
+      final before = r.writes.length;
+      for (var i = 0; i < 3; i++) {
+        r.rx(_historyEnd(expected: 3, token: 0x9500));
+        await pumpEventQueue();
+      }
+      expect(r.writes.length, before);
+      expect(r.engine.offloadSnapshot['ended_markers_dropped'], 3);
+      expect(r.engine.offloadActive, isFalse,
+          reason: 'stragglers must not re-open the task');
+
+      // A later explicit task starts cleanly once the write path recovers.
+      r.failFailureResults = false;
+      expect(await r.engine.debugStartHistoricalRefresh(), isTrue);
+      expect(r.drainRequests, hasLength(1));
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts + 10, counter: 501));
+      r.rx(_historyEnd(expected: 1, token: 0x9501));
+      await pumpEventQueue();
+      expect(r.successResults, hasLength(1),
+          reason: 'the new task validates and ACKs normally');
+    });
+  });
+
+  group('T6 — exhausted positive-result writes', () {
+    test(
+        'durable commit first, bounded retries, then one abort — and no '
+        'reconnect, no acked bookkeeping', () async {
+      final r = _Rig()..failSuccessResults = true;
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts, counter: 600));
+      r.rx(_historyEnd(expected: 1, token: 0x9600));
+      // Real (bounded) retry backoff: 200 + 400 ms.
+      await pumpEventQueue();
+      await Future<void>.delayed(const Duration(seconds: 1));
+      await pumpEventQueue();
+
+      // Commit-before-ACK: the durable commit precedes the first ACK attempt.
+      final commitAt = r.events.indexWhere((e) => e.startsWith('commit:') && !e.endsWith(':null'));
+      final firstAckAt = r.events.indexWhere(
+          (e) => e == 'write:${Cmd.historicalDataResult}:1');
+      expect(commitAt, isNonNegative);
+      expect(firstAckAt, greaterThan(commitAt));
+
+      expect(r.successResults, hasLength(3),
+          reason: 'the existing bounded ACK retries are preserved');
+      expect(r.aborts, hasLength(1),
+          reason: 'exactly one abort once the retries are exhausted');
+      expect(r.engine.offloadSnapshot['batches_acked'], 0,
+          reason: 'no acknowledged-batch bookkeeping may advance');
+      expect(r.engine.offloadSnapshot['last_hps_reason'], 'ack_write_exhausted');
+      expect(r.logs.where((l) => l.contains('bouncing the link')), isEmpty,
+          reason: 'no immediate reconnect loop');
+      expect(r.engine.isConnected, isFalse,
+          reason: 'fake link never enters listening — but nothing tore the '
+              'session down either');
+      expect(r.logs.where((l) => l.contains('BATCH-ACK FAILED')), hasLength(1));
+      expect(r.engine.offloadActive, isFalse);
+    });
+  });
+
+  group('T7 — no task starts while an abort is in flight', () {
+    test(
+        'manual, strap and repeated triggers all wait for the abort; at most '
+        'one serialized next task follows', () async {
+      final r = _Rig()..failFailureResults = true;
+      r.holdAbort = Completer<bool>();
+
+      // Terminal with the abort write parked open.
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts, counter: 700));
+      r.rx(_historyEnd(expected: 3, token: 0x9700));
+      await pumpEventQueue();
+      expect(r.aborts, hasLength(1), reason: 'abort issued and parked');
+
+      // Refresh triggers land while the abort is pending: a manual refresh,
+      // the strap's high-frequency prompt, and a second manual attempt.
+      final manual1 = r.engine.debugStartHistoricalRefresh();
+      r.rx(_eventInner(EventId.highFreqSyncPrompt, const <int>[]),
+          role: 'events');
+      final manual2 = r.engine.debugStartHistoricalRefresh();
+      await pumpEventQueue();
+
+      expect(r.rangePolls, isEmpty,
+          reason: 'no GET_DATA_RANGE may go out before the abort completes');
+      expect(r.drainRequests, isEmpty,
+          reason: 'no opcode 22 may go out before the abort completes');
+
+      // The abort completes — exactly one waiter claims the next task.
+      r.holdAbort!.complete(true);
+      r.holdAbort = null;
+      final results = await Future.wait([manual1, manual2]);
+      await pumpEventQueue();
+      // Give the strap-prompt path (fired unawaited) time to finish too.
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      expect(r.drainRequests, hasLength(1),
+          reason: 'at most one properly serialized next task');
+      expect(results.where((sent) => sent), hasLength(1));
+    });
+  });
+
+  group('T8 — an old task generation cannot touch its replacement', () {
+    test(
+        'a continuation parked in commit cannot ACK after the watchdog ends '
+        'the task, and the old task\'s queued frames are not processed as '
+        'part of the new one', () {
+      fakeAsync((async) {
+        // Microtasks AND the serialized drainer's zero-duration batch yields.
+        void pump() => async.elapse(Duration.zero);
+
+        final r = _Rig();
+        r.holdCommit = Completer<void>();
+        final held = r.holdCommit!;
+
+        // A complete burst whose durable commit parks mid-await.
+        r.rx(_historyStart());
+        r.rx(_gen5V18Inner(ts: ts, counter: 800));
+        r.rx(_historyEnd(expected: 1, token: 0x9800));
+        pump();
+        expect(r.successResults, isEmpty, reason: 'commit still parked');
+
+        // Three more frames arrive and queue up BEHIND the parked marker —
+        // they belong to the old task.
+        r.rx(_gen5V18Inner(ts: ts + 1, counter: 801));
+        r.rx(_gen5V18Inner(ts: ts + 2, counter: 802));
+        r.rx(_gen5V18Inner(ts: ts + 3, counter: 803));
+
+        // The idle watchdog ends the task while the commit is parked.
+        async.elapse(const Duration(seconds: 61));
+        expect(r.aborts, hasLength(1));
+
+        // The parked commit resolves — the old continuation resumes into a
+        // task that is over. It must NOT ACK.
+        held.complete();
+        pump();
+        expect(r.successResults, isEmpty,
+            reason: 'a stale continuation may not echo the trim token');
+
+        // A replacement task starts; the old task's queued frames must not
+        // be counted into its burst window.
+        var claimed = false;
+        r.engine.debugStartHistoricalRefresh().then((v) => claimed = v);
+        pump();
+        expect(claimed, isTrue);
+        r.rx(_historyStart());
+        r.rx(_gen5V18Inner(ts: ts + 10, counter: 810));
+        r.rx(_gen5V18Inner(ts: ts + 11, counter: 811));
+        r.rx(_historyEnd(expected: 5, token: 0x9810));
+        pump();
+
+        expect(r.shortLines, hasLength(1),
+            reason: 'the new burst is short — 2 of 5');
+        expect(r.shortLines.last, contains('traffic=2'),
+            reason: 'the old task\'s three leftover frames counted for '
+                'nothing in the new window');
+      });
+    });
+  });
+
+  group('T9 — session replacement', () {
+    test('an ACK retry loop finishing for session A neither writes onto nor '
+        'aborts session B', () {
+      fakeAsync((async) {
+        final r = _Rig()..failSuccessResults = true;
+        r.rx(_historyStart());
+        r.rx(_gen5V18Inner(ts: ts, counter: 900));
+        r.rx(_historyEnd(expected: 1, token: 0x9900));
+        async.elapse(Duration.zero);
+        expect(r.successResults, hasLength(1),
+            reason: 'first ACK attempt failed; retry backoff pending');
+
+        // The link is replaced while the retry loop sleeps.
+        r.connect();
+        final writesAtReplacement = r.writes.length;
+
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        expect(r.writes.length, writesAtReplacement,
+            reason: 'no retry, result or abort may reach the new session — '
+                'the owner-bound write and the stale-session guards both '
+                'stand between them');
+        expect(r.logs.where((l) => l.contains('BATCH-ACK FAILED')), isEmpty,
+            reason: 'the stale continuation stops silently — it does not '
+                'run the failure bookkeeping for a session it no longer owns');
+      });
+    });
+  });
+
+  group('T10 — gen4 stays advisory and byte-identical', () {
+    test('a short gen4 burst is still ACKed with the verbatim token and '
+        'never accumulates failures', () async {
+      final r = _Rig(band: BandProfile.gen4);
+      for (var i = 0; i < 4; i++) {
+        r.rx(_historyStart());
+        r.rx(_gen4V24Inner(ts: ts + i, counter: 1000 + i));
+        r.rx(_historyEnd(expected: 5, token: 0xA000 + i));
+        await pumpEventQueue();
+      }
+
+      expect(r.failureResults, isEmpty,
+          reason: 'gen4 never sends the failure result — the gate is '
+              'advisory there');
+      expect(r.aborts, isEmpty);
+      expect(r.shortLines, isEmpty);
+      expect(
+        r.logs.where((l) => l.contains('ADVISORY, gen4')).length,
+        4,
+        reason: 'the mismatch is recorded for observability only',
+      );
+      expect(r.successResults, hasLength(4));
+      // Byte-identical ACK: `01` + the verbatim 8-byte token.
+      final last = r.successResults.last;
+      expect(last.body.take(9).toList(), [0x01, ..._tokenBytes(0xA003)]);
+    });
+  });
+
+  group('T11 — commit-before-ACK ordering', () {
+    test('the durable commit with the trim token precedes the ACK write', () async {
+      final r = _Rig();
+      r.rx(_historyStart());
+      r.rx(_gen5V18Inner(ts: ts, counter: 1100));
+      r.rx(_historyEnd(expected: 1, token: 0xB100));
+      await pumpEventQueue();
+
+      expect(r.successResults, hasLength(1));
+      final commitAt =
+          r.events.indexWhere((e) => e.startsWith('commit:') && !e.endsWith(':null'));
+      final ackAt = r.events
+          .indexWhere((e) => e == 'write:${Cmd.historicalDataResult}:1');
+      expect(commitAt, isNonNegative,
+          reason: 'the trim token must be committed durably');
+      expect(ackAt, greaterThan(commitAt),
+          reason: 'the ACK is written only after the commit reported durable');
+      // And the ACK echoes the token verbatim.
+      expect(r.successResults.single.body.take(9).toList(),
+          [0x01, ..._tokenBytes(0xB100)]);
+    });
+  });
+}

--- a/test/history_task_safety_test.dart
+++ b/test/history_task_safety_test.dart
@@ -131,8 +131,11 @@ class _Rig {
   /// When set, abort (opcode 20) writes park on this future.
   Completer<bool>? holdAbort;
 
-  /// When set, the NEXT commit parks on this future (then completes normally).
+  /// When set, the NEXT commit parks on this future (then completes normally,
+  /// or throws if [failHeldCommit] is set — the shape of a transaction that
+  /// fails after parking for seconds).
   Completer<void>? holdCommit;
+  bool failHeldCommit = false;
 
   late final BleEngine engine;
 
@@ -154,6 +157,10 @@ class _Rig {
           if (hold != null) {
             holdCommit = null;
             await hold.future;
+            if (failHeldCommit) {
+              failHeldCommit = false;
+              throw StateError('held commit rolled back');
+            }
           }
           events.add('commit:$token');
           committedTokens.add(token);
@@ -268,9 +275,11 @@ void main() {
                 '60 s idle window, not the full timeout');
         expect(report!.complete, isFalse);
 
-        // A fresh claim (rearm) clears the terminal: the NEXT waiter parks
-        // normally instead of resolving instantly on the LAST task's abort.
+        // A fresh CLAIM (rearm + startFreshTask) clears the terminal: the
+        // NEXT waiter parks normally instead of resolving instantly on the
+        // LAST task's abort.
         d.rearm();
+        d.startFreshTask();
         SyncReport? next;
         d.awaitComplete(isLinkUp: () => true).then((r) => next = r);
         async.elapse(const Duration(seconds: 3));
@@ -278,6 +287,36 @@ void main() {
         d.onComplete();
         async.elapse(const Duration(seconds: 2));
         expect(next?.complete, isTrue);
+      });
+    });
+
+    test(
+        'a replacement claim landing between the terminal and the waiter\'s '
+        'next tick still resolves the OLD waiter incomplete', () {
+      fakeAsync((async) {
+        final d = drain();
+        SyncReport? old;
+        d.awaitComplete(isLinkUp: () => true).then((r) => old = r);
+
+        // Terminal AND the replacement claim inside one tick window — the
+        // claim clears the terminal flag before the once-a-second check ever
+        // sees it. The waiter generation is what still catches it.
+        d.onTaskTerminal();
+        d.rearm();
+        d.startFreshTask();
+        SyncReport? fresh;
+        d.awaitComplete(isLinkUp: () => true).then((r) => fresh = r);
+
+        async.elapse(const Duration(seconds: 2));
+        expect(old, isNotNull,
+            reason: 'the superseded waiter must resolve — not park against '
+                'the replacement task');
+        expect(old!.complete, isFalse);
+        expect(fresh, isNull, reason: 'the new task\'s waiter stays armed');
+
+        d.onComplete();
+        async.elapse(const Duration(seconds: 2));
+        expect(fresh?.complete, isTrue);
       });
     });
   });
@@ -541,15 +580,16 @@ void main() {
 
   group('T8 — an old task generation cannot touch its replacement', () {
     test(
-        'a continuation parked in commit cannot ACK after the watchdog ends '
-        'the task, and the old task\'s queued frames are not processed as '
-        'part of the new one', () {
+        'a continuation whose parked commit FAILS after the watchdog ends '
+        'the task cannot ACK, and its restored rows do not leak into the '
+        'replacement task', () {
       fakeAsync((async) {
         // Microtasks AND the serialized drainer's zero-duration batch yields.
         void pump() => async.elapse(Duration.zero);
 
         final r = _Rig();
         r.holdCommit = Completer<void>();
+        r.failHeldCommit = true;
         final held = r.holdCommit!;
 
         // A complete burst whose durable commit parks mid-await.
@@ -570,9 +610,10 @@ void main() {
         async.elapse(const Duration(seconds: 61));
         expect(r.aborts, hasLength(1));
 
-        // The parked commit resolves — the old continuation resumes into a
-        // task that is over. It must NOT ACK, and the old task's queued
-        // COMPLETE must not record a success terminal for it.
+        // The parked commit resolves by FAILING: DrainController restores
+        // its snapshot into the shared buffer. The stale continuation must
+        // not ACK, and the old task's queued COMPLETE must not record a
+        // success terminal for it.
         held.complete();
         pump();
         expect(r.successResults, isEmpty,
@@ -583,12 +624,19 @@ void main() {
           reason: 'a stale-generation COMPLETE is dropped, not completed',
         );
 
-        // A replacement task starts; the old task's queued frames must not
-        // be counted into its burst window.
+        // A replacement task starts. It must first DISCARD the failed
+        // commit's restored rows (never ACKed — the band re-delivers them),
+        // and the old task's queued frames must not be counted into its
+        // burst window.
         var claimed = false;
         r.engine.debugStartHistoricalRefresh().then((v) => claimed = v);
         pump();
         expect(claimed, isTrue);
+        expect(
+          r.logs.any((l) => l.contains('leftover un-ACKed buffer')),
+          isTrue,
+          reason: 'the restored row is discarded before the new task starts',
+        );
         r.rx(_historyStart());
         r.rx(_gen5V18Inner(ts: ts + 10, counter: 810));
         r.rx(_gen5V18Inner(ts: ts + 11, counter: 811));
@@ -600,6 +648,11 @@ void main() {
         expect(r.shortLines.last, contains('traffic=2'),
             reason: 'the old task\'s three leftover frames counted for '
                 'nothing in the new window');
+        // The refusal commits the short burst without a token — and it must
+        // carry ONLY the new task's two rows, not the old task's restored one.
+        expect(r.committedRows, [2],
+            reason: 'the failed commit\'s restored row did not ride into the '
+                'replacement task\'s commit');
       });
     });
 
@@ -744,6 +797,62 @@ void main() {
       await pumpEventQueue();
       expect(r.engine.offloadActive, isTrue,
           reason: 'the ending task may only release state it still owns');
+    });
+  });
+
+  group('T-INIT — the INIT drain honours the lifecycle barrier and its '
+      'session', () {
+    test(
+        'a link that dies while INIT waits out an old parked commit sends no '
+        'INIT traffic and does not report a successful setup', () {
+      fakeAsync((async) {
+        void pump() => async.elapse(Duration.zero);
+        final r = _Rig();
+        r.holdCommit = Completer<void>();
+        final held = r.holdCommit!;
+
+        // Session A's marker handler parks inside its commit…
+        r.rx(_historyStart());
+        r.rx(_gen5V18Inner(ts: ts, counter: 970));
+        r.rx(_historyEnd(expected: 1, token: 0x9970));
+        pump();
+
+        // …while session A's connect continuation reaches the INIT claim and
+        // waits on the lifecycle barrier.
+        bool? ready;
+        r.engine.debugStartInitDrain().then((v) => ready = v);
+        pump();
+        expect(ready, isNull, reason: 'the barrier is held by the commit');
+
+        // The link is replaced while the barrier is held.
+        r.connect();
+        final at = r.writes.length;
+
+        held.complete();
+        pump();
+        expect(ready, isFalse,
+            reason: 'a stale connect continuation must not report READY');
+        expect(r.writes.length, at,
+            reason: 'no GET_DATA_RANGE/opcode 22 for a dead session — and '
+                'nothing on the replacement link');
+      });
+    });
+
+    test('sendInit is session-bound — a link swap mid-sequence stops the '
+        'tail and reports not-written', () async {
+      final r = _Rig();
+      final init = r.engine.sendInit();
+      // Let the range poll go out, then swap the link inside the 120 ms gap
+      // before SEND_HISTORICAL_DATA.
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      expect(r.rangePolls, hasLength(1));
+      final at = r.writes.length;
+      r.connect();
+
+      expect(await init, isFalse);
+      expect(r.writes.length, at,
+          reason: 'the drain trigger must not land on the replacement link');
+      expect(r.drainRequests, isEmpty);
     });
   });
 

--- a/test/history_task_safety_test.dart
+++ b/test/history_task_safety_test.dart
@@ -131,6 +131,12 @@ class _Rig {
   /// When set, abort (opcode 20) writes park on this future.
   Completer<bool>? holdAbort;
 
+  /// When set, the link is replaced (a drop + reconnect, as far as
+  /// session-scoped state is concerned) immediately after the
+  /// SEND_HISTORICAL_DATA write SUCCEEDS — the write lands, the session dies
+  /// before the caller's continuation resumes.
+  bool dropLinkAfterDrainRequest = false;
+
   /// When set, the NEXT commit parks on this future (then completes normally,
   /// or throws if [failHeldCommit] is set — the shape of a transaction that
   /// fails after parking for seconds).
@@ -187,6 +193,10 @@ class _Rig {
           }
           if (opcode == Cmd.abortHistoricalTransmits && holdAbort != null) {
             return holdAbort!.future;
+          }
+          if (opcode == Cmd.sendHistoricalData && dropLinkAfterDrainRequest) {
+            dropLinkAfterDrainRequest = false;
+            connect(); // the write succeeds; the session it served is gone
           }
           if (opcode == Cmd.historicalDataResult) {
             if (body0 == 0x00 && failFailureResults) return false;
@@ -275,10 +285,9 @@ void main() {
                 '60 s idle window, not the full timeout');
         expect(report!.complete, isFalse);
 
-        // A fresh CLAIM (rearm + startFreshTask) clears the terminal: the
-        // NEXT waiter parks normally instead of resolving instantly on the
-        // LAST task's abort.
-        d.rearm();
+        // A fresh CLAIM (startFreshTask re-arms internally) clears the
+        // terminal: the NEXT waiter parks normally instead of resolving
+        // instantly on the LAST task's abort.
         d.startFreshTask();
         SyncReport? next;
         d.awaitComplete(isLinkUp: () => true).then((r) => next = r);
@@ -302,7 +311,6 @@ void main() {
         // claim clears the terminal flag before the once-a-second check ever
         // sees it. The waiter generation is what still catches it.
         d.onTaskTerminal();
-        d.rearm();
         d.startFreshTask();
         SyncReport? fresh;
         d.awaitComplete(isLinkUp: () => true).then((r) => fresh = r);
@@ -317,6 +325,29 @@ void main() {
         d.onComplete();
         async.elapse(const Duration(seconds: 2));
         expect(fresh?.complete, isTrue);
+      });
+    });
+
+    test(
+        'HISTORY_COMPLETE followed by an immediate auto-continue claim still '
+        'reports the superseded task as COMPLETE', () {
+      fakeAsync((async) {
+        final d = drain();
+        SyncReport? old;
+        d.awaitComplete(isLinkUp: () => true).then((r) => old = r);
+
+        // The offload completes and auto-continue claims the next task
+        // before the waiter's next once-a-second tick — the claim wipes the
+        // completion flag, so the recorded per-task outcome is all that is
+        // left of the truth.
+        d.onComplete();
+        d.startFreshTask();
+
+        async.elapse(const Duration(seconds: 2));
+        expect(old, isNotNull);
+        expect(old!.complete, isTrue,
+            reason: 'the superseded task DID complete — reporting failure '
+                'here turned every fast auto-continue into a phantom error');
       });
     });
   });
@@ -836,6 +867,21 @@ void main() {
             reason: 'no GET_DATA_RANGE/opcode 22 for a dead session — and '
                 'nothing on the replacement link');
       });
+    });
+
+    test(
+        'an INIT whose last write succeeds onto a link that dies before the '
+        'continuation resumes still does not report a successful setup',
+        () async {
+      final r = _Rig()..dropLinkAfterDrainRequest = true;
+      // The whole INIT sequence is written successfully — but the session is
+      // replaced the instant the final (drain-trigger) write lands, i.e.
+      // before _startInitDrain's continuation can run. The setup verdict
+      // must be false: a READY report for a dead session arms the caller's
+      // post-connect flows against a link that no longer exists.
+      expect(await r.engine.debugStartInitDrain(), isFalse);
+      expect(r.drainRequests, hasLength(1),
+          reason: 'the write itself did go out — only the verdict changes');
     });
 
     test('sendInit is session-bound — a link swap mid-sequence stops the '

--- a/test/history_task_safety_test.dart
+++ b/test/history_task_safety_test.dart
@@ -24,6 +24,7 @@ import 'dart:typed_data';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openstrap_edge/ble/ble_engine.dart';
+import 'package:openstrap_edge/data/models.dart';
 import 'package:openstrap_protocol/openstrap_protocol.dart';
 
 int _wallNow() => DateTime.now().millisecondsSinceEpoch ~/ 1000;
@@ -348,6 +349,57 @@ void main() {
         expect(old!.complete, isTrue,
             reason: 'the superseded task DID complete — reporting failure '
                 'here turned every fast auto-continue into a phantom error');
+      });
+    });
+
+    test(
+        'a superseded waiter performs NO commit — the replacement\'s buffered '
+        'rows are persisted only by its own token commit', () {
+      fakeAsync((async) {
+        RawRecord raw(int counter) => RawRecord(
+              counter: counter,
+              packetType: 0x2f,
+              hex: '2f18${counter.toRadixString(16).padLeft(8, '0')}',
+              capturedAt: 1786000000000 + counter,
+              recTs: 1786000000 + counter,
+            );
+        final commits = <(String?, int)>[];
+        final d = DrainController(
+          onRecord: (sample, r) async {},
+          onRecordsBatch: null,
+          onCommit: (raws, samples, token, {archives, deviceFamily}) async {
+            commits.add((token, raws.length));
+          },
+          onArchive: null,
+          log: (_) {},
+        );
+        SyncReport? old;
+        d.awaitComplete(isLinkUp: () => true).then((r) => old = r);
+
+        // The task completes and auto-continue claims the replacement, whose
+        // open burst buffers rows BEFORE the old waiter's next tick.
+        d.onComplete();
+        d.startFreshTask();
+        d.beginBurst();
+        d.onHistoricalRecord(raw(1), null, 24);
+        d.onHistoricalRecord(raw(2), null, 24);
+
+        async.elapse(const Duration(seconds: 2));
+        expect(old?.complete, isTrue);
+        expect(commits, isEmpty,
+            reason: 'a stale waiter flushing here would snapshot the '
+                'replacement\'s open burst and could overlap its token '
+                'commit — the ACK must never precede those rows\' '
+                'durability');
+        expect(d.bufferedRecords, 2,
+            reason: 'the rows stay in the replacement\'s buffer');
+
+        // Only the replacement's OWN token commit persists them.
+        bool? durable;
+        d.commit(const [1, 2, 3, 4, 5, 6, 7, 8]).then((v) => durable = v);
+        async.flushMicrotasks();
+        expect(durable, isTrue);
+        expect(commits, [('0102030405060708', 2)]);
       });
     });
   });


### PR DESCRIPTION
Makes the Gen5 historical-transfer task lifecycle safe across validation retries, failed `HISTORICAL_DATA_RESULT` writes, terminal aborts, concurrent refresh triggers, and stale asynchronous work from an older task or session. Implements items 4–7 of the follow-up ledger against the doc-05 official history-sync contract (Sensor-HPS task semantics). All changes live in `lib/ble/ble_engine.dart` plus tests; no protocol framing, opcode bodies, schema, metrics, dependency pins, or `kAlgoVersion` change.

## What this enforces

**Validation failures are scoped to one history task.**
`DrainController` now names the three lifecycle boundaries explicitly: `startFreshTask()` (the engine claiming a new task — the consecutive validation-failure counter starts fresh here, before opcode 22, and nowhere else), `rearm()` (completion latch + burst tally only), and `beginBurst()` (a band-declared HISTORY_START — poison latch + tally only). A replacement HISTORY_START inside a running task discards the partial accumulator but **keeps** the failure counter, so a genuinely repeated bad checkpoint can reach the terminal 15th attempt — and a later task can never inherit the previous task's two-packet slack. Success remains the one in-task reset.

**Failed result writes terminate the task with one session-bound abort.**
A negative (short-count) result that cannot be written used to be logged as `write_ok=false` and left the task wedged open while the band re-offered its HISTORY_END every ~2.5 s; exhausted positive-result (trim ACK) writes bounced the link without ever telling the band-side task it was over. Both now funnel through one boundary, `_endHistoryTaskWithAbort()`: latch the terminal (at most one abort per terminal), cancel the idle watchdog, send ONE best-effort session-bound opcode-20 abort, and release `_offloadActive` only after that write resolves. No reconnect is started — per doc 05, continuation belongs to a later connection, scheduler tick, or explicit trigger. Committed rows stay committed (without the trim token), and re-delivery remains dedup-safe.

**Replacement tasks wait for aborts and parked commits to finish.**
Every task start — refresh triggers *and* the INIT drain — waits for full quiescence of the previous task: the in-flight abort write and any sync-marker handler still parked inside a durable commit. The claim itself is synchronous, so concurrent triggers produce at most one next task; the rest fall out at the already-transmitting guard.

**Stale frames, markers, ACKs, and continuations cannot affect a replacement task.**
A history-task generation is bumped at every claim and every abort terminal. Queued offload frames carry the generation they arrived under and stale leftovers are skipped (including a stale HISTORY_COMPLETE, which used to be able to record a success terminal over an abort); parked continuations re-check the generation after every await — after the durable commit, between ACK retries, and across the refresh claim's range/clock/floor awaits — so an old task can neither ACK, abort, clear state, nor consume the new task's frames. A claim also discards the un-ACKed buffer an abort-ended task's failed commit restored (the band re-delivers it), while a normally completed task's preserved tail keeps its documented re-attempt behavior.

**Pre-START Gen5 data and duplicate HISTORY_END are not ingested or ACKed.**
Doc 05: a task is Running-with-no-active-burst until the strap's first HISTORY_START, and in that state a HISTORY_END is a duplicate — dropped, no ACK, no validation. Historical data frames in that window are dropped un-ACKed for the band to re-deliver under a real burst. Enforced on Gen5 only; the Gen4 marker flow is unpinned and unchanged (its count gate stays advisory, and its ACK still echoes the verbatim 8-byte token, pinned byte-exact by test).

**`runSync()` receives the correct task-scoped outcome.**
The abort boundary resolves `awaitComplete()` promptly via `DrainController.onTaskTerminal()` instead of letting the waiter sit out the 60 s idle window or its full timeout. Waiters are generation-scoped: a task superseded before the waiter's next tick reports the outcome it actually reached — HISTORY_COMPLETE followed by an immediate auto-continue claim resolves as success, an aborted task as incomplete. A superseded waiter performs **no** flush on the shared controller, so it can never overlap the replacement's token commit.

**INIT and all history writes remain bound to their originating BLE session.**
GET_DATA_RANGE, SEND_HISTORICAL_DATA, the failure result, the batch ACK, the abort, and every INIT packet pass `owner:` to the serialized write path — a session that died mid-await can never land a write on the replacement link. The INIT claim re-checks staleness after the quiescence wait and unconditionally after `sendInit`, so a link that dies under the INIT writes cannot report connect success; an old abort unwinding after a session swap no longer clears the replacement's offload state.

**Commit-before-ACK remains preserved.**
The decoded rows + trim cursor still commit durably, in one transaction, before `buildHistoryResultOk` echoes the verbatim 8-byte HISTORY_END token — the ordering is asserted directly against the commit sink and the wire in the new tests, and a failed result never advances the durable trim cursor.

## Tests

`test/history_task_safety_test.dart` (new) drives the real receive path (`FrameRoutePolicy` → serialized offload queue → marker handler) over a stubbed GATT transport with the production safe-trim commit sink: task-scoped counter lifetime, the 15th-failure boundary (14 negative results, exactly one abort, no fifteenth result), both result-write failure terminals, the abort-in-flight race, stale generations and queued frames, session replacement, pre-START windows, waiter outcome races, INIT lifecycle, and Gen4 regression pins. Two pre-existing tests that pinned the inverted counter reset and the COMPLETE-through-the-stuck-latch behavior now pin the doc-05 semantics.

## Verification

| command | result |
|---|---|
| `git status --short` | clean |
| `git merge-base --is-ancestor origin/main HEAD` | origin/main (`d4d4cde`) is an ancestor of HEAD |
| `git diff --check origin/main...HEAD` | clean |
| `flutter analyze --no-pub` | No issues found |
| `flutter test --concurrency=1` | all tests passed: 2993 passed, 422 skipped, 0 failed (full serial run at `b4cd24d`) |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when starting, refreshing, or aborting history transfers.
  * Prevented stale, pre-start, or out-of-sequence history data from affecting active sessions.
  * Ensured failed writes and terminal transfer errors restore a consistent state.
  * Improved handling of retries, acknowledgments, burst validation, and task completion.

* **Diagnostics**
  * Preserved CRC and revision diagnostics for historical data.
  * Archived history frames with unknown revisions for later inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
