### PR TITLE
fix irregular rhythm notification firing almost every day

### DIFF
--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -1432,11 +1432,31 @@ import 'substrate.dart';
 // Days already finalized keep the score they were derived with — raw prunes at
 // `rawRetentionDays`, so no bump can heal them.
 //
+// v80 — irregular-rhythm 24/7 SCREEN false-positive fix. `irregularBeatScreen`
+// (analytics) computed one Poincaré SD1/SD2 + pNN70 ratio blended across an
+// entire calendar day (sleep + rest + exercise + posture changes). Real user
+// data showed EVERY sampled day sat at or over both thresholds (sd1/sd2
+// 0.63-0.81 vs 0.70 cutoff; pnn70 27-56% vs 30% cutoff) — the "medical"
+// notification was firing almost daily, because ordinary daily physiological
+// variability alone clears these thresholds when blended into one number; the
+// thresholds were never validated for a 24h aggregate (traced to an
+// uncalibrated commit, PR #12). Fix: the screen now also requires the same
+// two conditions hold independently in a real fraction (default 50%) of
+// short (5-min) mostly-stationary windows across the day — i.e. sustained,
+// not just present once in the blend. Wired at both call sites
+// (`onehz_pipeline.dart`'s day-span AND sleep-only screens) via the new
+// `nnTimesMs` param. THIS CAN MOVE `irregular_rhythm_flag` from 1→0 on days
+// that were false-flagging; it cannot move it 0→1 (strictly stricter).
+// PIN GATE (invariant #5): do not release with a pubspec pin that predates
+// the analytics commit landing `_sustainedAcrossWindows` in
+// irregular_rhythm.dart, or recomputing v80 against a sibling without it
+// would silently keep firing the false positive.
+//
 // PIN GATE (invariant #5): v77 above cites the analytics walking term
 // (OpenStrap/analytics#52). Do not release with a pubspec pin that predates
 // that merge — recomputing v77+ against a sibling that cannot price walking
 // would burn the version on nothing.
-const int kAlgoVersion = 79;
+const int kAlgoVersion = 80;
 
 /// The sibling SHAs this version was derived against, asserted against
 /// pubspec.yaml in test/db_serve_version_and_reads_test.dart.

--- a/lib/compute/onehz_pipeline.dart
+++ b/lib/compute/onehz_pipeline.dart
@@ -457,6 +457,11 @@ Map<String, dynamic> deriveDayBundle(Map<String, dynamic> inputJson) {
       rrTsMs: d.dayRrTsMs.isEmpty ? null : d.dayRrTsMs);
   final irregular24h = irregularBeatScreen(
     dayCorrected.nn,
+    // Require sustained irregularity in independent short windows, not just
+    // in one ratio blended across sleep+rest+exercise+posture changes — see
+    // irregularBeatScreen's doc. Without this, real data showed the screen
+    // firing on effectively every day regardless of actual cardiac health.
+    nnTimesMs: dayCorrected.nnTimesMs,
     artifactFraction: (1.0 - dayCorrected.cleanFraction).clamp(0.0, 1.0),
   );
 
@@ -871,6 +876,7 @@ Map<String, dynamic> deriveDayBundle(Map<String, dynamic> inputJson) {
   // confidence was a hard-coded 0.5 however noisy the night was.
   final irregularSleep = irregularBeatScreen(
     nn,
+    nnTimesMs: nnTimes,
     artifactFraction: artifactFraction,
   );
   final irrSleep = irregularSleep.present ? irregularSleep.value : null;


### PR DESCRIPTION
companion to OpenStrap/analytics#53 — the sustained-window fix for the irregular-rhythm screen. this side just wires the new nnTimesMs param through both call sites (day-span + sleep-only) and bumps kAlgoVersion (79 -> 80) since it can move irregular_rhythm_flag on already-derived days.

don't merge before analytics#53 lands and this repo's pin is repinned to that merge, same pin-gate deal as v77/v79.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved irregular-rhythm detection by requiring patterns to persist across mostly stationary five-minute windows.
  - Reduced false-positive irregular-rhythm alerts in both full-day and sleep-only analyses.
- **Analytics**
  - Updated the analytics algorithm to version 80.
  - Enhanced time-aware analysis using cleaned heartbeat timing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->