### PR TITLE
language picker in profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,11 @@ lib/firebase_options.dart
 
 .codegraph/
 
+# gen-l10n output — regenerated from lib/l10n/*.arb by `flutter gen-l10n`
+# (also runs automatically before build/analyze/test). The .arb files are
+# the source and stay tracked.
+lib/l10n/app_localizations*.dart
+
 # Rendered previews of docs/*.svg — regenerate from the svg rather than
 # committing them. The svg IS the source; these are just what gets pasted
 # into Discord/issues, and they're ~750kb a piece.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,16 @@ are green locally first.
   more useful than a unit test alone.
 - No `Co-Authored-By` trailers.
 
+## Translations
+
+The app's strings live in `lib/l10n/app_en.arb` (the source of truth — only a
+handful of strings are wired up so far, more get pulled in over time). To add
+a language: copy `app_en.arb` to `app_<code>.arb` (e.g. `app_es.arb`) in the
+same folder, translate the values, and keep every key identical to the
+English file. Run `flutter gen-l10n` to regenerate, then add your language's
+display name to `_kLanguageNames` in `lib/ui2/profile/profile.dart` so it
+shows up in the picker. Open a PR.
+
 ## Reporting protocol findings
 
 If you've worked out a field, an opcode, or an event we don't decode yet, that's

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,3 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -122,6 +122,8 @@ class _OpenStrapAppState extends State<OpenStrapApp> with WidgetsBindingObserver
     final locale = context.watch<LocaleController>();
     return MaterialApp(
       title: 'OpenStrap',
+      onGenerateTitle: (context) =>
+          AppLocalizations.of(context)?.appTitle ?? 'OpenStrap',
       debugShowCheckedModeBanner: false,
       // The palette is the design system's, the CHOICE is still the user's.
       theme: buildTheme(Brightness.light),

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -6,9 +6,11 @@ import 'package:provider/provider.dart';
 
 import 'ai/briefing.dart' show BriefingPeriod;
 import 'coach/coach_config.dart';
+import 'l10n/app_localizations.dart';
 import 'notify/notification_service.dart';
 import 'notify/tap_router.dart';
 import 'state/app_state.dart';
+import 'state/locale_controller.dart';
 import 'state/prefs.dart';
 import 'telemetry/telemetry_service.dart';
 import 'theme/theme_controller.dart';
@@ -117,6 +119,7 @@ class _OpenStrapAppState extends State<OpenStrapApp> with WidgetsBindingObserver
   @override
   Widget build(BuildContext context) {
     final theme = context.watch<ThemeController>();
+    final locale = context.watch<LocaleController>();
     return MaterialApp(
       title: 'OpenStrap',
       debugShowCheckedModeBanner: false,
@@ -124,6 +127,9 @@ class _OpenStrapAppState extends State<OpenStrapApp> with WidgetsBindingObserver
       theme: buildTheme(Brightness.light),
       darkTheme: buildTheme(Brightness.dark),
       themeMode: theme.materialThemeMode,
+      locale: locale.locale, // null = follow the OS locale
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
       builder: (context, child) =>
           ThemeSwitchOverlay(key: themeSwitchKey, child: child!),
       navigatorObservers: [TelemetryNavigatorObserver()],

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -122,8 +122,6 @@ class _OpenStrapAppState extends State<OpenStrapApp> with WidgetsBindingObserver
     final locale = context.watch<LocaleController>();
     return MaterialApp(
       title: 'OpenStrap',
-      onGenerateTitle: (context) =>
-          AppLocalizations.of(context)?.appTitle ?? 'OpenStrap',
       debugShowCheckedModeBanner: false,
       // The palette is the design system's, the CHOICE is still the user's.
       theme: buildTheme(Brightness.light),

--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -1540,7 +1540,14 @@ const int kAlgoVersion = 80;
 // no caller passing it `active`/`basal`/`total` are byte-identical to before
 // — the walking-cadence NUMBER change already happened at v77 above, via
 // #283's own a077a4a pin, before this branch's pin moved past it.
-const String kAnalyticsPin = '7105256b37ad61b49453a6b96543a2b80ea74487';
+// Repin to analytics main @ #53 merge (187e026), one hop on top of 7105256.
+// This is the v80 PIN GATE above being closed: #53 lands `nnTimesMs` on
+// `irregularBeatScreen`, which onehz_pipeline.dart (this same v80 change) was
+// already calling — the pin was never moved when kAlgoVersion went to 80, so
+// a clean checkout failed `flutter analyze` (undefined_named_parameter) and
+// would have recomputed v80 against a sibling without the sustained-window
+// fix it claims. No other symbol changed; no further kAlgoVersion move.
+const String kAnalyticsPin = '187e026fd975d3885ff1a22af5e125d1c8c1825e';
 const String kProtocolPin = '19d72919ecc0cbca518e0fdbbe2f6f9dc7ffe265';
 
 // Fold idempotency, the minimum-nights warm-up, and legacy-payload handling

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,23 @@
+{
+  "@@locale": "en",
+  "appTitle": "OpenStrap",
+  "@appTitle": {
+    "description": "App name shown in the OS task switcher / MaterialApp title."
+  },
+  "profileTitle": "Profile",
+  "@profileTitle": {
+    "description": "Profile screen header."
+  },
+  "profileMyDevices": "My devices",
+  "@profileMyDevices": {
+    "description": "Profile > Quick access row label."
+  },
+  "profileLanguage": "Language",
+  "@profileLanguage": {
+    "description": "Profile > Quick access row label for the language picker."
+  },
+  "languageSystemDefault": "System default",
+  "@languageSystemDefault": {
+    "description": "Option in the language picker that follows the OS locale."
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'notify/notification_service.dart';
 import 'coach/coach_config.dart';
 import 'state/app_state.dart';
 import 'state/prefs.dart';
+import 'state/locale_controller.dart';
 import 'state/units_controller.dart';
 import 'sync/headless_boot.dart';
 import 'sync/ios_bg_task.dart';
@@ -159,6 +160,15 @@ Future<void> main() async {
     units = UnitsController.seed(UnitSystem.metric);
   }
 
+  // Local language override (null = system default).
+  LocaleController locale;
+  try {
+    locale = await LocaleController.bootstrap().timeout(_kStartupInitTimeout);
+  } catch (e, st) {
+    debugPrint('[main] LocaleController.bootstrap failed, using system: $e\n$st');
+    locale = LocaleController.seed(null);
+  }
+
   // Local BYOK AI-coach config (key in keychain). Best-effort load — and
   // deliberately NOT awaited: this is a flutter_secure_storage read, i.e. the
   // Android Keystore, which is the documented hang-forever case on some
@@ -179,6 +189,7 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => AppState(), lazy: false),
         ChangeNotifierProvider<ThemeController>.value(value: theme),
         ChangeNotifierProvider<UnitsController>.value(value: units),
+        ChangeNotifierProvider<LocaleController>.value(value: locale),
         ChangeNotifierProvider<CoachConfig>.value(value: coachConfig),
       ],
       child: const OpenStrapApp(),

--- a/lib/state/locale_controller.dart
+++ b/lib/state/locale_controller.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../l10n/app_localizations.dart';
+
 class LocaleController extends ChangeNotifier {
   static const String _kLocale = 'locale_override'; // language code, e.g. 'es'
 
@@ -15,7 +17,15 @@ class LocaleController extends ChangeNotifier {
 
   static Future<LocaleController> bootstrap() async {
     final prefs = await SharedPreferences.getInstance();
-    return LocaleController._(prefs.getString(_kLocale));
+    final stored = prefs.getString(_kLocale);
+    // A locale dropped from AppLocalizations.supportedLocales (or from a
+    // stale build) has no row in the picker — fall back to system default
+    // rather than showing a selection nothing matches.
+    final code = AppLocalizations.supportedLocales
+            .any((l) => l.languageCode == stored)
+        ? stored
+        : null;
+    return LocaleController._(code);
   }
 
   /// null = system default.

--- a/lib/state/locale_controller.dart
+++ b/lib/state/locale_controller.dart
@@ -1,0 +1,36 @@
+// Locale controller — the user's language override (or "System default").
+// Persisted on-device via SharedPreferences, mirroring ThemeController /
+// UnitsController. Null means follow the OS locale.
+
+import 'package:flutter/widgets.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LocaleController extends ChangeNotifier {
+  static const String _kLocale = 'locale_override'; // language code, e.g. 'es'
+
+  String? _code;
+  LocaleController._(this._code);
+
+  factory LocaleController.seed(String? code) => LocaleController._(code);
+
+  static Future<LocaleController> bootstrap() async {
+    final prefs = await SharedPreferences.getInstance();
+    return LocaleController._(prefs.getString(_kLocale));
+  }
+
+  /// null = system default.
+  String? get code => _code;
+  Locale? get locale => _code == null ? null : Locale(_code!);
+
+  Future<void> setCode(String? code) async {
+    if (_code == code) return;
+    _code = code;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    if (code == null) {
+      await prefs.remove(_kLocale);
+    } else {
+      await prefs.setString(_kLocale, code);
+    }
+  }
+}

--- a/lib/ui2/profile/profile.dart
+++ b/lib/ui2/profile/profile.dart
@@ -146,9 +146,9 @@ Future<void> _pickLanguage(BuildContext c) async {
               trailing: ctrl.code == code
                   ? Icon(LucideIcons.check, size: 18, color: p.on(C.blue))
                   : null,
-              onTap: () {
-                ctrl.setCode(code);
-                Navigator.of(sheet).pop();
+              onTap: () async {
+                await ctrl.setCode(code);
+                if (sheet.mounted) Navigator.of(sheet).pop();
               },
             ),
         ],

--- a/lib/ui2/profile/profile.dart
+++ b/lib/ui2/profile/profile.dart
@@ -125,8 +125,9 @@ void openProfile(BuildContext c) => goto(c, const ProfileHome());
 /// actually has translations for.
 const Map<String, String> _kLanguageNames = {'en': 'English'};
 
-String _languageLabel(String? code) =>
-    code == null ? 'System default' : (_kLanguageNames[code] ?? code);
+String _languageLabel(BuildContext c, String? code) => code == null
+    ? (AppLocalizations.of(c)?.languageSystemDefault ?? 'System default')
+    : (_kLanguageNames[code] ?? code);
 
 Future<void> _pickLanguage(BuildContext c) async {
   final p = P.of(c);
@@ -142,7 +143,7 @@ Future<void> _pickLanguage(BuildContext c) async {
         children: [
           for (final code in options)
             ListTile(
-              title: Text(_languageLabel(code), style: F.body.copyWith(color: p.ink)),
+              title: Text(_languageLabel(sheet, code), style: F.body.copyWith(color: p.ink)),
               trailing: ctrl.code == code
                   ? Icon(LucideIcons.check, size: 18, color: p.on(C.blue))
                   : null,
@@ -322,7 +323,7 @@ class ProfileHomeView extends StatelessWidget {
                   Builder(builder: (c) => SetRow(
                       LucideIcons.languages, C.blue,
                       AppLocalizations.of(c)?.profileLanguage ?? 'Language',
-                      sub: _languageLabel(c.watch<LocaleController>().code),
+                      sub: _languageLabel(c, c.watch<LocaleController>().code),
                       onTap: () => _pickLanguage(c))),
                 ]),
                 settingsGroup(c, 'Your data', [

--- a/lib/ui2/profile/profile.dart
+++ b/lib/ui2/profile/profile.dart
@@ -14,7 +14,9 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
 
 import '../../health/health_import_state.dart' show storeName;
+import '../../l10n/app_localizations.dart';
 import '../../state/app_state.dart';
+import '../../state/locale_controller.dart';
 import '../ui2.dart';
 import '../screens/coach.dart' show CoachSetup, coachSubtitle;
 import 'devices.dart';
@@ -116,6 +118,44 @@ Future<void> goto(BuildContext c, Widget w) =>
 /// The one way into the profile stack. Home's avatar calls this — profile is
 /// a pushed route, never a sixth tab.
 void openProfile(BuildContext c) => goto(c, const ProfileHome());
+
+/// Display name for a language code, sourced from a small hardcoded table.
+/// Add a row here when a contributor's `app_<code>.arb` lands — nothing else
+/// to touch; the picker below only ever offers what [AppLocalizations]
+/// actually has translations for.
+const Map<String, String> _kLanguageNames = {'en': 'English'};
+
+String _languageLabel(String? code) =>
+    code == null ? 'System default' : (_kLanguageNames[code] ?? code);
+
+Future<void> _pickLanguage(BuildContext c) async {
+  final p = P.of(c);
+  final ctrl = c.read<LocaleController>();
+  final options = <String?>[null, ...AppLocalizations.supportedLocales.map((l) => l.languageCode)];
+  await showModalBottomSheet<void>(
+    context: c,
+    backgroundColor: p.card,
+    showDragHandle: true,
+    builder: (sheet) => SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (final code in options)
+            ListTile(
+              title: Text(_languageLabel(code), style: F.body.copyWith(color: p.ink)),
+              trailing: ctrl.code == code
+                  ? Icon(LucideIcons.check, size: 18, color: p.on(C.blue))
+                  : null,
+              onTap: () {
+                ctrl.setCode(code);
+                Navigator.of(sheet).pop();
+              },
+            ),
+        ],
+      ),
+    ),
+  );
+}
 
 /// Human-readable byte size. No dependency for four lines of arithmetic.
 String formatBytes(int b) {
@@ -279,6 +319,11 @@ class ProfileHomeView extends StatelessWidget {
                       LucideIcons.sparkles, C.purple, 'AI coach',
                       sub: coachSubtitle(c) ?? 'Not set up',
                       onTap: onCoach)),
+                  Builder(builder: (c) => SetRow(
+                      LucideIcons.languages, C.blue,
+                      AppLocalizations.of(c)?.profileLanguage ?? 'Language',
+                      sub: _languageLabel(c.watch<LocaleController>().code),
+                      onTap: () => _pickLanguage(c))),
                 ]),
                 settingsGroup(c, 'Your data', [
                   SetRow(LucideIcons.database, C.green, 'Storage',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -929,8 +929,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "7105256b37ad61b49453a6b96543a2b80ea74487"
-      resolved-ref: "7105256b37ad61b49453a6b96543a2b80ea74487"
+      ref: "187e026fd975d3885ff1a22af5e125d1c8c1825e"
+      resolved-ref: "187e026fd975d3885ff1a22af5e125d1c8c1825e"
       url: "https://github.com/OpenStrap/analytics.git"
     source: git
     version: "1.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -478,6 +478,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_map:
     dependency: "direct main"
     description:
@@ -705,13 +710,13 @@ packages:
     source: hosted
     version: "4.8.0"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -250,7 +250,13 @@ dependencies:
       # the meantime — 7105256 already contains it: analytics main order is
       # a077a4a (#52) then 7105256 (#51), so this pin supersedes that one and
       # no further move is needed.
-      ref: 7105256b37ad61b49453a6b96543a2b80ea74487
+      #
+      # REPIN: analytics main @ 187e026 (PR #53 merge). One hop on top of
+      # 7105256: adds the optional `nnTimesMs` param to irregularBeatScreen
+      # that onehz_pipeline.dart (edge #289 / 3120774) already calls -- the
+      # pin was never moved when that landed, which broke `flutter analyze`
+      # (undefined_named_parameter, both call sites). No other symbol changed.
+      ref: 187e026fd975d3885ff1a22af5e125d1c8c1825e
 
   # BLE — flutter_blue_plus is the maintained cross-platform GATT client.
   flutter_blue_plus: ^1.36.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  # Pinned to what flutter_localizations (this SDK) requires — see its own
+  # pubspec.lock entry, don't drift it independently.
+  intl: ^0.20.2
   cupertino_icons: ^1.0.8
 
   # The single icon family behind lib/ui2. One pack, one stroke weight, one
@@ -449,6 +454,7 @@ flutter_launcher_icons:
   adaptive_icon_foreground: "assets/launcher/icon_adaptive.png"
 
 flutter:
+  generate: true
   uses-material-design: true
   assets:
     - assets/images/


### PR DESCRIPTION
### **User description**
adds a language picker to the profile screen, backed by proper ARB-based i18n plumbing (l10n.yaml, lib/l10n/app_en.arb, flutter_localizations). also added a CONTRIBUTING note for anyone who wants to send translation PRs.

just en for now, the plumbing's what matters.

## Summary by Sourcery

Add user-selectable language support to the profile screen and establish the localization foundation for future translations.

New Features:
- Add a profile language picker that lets users choose a supported language or return to the system default.
- Introduce ARB-based localization with generated English strings and application-level locale support.

Bug Fixes:
- Repin the analytics dependency so the existing pipeline calls compile and analysis succeeds.

Enhancements:
- Persist language overrides locally and gracefully fall back to the system locale when a stored language is unsupported.

Build:
- Enable Flutter localization generation and add the required localization dependencies and configuration.

Documentation:
- Document the process for contributing new translations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localization support with English translations.
  - Added a language picker in Profile settings, including a system-default option.
  - Language preferences are saved and restored when the app starts.
  - The app now updates displayed text when the selected language changes.

- **Documentation**
  - Added guidance for contributing translation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Enhancement


___

### **Description**
- Introduces ARB-based localization infrastructure.
  - Adds `flutter_localizations` and `intl` dependencies.
  - Configures `l10n.yaml` and base English strings.

- Adds language picker to Profile screen.
  - Allows users to override system default language.
  - Persists selection via `SharedPreferences`.

- Handles unsupported locale fallbacks gracefully.

- Note: Changes behavior without adding tests.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Profile Screen"] -- "Select Language" --> B["LocaleController"]
  B -- "Save Preference" --> C["SharedPreferences"]
  B -- "Notify" --> D["MaterialApp"]
  D -- "Apply Locale" --> E["AppLocalizations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>app.dart</strong><dd><code>Wires up localization delegates and locale to MaterialApp</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/291/files#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.dart</strong><dd><code>Bootstraps and injects LocaleController during app startup</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/291/files#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>l10n.yaml</strong><dd><code>Configures Flutter localization generation tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/291/files#diff-0c64eebd4f214039385035136cc2aa36df243de4640f0751cb43bd45b26235ba">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>locale_controller.dart</strong><dd><code>Manages and persists user language preference via SharedPreferences</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/291/files#diff-c8f933bb743ea29c328edc8a7b6d02cb8f8c58f9ec2aabb20797c310b0033a9b">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>profile.dart</strong><dd><code>Adds language selection row and bottom sheet picker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/291/files#diff-ce3814589d5759649d03a79f3a907f7e7e5821c98fd5366bcd7d556a82989abc">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_en.arb</strong><dd><code>Defines base English localization strings and metadata</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/291/files#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CONTRIBUTING.md</strong><dd><code>Documents the process for adding new language translations</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/291/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pubspec.yaml</strong><dd><code>Adds localization dependencies and enables code generation</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/291/files#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

