### PR TITLE
fix ios build: known out of scope in AccessorySetup

### DIFF
--- a/ios/Runner/AccessorySetup.swift
+++ b/ios/Runner/AccessorySetup.swift
@@ -239,7 +239,7 @@ private final class Impl {
     })
 
     pickerResult = completion
-    present(items, allowGen4Retry: true)
+    present(items, known: known, allowGen4Retry: true)
   }
 
   /// Presents the picker and resolves `pickerResult`.
@@ -247,7 +247,10 @@ private final class Impl {
   /// If iOS rejects the widened descriptor list (a name-only item is the
   /// experimental one), retry once with the WHOOP 4.0 item that already ships,
   /// so the experiment can never take down 4.0 pairing.
-  private func present(_ items: [ASPickerDisplayItem], allowGen4Retry: Bool) {
+  ///
+  /// - Parameter known: accessory ids provisioned before this picker run started,
+  ///   so the success handler can tell which id it just added (see below).
+  private func present(_ items: [ASPickerDisplayItem], known: [String], allowGen4Retry: Bool) {
     session.showPicker(for: items) { [weak self] error in
       guard let self = self else { return }
       // The retry (if any) that led to THIS completion running is no longer
@@ -269,7 +272,7 @@ private final class Impl {
           NSLog("[ASK] picker rejected the %d-item descriptor list (%@) — "
                 + "retrying with the WHOOP 4.0 item only.", items.count, message)
           self.retryInFlight = true
-          self.present([items[0]], allowGen4Retry: false)
+          self.present([items[0]], known: known, allowGen4Retry: false)
           return
         }
         self.pickerResult = nil


### PR DESCRIPTION
### **User description**
AccessorySetup.swift's present() referenced known but it wasn't a param, just whatever happened to be in scope at the call site — broke ios builds with "Cannot find 'known' in scope". threaded it through as an explicit param, updated both call sites.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes an iOS build compilation error

- Threads the `known` array explicitly into `present()`

- Note: No tests were added under `test/` for this fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Caller["Caller Method"] -- "passes `known` array" --> Present["present()"]
  Present -- "passes `known` array on retry" --> Present
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AccessorySetup.swift</strong><dd><code>Fix scope error by passing `known` parameter explicitly</code>&nbsp; &nbsp; </dd></summary>
<hr>

ios/Runner/AccessorySetup.swift

<ul><li>Added the <code>known</code> parameter of type <code>[String]</code> to the <code>present</code> method <br>signature.<br> <li> Updated both call sites of <code>present</code> to explicitly pass the <code>known</code> <br>variable.<br> <li> Added documentation explaining the <code>known</code> parameter's purpose.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/292/files#diff-b33a2664de02f4ddc2187aad8729bed162cb5b5e1e5776c4dcee14198894987d">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

