### PR TITLE
fix: activity-type edit regression + Active Energy workout-gap credit

### DIFF
--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -1456,7 +1456,22 @@ import 'substrate.dart';
 // (OpenStrap/analytics#52). Do not release with a pubspec pin that predates
 // that merge — recomputing v77+ against a sibling that cannot price walking
 // would burn the version on nothing.
-const int kAlgoVersion = 80;
+//
+// v81 — ACTIVE ENERGY WORKOUT-GAP CREDIT. `applyDayActivity`'s calorie figure
+// is built entirely from `daySub.hr` (the day's own continuous 1 Hz trace)
+// and never read `sessions` at all — so a workout that scored its own
+// calories through the SEPARATE session pipeline (`computeManualSessionStats`
+// / the live-tick accumulator) contributed nothing to Active Energy whenever
+// the band lost PPG contact for its whole window, which is common for a
+// wrist-gripping or arm-swinging session (lifting, a brisk walk) next to a
+// low-motion one (Pilates) that keeps contact. `applyDayActivity` now takes
+// this day's `sessions` rows and credits a DONE, non-private session's own
+// `calories` into the day total ONLY when `daySub` has ZERO real HR samples
+// across that session's whole window — never a partial one, so a window the
+// trace already priced is never double-billed. THIS CAN RAISE `calories` /
+// `calories_total` for a day with a workout the day trace fully missed;
+// every other day is unaffected.
+const int kAlgoVersion = 81;
 
 /// The sibling SHAs this version was derived against, asserted against
 /// pubspec.yaml in test/db_serve_version_and_reads_test.dart.
@@ -4903,6 +4918,20 @@ class DerivationEngine {
     return (keys: keys, hr: [for (final k in keys) _meanWake(buckets[k]!)!]);
   }
 
+  /// Whether `daySub` has AT LEAST ONE real HR sample (`hr > 0`) inside
+  /// `[fromSec, toSec)` — the gate for the workout-gap credit in
+  /// [applyDayActivity]. Same "real sample" test as [_perMinuteMeanWake]'s own
+  /// bucketing, so "covered" here means exactly what would have priced a
+  /// minute there.
+  static bool _hasHrCoverage(Substrate s, int fromSec, int toSec) {
+    for (var i = 0; i < s.hr.length && i < s.tsSec.length; i++) {
+      if (s.hr[i] <= 0) continue;
+      final t = s.tsSec[i];
+      if (t >= fromSec && t < toSec) return true;
+    }
+    return false;
+  }
+
   static Map<String, int> _wakeZoneMinutes(
     Substrate s,
     int sleepOnsetSec,
@@ -5089,6 +5118,10 @@ class DerivationEngine {
     int liveStepsFromStrap = 0,
     int dynHistoryDays = 0,
     List<List<int>> stepSpans = const [],
+    /// This day's `sessions` rows (`LocalDb.sessionsInRange`), for the
+    /// zero-coverage credit below. Defaults to none — every existing caller
+    /// keeps its old behaviour until it is threaded through.
+    List<Map<String, dynamic>> sessions = const [],
   }) {
     final wake = _buildWakeDayFeatures(
       daySub,
@@ -5102,6 +5135,49 @@ class DerivationEngine {
       dynFloorG: dynFloorG,
       stepSpans: stepSpans,
     );
+    // ACTIVE ENERGY WORKOUT-GAP CREDIT. `wake['calories']` above is built
+    // ENTIRELY from `daySub.hr` — the day's own continuous 1 Hz trace — and
+    // never once reads `sessions`. A workout scores its OWN calorie figure
+    // through a completely separate pipeline (`computeManualSessionStats` /
+    // the live-tick accumulator, reconciled in `reconcileSessionScore`), so a
+    // session whose window the band's PPG lost contact for — commonly a
+    // wrist-gripping or arm-swinging one, e.g. lifting or a brisk walk, next
+    // to a low-motion one like Pilates that keeps contact — can be fully
+    // scored on its own summary card while contributing exactly nothing to
+    // Active Energy, because that window is a real, total gap in `daySub.hr`.
+    //
+    // Credited ONLY when a session's window has ZERO real HR samples in
+    // `daySub` — never a partial one — which is what makes this safe: a
+    // window `daySub.hr` already priced any of is left alone, so this can
+    // never double-bill a minute the trace already counted. A day the trace
+    // produced no figure for at all is left absent, same as always — this
+    // fills a gap in an existing number, it does not fabricate one.
+    if (wake['calories'] != null && sessions.isNotEmpty) {
+      var credited = 0.0;
+      for (final s in sessions) {
+        if (s['status'] != 'done') continue;
+        if ((s['private'] as num?)?.toInt() == 1) continue;
+        final sStart = (s['start_ts'] as num?)?.toInt();
+        final sEnd = (s['end_ts'] as num?)?.toInt();
+        final sCal = (s['calories'] as num?)?.toDouble();
+        if (sStart == null ||
+            sEnd == null ||
+            sEnd <= sStart ||
+            sCal == null ||
+            sCal <= 0) {
+          continue;
+        }
+        if (_hasHrCoverage(daySub, sStart, sEnd)) continue;
+        credited += sCal;
+      }
+      if (credited > 0) {
+        wake['calories'] = (wake['calories'] as num).toDouble() + credited;
+        final total = wake['calories_total'];
+        if (total != null) {
+          wake['calories_total'] = (total as num).toDouble() + credited;
+        }
+      }
+    }
     _applyWakeDayFeatures(bundle, scalars, wake);
     _stepsAndEnergy(
       bundle,
@@ -7078,6 +7154,7 @@ class DerivationEngine {
       liveStepsFromStrap: inp.liveStepsFromStrap,
       dynHistoryDays: inp.dynHistoryDays,
       stepSpans: inp.stepSpans,
+      sessions: inp.savedSessions,
     );
 
     bundlePatch['daytime_hrv'] = _daytimeHrv(daySub, onset, offset);

--- a/lib/ui2/activity/summary.dart
+++ b/lib/ui2/activity/summary.dart
@@ -29,8 +29,10 @@ import '../grammar.dart';
 import '../paint_activity.dart';
 import '../profile/profile.dart';
 import '../screens/home_screen.dart' show unitsOf;
+import '../screens/log_workout.dart' show bumpInsights;
 import '../theme.dart';
 import 'catalogue.dart';
+import 'picker.dart';
 // The share card and this screen describe the same session, so they draw its
 // stats with the same widget and split its values with the same function.
 // poster.dart imports this file back for [ActivityResult]; that is the seam,
@@ -811,6 +813,28 @@ class _ActivitySummaryState extends State<ActivitySummary> {
         ]),
       );
 
+  /// Correct a session's activity type — the band's own guess, or a hand-typed
+  /// one that was wrong. `LocalDb.setSessionType` is the narrow UPDATE this
+  /// reuses; it used to have no caller at all (lost in the ui2 rewrite along
+  /// with the screen that called it).
+  ///
+  /// Archetype-specific fields on [r] (sets, route, splits…) belong to the OLD
+  /// type and cannot be salvaged for the new one, so this does not try to
+  /// patch [r] in place — it hands back to whatever list pushed this screen,
+  /// which re-reads on the revision bump below.
+  Future<void> _changeType(BuildContext c) async {
+    final id = r.sessionId;
+    if (id == null) return;
+    await Navigator.of(c).push(MaterialPageRoute(
+      builder: (_) => ActivityPicker(onPick: (pc, newActivity) async {
+        await LocalDb.setSessionType(id, newActivity.name);
+        if (mounted) bumpInsights(c);
+        Navigator.of(pc).pop();
+      }),
+    ));
+    if (mounted) Navigator.of(c).pop();
+  }
+
   Future<void> _retrySave() async {
     if (_saving) return;
     setState(() => _saving = true);
@@ -841,12 +865,24 @@ class _ActivitySummaryState extends State<ActivitySummary> {
             child: NavBar(
               a.name,
               sub: _shortDate(r.start).toUpperCase(),
-              trailing: Pressable(
-                semanticLabel: 'Share this ${a.name.toLowerCase()}',
-                onTap: () => Navigator.of(c).push(MaterialPageRoute(
-                    builder: (_) => ShareSheet(r))),
-                child: Icon(LucideIcons.share2, size: 19, color: p.ink2),
-              ),
+              trailingWidth: S.tap * 2,
+              trailing: Row(mainAxisSize: MainAxisSize.min, children: [
+                // Only a saved session has an id to correct — a draft on
+                // screen because the write threw has nowhere to put it.
+                if (r.sessionId != null)
+                  Pressable(
+                    semanticLabel: 'Change activity type',
+                    onTap: () => _changeType(c),
+                    child: Icon(LucideIcons.pencil, size: 18, color: p.ink2),
+                  ),
+                const SizedBox(width: S.x3),
+                Pressable(
+                  semanticLabel: 'Share this ${a.name.toLowerCase()}',
+                  onTap: () => Navigator.of(c).push(MaterialPageRoute(
+                      builder: (_) => ShareSheet(r))),
+                  child: Icon(LucideIcons.share2, size: 19, color: p.ink2),
+                ),
+              ]),
             ),
           ),
           Padding(

--- a/lib/ui2/activity/summary.dart
+++ b/lib/ui2/activity/summary.dart
@@ -825,14 +825,22 @@ class _ActivitySummaryState extends State<ActivitySummary> {
   Future<void> _changeType(BuildContext c) async {
     final id = r.sessionId;
     if (id == null) return;
+    // Only true once a pick actually landed — pressing back out of the picker
+    // must return to this screen, not fall through and pop it too.
+    var picked = false;
     await Navigator.of(c).push(MaterialPageRoute(
       builder: (_) => ActivityPicker(onPick: (pc, newActivity) async {
-        await LocalDb.setSessionType(id, newActivity.name);
+        // The stored key everywhere else uses — `startWorkout(type:
+        // a.typeKey)` is the live path's own write. `a.name` here would still
+        // resolve through `activityByName`'s normalized lookup, but it would
+        // store a different string than every other producer of this column.
+        await LocalDb.setSessionType(id, newActivity.typeKey);
+        picked = true;
         if (mounted) bumpInsights(c);
         Navigator.of(pc).pop();
       }),
     ));
-    if (mounted) Navigator.of(c).pop();
+    if (mounted && picked) Navigator.of(c).pop();
   }
 
   Future<void> _retrySave() async {

--- a/lib/ui2/activity/summary.dart
+++ b/lib/ui2/activity/summary.dart
@@ -874,7 +874,11 @@ class _ActivitySummaryState extends State<ActivitySummary> {
             child: NavBar(
               a.name,
               sub: _shortDate(r.start).toUpperCase(),
-              trailingWidth: S.tap * 2,
+              // Two icons, each a Pressable with S.tap's own 44 pt minimum
+              // hit box (grammar.dart's accessibility floor, not optional) —
+              // S.tap * 2 alone is 12 pt short of that plus the gap between
+              // them, which is exactly the RenderFlex overflow this fixed.
+              trailingWidth: S.tap * 2 + S.x3,
               trailing: Row(mainAxisSize: MainAxisSize.min, children: [
                 // Only a saved session has an id to correct — a draft on
                 // screen because the write threw has nowhere to put it.

--- a/lib/ui2/activity/summary.dart
+++ b/lib/ui2/activity/summary.dart
@@ -834,7 +834,15 @@ class _ActivitySummaryState extends State<ActivitySummary> {
         // a.typeKey)` is the live path's own write. `a.name` here would still
         // resolve through `activityByName`'s normalized lookup, but it would
         // store a different string than every other producer of this column.
-        await LocalDb.setSessionType(id, newActivity.typeKey);
+        try {
+          await LocalDb.setSessionType(id, newActivity.typeKey);
+        } catch (_) {
+          // Same rule as `_saveRpe`: the row is unchanged, so leave the
+          // picker open rather than close it over a write that never
+          // happened — `onPick` is a `void Function`, so there is no caller
+          // to hand this failure back to.
+          return;
+        }
         picked = true;
         if (!pc.mounted) return;
         bumpInsights(pc);
@@ -865,6 +873,11 @@ class _ActivitySummaryState extends State<ActivitySummary> {
   Widget build(BuildContext c) {
     final p = P.of(c);
     _u = unitsOf(c);
+    // Only a saved session has an id to correct — a draft on screen because
+    // the write threw has nowhere to put it. Reserving the two-icon width
+    // for a row that only ever draws one icon would shove the title left on
+    // every unsaved-session summary for no reason.
+    final canChangeType = r.sessionId != null;
     return Scaffold(
       backgroundColor: p.bg,
       body: SafeArea(
@@ -878,17 +891,16 @@ class _ActivitySummaryState extends State<ActivitySummary> {
               // hit box (grammar.dart's accessibility floor, not optional) —
               // S.tap * 2 alone is 12 pt short of that plus the gap between
               // them, which is exactly the RenderFlex overflow this fixed.
-              trailingWidth: S.tap * 2 + S.x3,
+              trailingWidth: canChangeType ? S.tap * 2 + S.x3 : S.tap,
               trailing: Row(mainAxisSize: MainAxisSize.min, children: [
-                // Only a saved session has an id to correct — a draft on
-                // screen because the write threw has nowhere to put it.
-                if (r.sessionId != null)
+                if (canChangeType) ...[
                   Pressable(
                     semanticLabel: 'Change activity type',
                     onTap: () => _changeType(c),
                     child: Icon(LucideIcons.pencil, size: 18, color: p.ink2),
                   ),
-                const SizedBox(width: S.x3),
+                  const SizedBox(width: S.x3),
+                ],
                 Pressable(
                   semanticLabel: 'Share this ${a.name.toLowerCase()}',
                   onTap: () => Navigator.of(c).push(MaterialPageRoute(

--- a/lib/ui2/activity/summary.dart
+++ b/lib/ui2/activity/summary.dart
@@ -836,11 +836,12 @@ class _ActivitySummaryState extends State<ActivitySummary> {
         // store a different string than every other producer of this column.
         await LocalDb.setSessionType(id, newActivity.typeKey);
         picked = true;
-        if (mounted) bumpInsights(c);
+        if (!pc.mounted) return;
+        bumpInsights(pc);
         Navigator.of(pc).pop();
       }),
     ));
-    if (mounted && picked) Navigator.of(c).pop();
+    if (c.mounted && picked) Navigator.of(c).pop();
   }
 
   Future<void> _retrySave() async {

--- a/lib/ui2/grammar.dart
+++ b/lib/ui2/grammar.dart
@@ -2341,12 +2341,18 @@ class NavBar extends StatelessWidget {
   final Widget? trailing;
   final VoidCallback? onBack;
 
+  /// Width of the trailing slot. Only [ActivitySummary] widens it, to fit a
+  /// share icon beside an edit-type one — every other caller keeps the
+  /// one-icon default.
+  final double trailingWidth;
+
   const NavBar(
     this.title, {
     super.key,
     this.sub = '',
     this.trailing,
     this.onBack,
+    this.trailingWidth = S.tap,
   });
 
   @override
@@ -2382,7 +2388,7 @@ class NavBar extends StatelessWidget {
             ),
           ),
           SizedBox(
-            width: S.tap,
+            width: trailingWidth,
             child: Align(alignment: Alignment.centerRight, child: trailing),
           ),
         ],

--- a/test/daily_energy_consistency_test.dart
+++ b/test/daily_energy_consistency_test.dart
@@ -388,6 +388,123 @@ void main() {
       // silently take movement down with it.
       expect(bundle['movement'], isNotNull);
     });
+
+    group('workout-gap credit (Active Energy missed a session)', () {
+      // The bug this covers: a workout scores its own calories through the
+      // SEPARATE session pipeline, but the day trace above never reads
+      // `sessions` at all — so a session whose window the band's PPG never
+      // once covered contributed nothing to `calories`/`calories_total`,
+      // silently, even though it "was recorded" and had a real number of its
+      // own. `dayEnd` sits one second past this fixture's last covered
+      // second, so a session starting there is a clean, total gap.
+      Map<String, dynamic> session({
+        double? calories,
+        String status = 'done',
+        int? private,
+        int startOffsetSec = 0,
+        int durationSec = 1800,
+      }) =>
+          {
+            'start_ts': dayEnd + startOffsetSec,
+            'end_ts': dayEnd + startOffsetSec + durationSec,
+            'calories': calories,
+            'status': status,
+            'private': private,
+          };
+
+      test('a session with NO HR coverage at all credits its calories in',
+          () {
+        final bundle = <String, dynamic>{};
+        final scalars = <String, dynamic>{};
+        DerivationEngine.applyDayActivity(
+          bundle: bundle,
+          scalars: scalars,
+          daySub: build(),
+          profile: older,
+          sleepOnsetSec: sleepOnset,
+          sleepOffsetSec: sleepOffset,
+          dayStartSec: dayStart,
+          dayCalendarEndSec: dayEnd + 3600,
+          dataNowSec: dayEnd + 3600,
+          sessions: [session(calories: 250.0)],
+        );
+        final activeNoCredit = 661.58; // from the sibling test above
+        expect(scalars['calories'], closeTo(activeNoCredit + 250.0, 2.0));
+        expect(
+          scalars['calories_total'],
+          closeTo(
+            (scalars['calories'] as double) +
+                ((bundle['calories_total'] as Map)['basal'] as int),
+            1.0,
+          ),
+          reason: 'crediting a gap must not break calories_total - calories '
+              '== basal',
+        );
+      });
+
+      test('a session the trace already covers is never double-billed', () {
+        final bundle = <String, dynamic>{};
+        final scalars = <String, dynamic>{};
+        DerivationEngine.applyDayActivity(
+          bundle: bundle,
+          scalars: scalars,
+          daySub: build(),
+          profile: older,
+          sleepOnsetSec: sleepOnset,
+          sleepOffsetSec: sleepOffset,
+          dayStartSec: dayStart,
+          dayCalendarEndSec: dayEnd + 1,
+          dataNowSec: dayEnd + 1,
+          // Inside the fixture's own covered span (the hard hour), which
+          // already has real HR — so this must NOT add on top of it.
+          sessions: [
+            {
+              'start_ts': dayStart,
+              'end_ts': hardUntil,
+              'calories': 999.0,
+              'status': 'done',
+            }
+          ],
+        );
+        expect(scalars['calories'], closeTo(661.58, 2.0));
+      });
+
+      test('a private session is never credited', () {
+        final bundle = <String, dynamic>{};
+        final scalars = <String, dynamic>{};
+        DerivationEngine.applyDayActivity(
+          bundle: bundle,
+          scalars: scalars,
+          daySub: build(),
+          profile: older,
+          sleepOnsetSec: sleepOnset,
+          sleepOffsetSec: sleepOffset,
+          dayStartSec: dayStart,
+          dayCalendarEndSec: dayEnd + 3600,
+          dataNowSec: dayEnd + 3600,
+          sessions: [session(calories: 250.0, private: 1)],
+        );
+        expect(scalars['calories'], closeTo(661.58, 2.0));
+      });
+
+      test('a live (not-yet-done) session is never credited', () {
+        final bundle = <String, dynamic>{};
+        final scalars = <String, dynamic>{};
+        DerivationEngine.applyDayActivity(
+          bundle: bundle,
+          scalars: scalars,
+          daySub: build(),
+          profile: older,
+          sleepOnsetSec: sleepOnset,
+          sleepOffsetSec: sleepOffset,
+          dayStartSec: dayStart,
+          dayCalendarEndSec: dayEnd + 3600,
+          dataNowSec: dayEnd + 3600,
+          sessions: [session(calories: 250.0, status: 'live')],
+        );
+        expect(scalars['calories'], closeTo(661.58, 2.0));
+      });
+    });
   });
 
   // The 1 Hz pipeline computes the SAME active quantity for the early-read path


### PR DESCRIPTION
### **User description**
two unrelated fixes bundled since they landed in the same pass:

**activity type edit** — the pencil-icon flow to correct a workout's type
existed pre-ui2-rewrite (setSessionType/setWorkoutType), got dropped when
lib/ui was deleted and rebuilt as lib/ui2, and the dead db method was later
swept out for having no callers. wired it back onto the summary screen's
navbar, reusing the existing ActivityPicker.

**Active Energy missing workout calories** — Today's Active Energy comes
entirely from the day's own 1hz band HR trace and never reads
sessions.calories. a workout that lost PPG contact for its whole window
(lifting, brisk walking — anything with real wrist motion/grip) scored
real calories on its own summary card but added zero to Active Energy,
while low-motion sessions (Pilates) worked fine since the trace stayed
covered. now credits a done session's own calories into the day when the
trace has ZERO HR coverage across its window — never partial, so nothing
gets double-counted. algo v81, tests added in daily_energy_consistency_test.

## Test plan
- [x] flutter test test/daily_energy_consistency_test.dart (4 new cases + all existing green)
- [x] flutter test test/step_source_ladder_test.dart test/wear_coverage_test.dart test/strain_resting_hr_source_test.dart
- [x] dart analyze on touched files (clean except 2 pre-existing-style info lints)

## Summary by Sourcery

Restore workout activity-type correction and reconcile missed workout calories in Active Energy.

Bug Fixes:
- Restore activity-type editing for saved workout summaries.
- Credit completed, non-private workout calories to Active Energy when the workout has no heart-rate coverage, while avoiding double-counting covered sessions.

Enhancements:
- Bump the analytics algorithm version to 81 for the Active Energy calculation update.
- Allow navigation bars to accommodate multiple trailing actions.

Tests:
- Add coverage for missing heart-rate workout calorie credits, double-count prevention, and exclusion of private and live sessions.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Credits missed workout calories to Active Energy.
  - Fills gaps when HR data is missing.
  - Prevents double-counting of covered sessions.
  - Excludes private and live sessions.

- Bumps `kAlgoVersion` to 81 for analytics changes.
  - Required due to Active Energy calculation updates.

- Restores activity type editing on workout summary.
  - Adds pencil icon to the navigation bar.
  - Reuses existing `ActivityPicker` and `LocalDb.setSessionType`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph UI Changes
    A["Activity Summary"] -- "Tap Edit" --> B["Activity Picker"]
    B -- "Save" --> C["LocalDb.setSessionType"]
  end
  subgraph Analytics Changes
    D["applyDayActivity"] -- "Check HR Coverage" --> E["_hasHrCoverage"]
    E -- "Zero Coverage" --> F["Credit Session Calories"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>derivation_engine.dart</strong><dd><code>Updates Active Energy calculation and bumps algorithm version</code></dd></summary>
<hr>

lib/compute/derivation_engine.dart

<ul><li>Bumps <code>kAlgoVersion</code> to 81 to reflect the new Active Energy calculation.<br> <li> Adds <code>_hasHrCoverage</code> to detect if a time window has at least one real <br>HR sample.<br> <li> Updates <code>applyDayActivity</code> to accept <code>sessions</code> and credit calories from <br>completed, non-private sessions if the HR trace has zero coverage for <br>that window.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/294/files#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6">+78/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>grammar.dart</strong><dd><code>Adds adjustable trailing width to the navigation bar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/ui2/grammar.dart

<ul><li>Adds a <code>trailingWidth</code> parameter to the <code>NavBar</code> widget.<br> <li> Allows the trailing slot to be widened to accommodate multiple icons <br>(e.g., edit and share).</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/294/files#diff-3c5a92d71f74b6ea51b66f825c93aa7707c2e8a04270b4b3454c4d4808a841a0">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>summary.dart</strong><dd><code>Restores activity type editing in the workout summary</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/ui2/activity/summary.dart

<ul><li>Adds <code>_changeType</code> method to allow users to correct a session's activity <br>type via <code>ActivityPicker</code>.<br> <li> Adds a pencil icon to the <code>NavBar</code> trailing section for saved sessions <br>to trigger the edit flow.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/294/files#diff-603b1a20ab2f5f524c2d4095d5cb4bc6d8c937acad3a6fd25c7ddae8cc11b611">+42/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>daily_energy_consistency_test.dart</strong><dd><code>Adds tests for workout-gap calorie crediting logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/daily_energy_consistency_test.dart

<ul><li>Adds tests to verify that sessions with no HR coverage correctly <br>credit their calories to the daily total.<br> <li> Ensures sessions already covered by the HR trace are not <br>double-billed.<br> <li> Confirms that private and live (incomplete) sessions are excluded from <br>the credit.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/294/files#diff-f317634af34f6477f6c8ec9756a31f9b38db2ea7e89a2308aa0c3d7246b9e8ce">+117/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an edit option to change and save the activity type of completed workout sessions.
  * Updated the activity summary navigation to support editing alongside sharing.

* **Bug Fixes**
  * Improved active-energy calculations when heart-rate data is unavailable for a completed workout.
  * Prevented duplicate calorie counting for sessions with incomplete heart-rate coverage.
  * Preserved the activity picker or summary when saving fails or no activity type is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->