### PR TITLE
urgent: fix app defaulting to german on fresh install

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -130,6 +130,21 @@ class _OpenStrapAppState extends State<OpenStrapApp> with WidgetsBindingObserver
       locale: locale.locale, // null = follow the OS locale
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
+      // `locale:` above wins whenever the user has an override, so this only
+      // runs on "system default". Flutter's own default resolution falls
+      // back to supportedLocales.first when nothing matches — which is
+      // whichever language sorts first alphabetically among our .arb files
+      // (currently German), not English. Match by language only (none of
+      // our locales carry a country/script code) and fall back to English
+      // explicitly instead of leaving that to alphabetical luck.
+      localeListResolutionCallback: (deviceLocales, supported) {
+        for (final deviceLocale in deviceLocales ?? const <Locale>[]) {
+          for (final s in supported) {
+            if (s.languageCode == deviceLocale.languageCode) return s;
+          }
+        }
+        return const Locale('en');
+      },
       builder: (context, child) =>
           ThemeSwitchOverlay(key: themeSwitchKey, child: child!),
       navigatorObservers: [TelemetryNavigatorObserver()],

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -130,13 +130,18 @@ class _OpenStrapAppState extends State<OpenStrapApp> with WidgetsBindingObserver
       locale: locale.locale, // null = follow the OS locale
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      // `locale:` above wins whenever the user has an override, so this only
-      // runs on "system default". Flutter's own default resolution falls
-      // back to supportedLocales.first when nothing matches — which is
-      // whichever language sorts first alphabetically among our .arb files
-      // (currently German), not English. Match by language only (none of
-      // our locales carry a country/script code) and fall back to English
-      // explicitly instead of leaving that to alphabetical luck.
+      // Runs even when `locale:` above has a user override — Flutter still
+      // calls this callback, just with [locale.locale] as the sole
+      // "device" candidate instead of the real device list, so an override
+      // resolves through the same language-match path below and comes back
+      // unchanged (LocaleController only ever holds a bare language code
+      // that's already in supportedLocales). Flutter's own default
+      // resolution falls back to supportedLocales.first when nothing
+      // matches — which is whichever language sorts first alphabetically
+      // among our .arb files (currently German), not English. Match by
+      // language only (none of our locales carry a country/script code)
+      // and fall back to English explicitly instead of leaving that to
+      // alphabetical luck.
       localeListResolutionCallback: (deviceLocales, supported) {
         for (final deviceLocale in deviceLocales ?? const <Locale>[]) {
           for (final s in supported) {


### PR DESCRIPTION
### **User description**
live bug, affects everyone on fresh install / no locale override.

root cause: gen-l10n orders `supportedLocales` alphabetically by arb
filename (de, en, es, fr, hi, zh — de sorts first), and flutter's default
locale resolution falls back to `supportedLocales.first` whenever the
device's locale isn't one of the 6 we support. so anyone whose system
locale isn't de/en/es/fr/hi/zh gets german instead of english.

(devices whose system locale IS one of the 6 were already fine — flutter
matches those by exact language code regardless of list order, so this
wasn't as broad as "everyone gets german", but it's still wrong for every
unsupported locale, and fragile — silently changes again if a language
gets added before 'en' alphabetically.)

fix: explicit `localeListResolutionCallback` on MaterialApp — matches the
device's preferred locales by language code same as before, but falls back
to `Locale('en')` instead of alphabetical luck. only kicks in when there's
no user override (`locale:` still wins when set).

verified: flutter analyze clean.

## Summary by Sourcery

Set deterministic English fallback behavior for unmatched device locales in the application.

Bug Fixes:
- Ensure fresh installs on unsupported system locales fall back to English instead of German.

Enhancements:
- Make locale resolution deterministic by matching preferred device languages against supported locales while preserving explicit user overrides.


___

### **PR Type**
Bug fix


___

### **Description**
- Fresh installs on unsupported system locales now fall back to English, not German

- Adds explicit `localeListResolutionCallback` to `MaterialApp` for deterministic locale resolution

- Matches device locales by language code; only activates when no user override is set


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Device locale (any)"]
  B["User locale override set?"]
  C["Use override locale"]
  D["localeListResolutionCallback"]
  E["Match by languageCode in supportedLocales"]
  F["Return matched locale"]
  G["Fallback: Locale('en')"]

  A --> B
  B -- "yes" --> C
  B -- "no" --> D
  D --> E
  E -- "match found" --> F
  E -- "no match" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.dart</strong><dd><code>Explicit English fallback for unmatched system locales</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/app.dart

<ul><li>Adds <code>localeListResolutionCallback</code> to <code>MaterialApp</code> to override Flutter's <br>default alphabetical locale fallback<br> <li> Iterates device preferred locales and matches by <code>languageCode</code> against <br>supported locales<br> <li> Falls back explicitly to <code>Locale('en')</code> when no match is found, instead <br>of relying on <code>supportedLocales.first</code><br> <li> Only activates when no explicit user locale override is set (<code>locale:</code> <br>still takes precedence)</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/298/files#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20d">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language and regional settings detection.
  * The app now selects the first supported device language and consistently falls back to English when no match is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->