### PR TITLE
gate the workout health write on a delete that actually cleared

### DIFF
--- a/lib/health/health_export.dart
+++ b/lib/health/health_export.dart
@@ -93,6 +93,39 @@ List<HealthDataType> healthDeleteTypes({required bool isApplePlatform}) {
       : types.where((type) => type != HealthDataType.HEART_RATE).toList();
 }
 
+/// Does a `delete()` answer mean the window is now clear of OUR samples — i.e.
+/// is it safe to write the replacement?
+///
+/// The two stores answer the EMPTY range differently, so the raw bool cannot be
+/// read the same way on both, and reading it wrong breaks the delete-then-write
+/// idempotency in opposite directions:
+///
+///   * Health Connect (`HealthPlugin.deleteData`) calls `deleteRecords` over a
+///     time range and reports success unless it THREW. A zero-match range is a
+///     normal success. So `false` there is always a genuine failure — a denied
+///     permission, an unmapped type, a store error — and the samples we meant
+///     to replace may well still be sitting there.
+///
+///   * HealthKit (`SwiftHealthPlugin.delete`) queries our own samples
+///     (`HKSource.default()`) and hands whatever came back to
+///     `HKHealthStore.delete`, which Apple documents as: "Deleting an empty
+///     array fails with an `errorInvalidArgument` error." So on Apple `false`
+///     is the NORMAL answer for a window we have never written — every FIRST
+///     export of every day and every workout sees it — and it says nothing
+///     about whether a real sample survived.
+///
+/// Hence: gate the write on Android, never on Apple. Trusting Apple's `false`
+/// is not optimism, it is the only reading the platform supports; and the
+/// HealthKit failures that CAN leave one of our samples behind (share
+/// permission never requested, or denied) suppress the following write for the
+/// same reason, so they cannot produce the duplicate this gate exists to stop.
+///
+/// Parameterised on [ios] rather than reading `Platform` for the same reason
+/// [healthActivityForType] is — so a host-VM test can exercise both branches.
+@visibleForTesting
+bool healthDeleteClearedRange({required bool deleted, required bool ios}) =>
+    deleted || ios;
+
 /// Cursor for the one-shot Apple Health sleep rewrite. Bump when the writer
 /// changes enough that nights already sitting in HealthKit should be replaced
 /// (plugin Core/in-bed misses, leftover 11pm fragments). Does not bump
@@ -352,6 +385,32 @@ class HealthExporter {
     } catch (e) {
       // Leave the cursor where it is so the next pass retries this day.
       debugPrint('[health] purge legacy steps $date: $e');
+    }
+  }
+
+  /// Delete OUR [type] samples in [start,end) and report whether the window is
+  /// now safe to write into — see [healthDeleteClearedRange] for why the two
+  /// stores' `false` cannot be read the same way.
+  ///
+  /// A THROW is a genuine failure on both stores (and on Apple the only signal
+  /// there is), so it is the one case that reports "not cleared" everywhere.
+  Future<bool> _deleteOwnSamples(
+    HealthDataType type,
+    DateTime start,
+    DateTime end,
+  ) async {
+    try {
+      return healthDeleteClearedRange(
+        deleted: await _health.delete(
+          type: type,
+          startTime: start,
+          endTime: end,
+        ),
+        ios: isApple,
+      );
+    } catch (e) {
+      debugPrint('[health] delete ${type.name}: $e');
+      return false;
     }
   }
 
@@ -844,21 +903,20 @@ class HealthExporter {
     // Idempotency: remove OUR previously-written samples for this day (HealthKit /
     // Health Connect only let an app delete its own data), then re-write fresh.
     // Sleep is not in this list — native replace already deleted it.
+    //
+    // A type whose delete did NOT clear the window must not be re-written on
+    // top of the survivor — that is how a retry turns one stale sample into
+    // two, then three. Only WORKOUT is tracked, because a duplicated workout
+    // is the one that shows up as a second entry in the user's activity list
+    // (and is the type `exportWorkout` re-writes out-of-band too); the scalar
+    // types below still write unconditionally, so an uncleared RHR/HRV window
+    // can still double until the next successful delete replaces both.
+    var workoutCleared = true;
     for (final t in _rewriteTypes) {
-      try {
-        final deleted = await _health.delete(
-          type: t,
-          startTime: dayStart,
-          endTime: dayEnd,
-        );
-        if (!deleted) {
-          debugPrint('[health] delete ${t.name} returned false');
-          success = false;
-        }
-      } catch (e) {
-        debugPrint('[health] delete ${t.name}: $e');
-        success = false;
-      }
+      if (await _deleteOwnSamples(t, dayStart, dayEnd)) continue;
+      debugPrint('[health] delete ${t.name} did not clear the day');
+      success = false;
+      if (t == HealthDataType.WORKOUT) workoutCleared = false;
     }
 
     final scalars = (b['scalars'] as Map?)?.cast<String, dynamic>() ?? const {};
@@ -1099,7 +1157,12 @@ class HealthExporter {
         debugPrint('[health] query workouts: $e');
         success = false;
       }
-      if (rows != null) {
+      // `workoutCleared` is false only when the day's WORKOUT delete genuinely
+      // failed (see the rewrite loop above), in which case every row here would
+      // land beside a survivor. `success` is already false, so the day retries
+      // and re-attempts the delete first; skipping only this block keeps that
+      // failure from touching the day's unrelated exports.
+      if (rows != null && workoutCleared) {
         for (final r in rows) {
           if (await _writeOneWorkout(r) == false) {
             debugPrint('[health] write workout returned false');
@@ -1161,6 +1224,11 @@ class HealthExporter {
   /// [_exportDay], which owns the whole-day delete). Best-effort — never
   /// throws; no-op if the health store isn't configured/available/permitted
   /// (mirrors [_exportDay]'s silent-no-op-on-missing-permission contract).
+  ///
+  /// The idempotency is only as good as the delete, so the write is GATED on
+  /// it: a delete that did not clear the window returns false without writing,
+  /// because writing beside a survivor is what turns a retry into a duplicate.
+  /// See [healthDeleteClearedRange] for what "did not clear" means per store.
   Future<bool> exportWorkout(Map<String, Object?> session) async {
     if ((session['status']?.toString() ?? '') == 'live') return false;
     final st = (session['start_ts'] as num?)?.toInt();
@@ -1171,20 +1239,16 @@ class HealthExporter {
       if (await _androidUnavailable() != null) return false;
       final start = DateTime.fromMillisecondsSinceEpoch(st * 1000);
       final end = DateTime.fromMillisecondsSinceEpoch(en * 1000);
-      var success = true;
-      try {
-        final deleted = await _health.delete(
-          type: HealthDataType.WORKOUT,
-          startTime: start,
-          endTime: end,
-        );
-        if (!deleted) success = false;
-      } catch (e) {
-        debugPrint('[health] delete workout @$st: $e');
-        success = false;
+      if (!await _deleteOwnSamples(HealthDataType.WORKOUT, start, end)) {
+        // The window still holds a copy we could not remove, so writing now
+        // would leave TWO of this workout in the store — and returning false
+        // hands the caller a retry, which would write a third. Bail instead:
+        // the same false still asks for a retry, but the retry re-attempts the
+        // delete FIRST and only writes once it actually clears.
+        debugPrint('[health] delete workout @$st did not clear the window');
+        return false;
       }
-      final wrote = (await _writeOneWorkout(session)) ?? false;
-      return success && wrote;
+      return (await _writeOneWorkout(session)) ?? false;
     } catch (e) {
       debugPrint('[health] exportWorkout: $e');
       return false;

--- a/test/health_workout_export_delete_gate_test.dart
+++ b/test/health_workout_export_delete_gate_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/health/health_export.dart';
+
+/// A stand-in for the platform health store, driven over the `health` plugin's
+/// own method channel — the only seam `HealthExporter` reaches the store
+/// through. Records every call so a test can assert what the exporter did
+/// AFTER a delete came back false, which is the whole point: the bug was that
+/// it wrote anyway.
+class _FakeHealthStore {
+  _FakeHealthStore({required this.deleteResult, this.deleteThrows = false});
+
+  /// What `delete` answers. On Health Connect a `false` here means the delete
+  /// genuinely failed and whatever we wrote before is STILL in the store.
+  final bool deleteResult;
+  final bool deleteThrows;
+
+  final calls = <String>[];
+
+  static const _channel = MethodChannel('flutter_health');
+
+  void install() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_channel, (call) async {
+          calls.add(call.method);
+          switch (call.method) {
+            case 'delete':
+              if (deleteThrows) {
+                throw PlatformException(code: 'delete-failed');
+              }
+              return deleteResult;
+            case 'writeWorkoutData':
+              return true;
+            default:
+              return null;
+          }
+        });
+  }
+
+  void remove() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_channel, null);
+  }
+}
+
+Map<String, Object?> _session() {
+  final start = DateTime(2026, 8, 26, 18, 30);
+  final end = DateTime(2026, 8, 26, 19, 15);
+  return {
+    'status': 'done',
+    'type': 'run',
+    'start_ts': start.millisecondsSinceEpoch ~/ 1000,
+    'end_ts': end.millisecondsSinceEpoch ~/ 1000,
+    'calories': 412,
+  };
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('healthDeleteClearedRange', () {
+    // The fact the whole gate hinges on, pinned so a future reader does not
+    // "simplify" it back to a bare `deleted`. Verified against the plugin
+    // sources in health 12.2.1 and Apple's own docs:
+    //
+    //   * HealthPlugin.kt `deleteData` -> deleteRecords over a time range,
+    //     `result.success(true)` unless it threw. Zero matches is a success.
+    //   * SwiftHealthPlugin.swift `delete` -> HKSampleQuery scoped to
+    //     HKSource.default(), then HKHealthStore.delete(samples) with whatever
+    //     came back — including an EMPTY array, which Apple documents as
+    //     "Deleting an empty array fails with an errorInvalidArgument error".
+    //
+    // So on Apple a false delete is what every first export sees, and gating
+    // the write on it would mean no workout ever reaches HealthKit at all.
+    test('Health Connect false is a genuine failure', () {
+      expect(healthDeleteClearedRange(deleted: false, ios: false), isFalse);
+      expect(healthDeleteClearedRange(deleted: true, ios: false), isTrue);
+    });
+
+    test('HealthKit false is the documented empty-range answer', () {
+      expect(healthDeleteClearedRange(deleted: false, ios: true), isTrue);
+      expect(healthDeleteClearedRange(deleted: true, ios: true), isTrue);
+    });
+  });
+
+  group('exportWorkout delete-then-write', () {
+    // The host VM is neither iOS nor macOS, so `HealthExporter.isApple` is
+    // false and these exercise the Health-Connect reading of `delete`.
+    late _FakeHealthStore store;
+
+    tearDown(() => store.remove());
+
+    test('a failed delete does not write a duplicate on top of it', () async {
+      store = _FakeHealthStore(deleteResult: false)..install();
+
+      final ok = await HealthExporter().exportWorkout(_session());
+
+      expect(ok, isFalse, reason: 'the caller must retry this workout');
+      expect(store.calls, contains('delete'));
+      expect(
+        store.calls,
+        isNot(contains('writeWorkoutData')),
+        reason:
+            'the previously exported copy survived the delete, so writing '
+            'would leave two of this workout in the store — and the false '
+            'return drives a retry that would write a third',
+      );
+    });
+
+    test('a thrown delete does not write either', () async {
+      store = _FakeHealthStore(deleteResult: true, deleteThrows: true)
+        ..install();
+
+      final ok = await HealthExporter().exportWorkout(_session());
+
+      expect(ok, isFalse);
+      expect(store.calls, isNot(contains('writeWorkoutData')));
+    });
+
+    test('a successful delete still writes', () async {
+      store = _FakeHealthStore(deleteResult: true)..install();
+
+      final ok = await HealthExporter().exportWorkout(_session());
+
+      expect(ok, isTrue);
+      expect(store.calls, containsAllInOrder(['delete', 'writeWorkoutData']));
+    });
+  });
+}


### PR DESCRIPTION
## The bug

`exportWorkout` and `_exportDay` both document delete-then-write idempotency, but
called the write even when the preceding `_health.delete(type: WORKOUT, ...)`
returned false or threw — they only recorded `success = false` and carried on.

If an already-exported copy survived the failed delete and the write then
succeeded, the store ended up with **two of the same workout** — and the `false`
return drove a retry through the attempts/backoff/give-up machinery that would
write a third.

Pre-existing; found during review of `claude/workout-general-bowling-143476`
but **not caused by it**, so it is split out here.

## Why the write can't just be gated on `delete() == true`

The two stores answer the **empty range** differently, which is the fact the
whole fix hinges on:

| store | empty range → | so `false` means |
|---|---|---|
| Health Connect | `true` | a genuine failure, always |
| HealthKit | `false` | almost always "we never wrote here" |

- **Health Connect** (`HealthPlugin.deleteData`, health 12.2.1) calls
  `deleteRecords` over a time range and reports success unless it *threw*. A
  zero-match range does not throw.
- **HealthKit** (`SwiftHealthPlugin.delete`) queries our own samples via
  `HKSource.default()` and hands whatever came back — **including an empty
  array** — to `HKHealthStore.delete`. Apple documents that parameter as:
  *"Deleting an empty array fails with an `errorInvalidArgument` error."*

So on Apple `false` is the normal answer for a window we have never written.
Gating on it would have broken **every first export on iOS, permanently**.

Two corroborations that this is real:

- The plugin's own sibling `deleteByUUID` explicitly guards `!samples.isEmpty`
  → `result(false)`; the range `delete()` just forgot the guard.
- `health_export.dart` already reasoned about exactly this for STEPS: *"a false
  `delete()` flips `success` … could permanently stall a day's export cursor."*

## The fix

`healthDeleteClearedRange({deleted, ios}) => deleted || ios` encodes the
asymmetry: gate on Android, never on Apple.

Trusting Apple's `false` is not optimism — it is the only reading the platform
supports, and it is safe: the HealthKit failures that *can* leave one of our
samples behind (share permission never requested, or denied) suppress the
following write for the same authorization reason, so they cannot produce the
duplicate the gate exists to stop. A **throw** is a genuine failure on both
stores and is the one case that reports "not cleared" everywhere.

Three sites rewired through a `_deleteOwnSamples` helper:

- `exportWorkout` — bails without writing when the window is not cleared; still
  returns `false` so the retry happens, but the retry re-attempts the *delete*
  first.
- `_exportDay`'s rewrite loop — tracks `workoutCleared`.
- the per-day workout loop — skipped **only** when the day's WORKOUT delete
  genuinely failed, so a failed workout export cannot pause that day's unrelated
  RHR/HRV/sleep/energy exports.

### Side effect worth calling out

On iOS an empty-range delete was flipping a day's `success` to false on
essentially **every fresh export**, driving the retry cursor with no actual
failure behind it. That stops too.

## Test

`test/health_workout_export_delete_gate_test.dart` — a fake store over the
plugin's own `flutter_health` method channel. Verified to **fail against the
pre-fix code**:

```
Expected: not contains 'writeWorkoutData'
  Actual: ['delete', 'writeWorkoutData']
```

Five cases: both platform branches of the predicate, plus delete-false /
delete-throws / delete-succeeds through `exportWorkout`. Parameterised on `ios`
rather than reading `Platform`, for the same reason `healthActivityForType`
already is — so a host VM can exercise both branches.

## Verification

- `flutter test` — `+3169 ~423 -1`. The single failure is
  `gen5_pairing_filter_test.dart` (Dart↔Swift `present(items, allowGen4Retry:)`
  lockstep), **confirmed pre-existing** by re-running it with
  `health_export.dart` restored from HEAD — it fails identically.
- `flutter analyze` clean on both changed files.

Note for anyone running the suite in a fresh worktree: `lib/l10n/app_localizations*.dart`
is gitignored generated output and `flutter test` did **not** auto-generate it
here despite `generate: true`. Run `flutter gen-l10n` first or ~55 tests fail to
compile for unrelated reasons.

## Not fixed here

The scalar types (RHR/HRV/respiratory/energy) still write unconditionally after
a failed delete and can still double on Health Connect. That needs per-type
"cleared" state threaded through `writeAt`/`writeGeneric` — a different-shaped
change into the retry machinery. Documented in the rewrite loop rather than
silently left.

## Summary by Sourcery

Gate workout writes on a cleared deletion window while accounting for the different empty-range responses from Health Connect and HealthKit.

Bug Fixes:
- Prevent workout exports from writing replacement samples when deletion did not clear the existing window, avoiding duplicate workouts across retries.
- Preserve first-time HealthKit exports by treating its empty-range delete result as cleared while requiring successful deletion on Health Connect.
- Keep failed workout deletion from blocking unrelated daily health exports.

Enhancements:
- Centralize platform-specific delete-cleared handling and reuse it across standalone workout and daily rewrite exports.

Tests:
- Add coverage for platform-specific delete semantics and workout export behavior after failed, thrown, and successful deletes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workout export reliability across Apple HealthKit and Android Health Connect.
  - Prevented duplicate or conflicting workout records when existing data cannot be cleared.
  - Workout exports now safely stop instead of writing alongside records that remain in the export window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->