### PR TITLE
fix gen5 pairing test pinning a stale present() signature

### DIFF
--- a/test/gen5_pairing_filter_test.dart
+++ b/test/gen5_pairing_filter_test.dart
@@ -170,8 +170,22 @@ void main() {
       // must be items[0] — the WHOOP 4.0 (gen4) descriptor built first in
       // `items`, so a rejection of the widened list falls back to exactly
       // what already ships.
-      expect(swift, contains('present(items, allowGen4Retry: true)'));
-      expect(swift, contains('self.present([items[0]], allowGen4Retry: false)'));
+      // Matched by shape, not by full line: `present` has picked up extra
+      // parameters before (`known:`) and a pinned literal silently drifts out
+      // of lockstep with the source it is supposed to guard. What matters is
+      // the argument the retry hinges on, whatever else rides along.
+      expect(
+        swift,
+        matches(RegExp(r'present\(\s*items\s*,[^)]*allowGen4Retry:\s*true')),
+        reason: 'the widened list must be presented WITH the Gen 4 retry armed',
+      );
+      expect(
+        swift,
+        matches(
+            RegExp(r'present\(\s*\[items\[0\]\]\s*,[^)]*allowGen4Retry:\s*false')),
+        reason: 'the single-item retry must be items[0] and must NOT retry '
+            'again, or a rejected list loops',
+      );
       // items[0] must be the FIRST registry-driven item (gen4 — kBandRegistry
       // lists it before gen5, see _registry.dart), not the appended gen5-only
       // fallback items (member UUID / name substring).


### PR DESCRIPTION
`test/gen5_pairing_filter_test.dart` fails deterministically on `main` (verified at 979b20d, in isolation).

## What broke

The test reads `ios/Runner/AccessorySetup.swift` as source text and pinned two exact lines:

```
present(items, allowGen4Retry: true)
self.present([items[0]], allowGen4Retry: false)
```

Both calls gained a `known:` parameter when `present` started forwarding the pre-picker accessory list, so neither literal matches any more:

```swift
present(items, known: known, allowGen4Retry: true)          // :242
self.present([items[0]], known: known, allowGen4Retry: false) // :275
```

Both had drifted, not just the one in the failure output — the first `expect` aborts the test body, so the second was never reached.

## The fix

Match by shape rather than by full line. The invariant the test actually guards is that the widened list is presented **with** the Gen 4 retry armed, and that the single-item retry targets `items[0]` with the retry **disarmed**. `[^)]*` absorbs any intervening arguments, and is deliberately paren-free so it cannot run past the end of the call.

Checked that this is not merely permissive — against mutated copies of the Swift:

| Mutation | Caught |
|---|---|
| widened list presented with `allowGen4Retry: false` | yes |
| retry target changed to `items[1]` | yes |
| retry re-arms the retry (infinite loop) | yes |
| an extra parameter added before `allowGen4Retry:` | tolerated, as intended |

## Scope

Every other pinned literal in the file was re-checked against its source and still holds: `whoopMemberUUID16`, `CBUUID(string: AccessorySetup.whoopMemberUUID16)`, `bluetoothNameSubstring`, the four `retryInFlight` pins, the `items`-ordering `indexOf` pair, and the `Info.plist` / `ble_engine.dart` literals. The other 19 tests that read source files as text were swept for the same failure mode; none pin a call signature with named parameters, so there is no cleanup backlog behind this. No production code is touched.

## Verification

`flutter test` — 3165 passed, 0 failed, 423 skipped.

## Summary by Sourcery

Harden the Gen 5 pairing test’s source-level assertions against future `present` call signature changes.

Bug Fixes:
- Update the Gen 5 pairing source-text test to continue validating retry behavior after the Swift `present` call signature changes.

Enhancements:
- Make call assertions resilient to additional named arguments while preserving checks for the widened list, retry target, and retry flags.

Tests:
- Add balanced-call parsing and complete named-argument matching to prevent stale or overly permissive source-based assertions.