### PR TITLE
step goal editing + dashed calibrating rings

### DIFF
--- a/lib/data/local_repository.dart
+++ b/lib/data/local_repository.dart
@@ -20,9 +20,9 @@ import 'journal_fields.dart';
 /// the commonly-cited optimal benefit/cost ratio for step count). Both the
 /// data layer (local_repository_impl.dart's `getProfile()`/`_stepGoal()`,
 /// which is where `TodayData.stepGoal` actually gets its default BEFORE any
-/// UI-level fallback ever sees a null) and the UI (`EditProfileView`'s step
-/// goal field, in ui2/profile/settings.dart, seeded from this same constant)
-/// must agree — they used to independently default to two different values
+/// UI-level fallback ever sees a null) and the UI (the steps detail screen's
+/// `_StepGoalGauge`, in ui2/screens/metric_detail.dart, seeded from this same
+/// constant) must agree — they used to independently default to two different values
 /// (10000 here vs. 8000 in the UI), so the UI fallback never actually
 /// triggered for real profile data.
 const int kDefaultStepGoal = 8000;

--- a/lib/data/local_repository.dart
+++ b/lib/data/local_repository.dart
@@ -20,10 +20,11 @@ import 'journal_fields.dart';
 /// the commonly-cited optimal benefit/cost ratio for step count). Both the
 /// data layer (local_repository_impl.dart's `getProfile()`/`_stepGoal()`,
 /// which is where `TodayData.stepGoal` actually gets its default BEFORE any
-/// UI-level fallback ever sees a null) and the UI (`StepGoalScreen.defaultGoal`,
-/// the preset picker's own default) must agree — they used to independently
-/// default to two different values (10000 here vs. 8000 in the UI), so the UI
-/// fallback never actually triggered for real profile data.
+/// UI-level fallback ever sees a null) and the UI (`EditProfileView`'s step
+/// goal field, in ui2/profile/settings.dart, seeded from this same constant)
+/// must agree — they used to independently default to two different values
+/// (10000 here vs. 8000 in the UI), so the UI fallback never actually
+/// triggered for real profile data.
 const int kDefaultStepGoal = 8000;
 
 /// Replaces the old ApiClient `ApiException`. Screens catch this to show an

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -244,14 +244,12 @@ class LocalRepositoryImpl extends LocalRepository {
 
   /// Persist the daily step goal.
   ///
-  /// [goal] arrives from a caller that may be an LLM, so it is bounded here
-  /// rather than trusted: a step goal is a target a person walks to, and a
-  /// four-digit typo would sit on Home forever with no screen to correct it.
-  ///
-  // ponytail: no UI writes this yet — the coach is the only caller, and the
-  // Home tile still prints "Goal 8,000" as if the user had chosen it. The field
-  // belongs beside the other profile numbers in EditProfile; one more key in
-  // that form's unconditional write is the whole fix.
+  /// [goal] arrives from a caller that may be an LLM (the coach's
+  /// `set_step_goal`), so it is bounded here rather than trusted: a step goal
+  /// is a target a person walks to, and a four-digit typo would sit on Home
+  /// forever with no screen to correct it. EditProfile (settings.dart) writes
+  /// the same field directly through `AppState.updateProfile` with the same
+  /// bound, rather than through this method.
   @override
   Future<Map<String, dynamic>> setStepGoal(int goal) async {
     if (goal < 500 || goal > 100000) {

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -247,9 +247,10 @@ class LocalRepositoryImpl extends LocalRepository {
   /// [goal] arrives from a caller that may be an LLM (the coach's
   /// `set_step_goal`), so it is bounded here rather than trusted: a step goal
   /// is a target a person walks to, and a four-digit typo would sit on Home
-  /// forever with no screen to correct it. EditProfile (settings.dart) writes
-  /// the same field directly through `AppState.updateProfile` with the same
-  /// bound, rather than through this method.
+  /// forever with no screen to correct it. The steps detail screen's
+  /// `_StepGoalGauge` (metric_detail.dart) writes the same field directly
+  /// through `AppState.updateProfile` with the same bound, rather than
+  /// through this method.
   @override
   Future<Map<String, dynamic>> setStepGoal(int goal) async {
     if (goal < 500 || goal > 100000) {

--- a/lib/ui2/charts.dart
+++ b/lib/ui2/charts.dart
@@ -655,7 +655,11 @@ class DashedRing extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant DashedRing o) =>
-      o.v != v || o.color != color || o.track != track || o.segments != segments;
+      o.v != v ||
+      o.color != color ||
+      o.track != track ||
+      o.segments != segments ||
+      o.stroke != stroke;
 }
 
 /// The small flat ring used in macro/nutrient clusters.

--- a/lib/ui2/charts.dart
+++ b/lib/ui2/charts.dart
@@ -615,6 +615,49 @@ class Ring extends CustomPainter {
       o.v != v || o.t != t || o.solid != solid || o.color != color;
 }
 
+/// A ring made of discrete dashes rather than a continuous arc — for a value
+/// that is still filling (a baseline calibrating night by night), so "not
+/// solid yet" is literally true of the shape, not just a softer tint of the
+/// same arc [Ring] draws for a finished measurement.
+class DashedRing extends CustomPainter {
+  final double v;
+  final Color color, track;
+  final double stroke;
+  final int segments;
+
+  DashedRing(this.v, this.color, this.track,
+      {this.stroke = 10, this.segments = 24});
+
+  @override
+  void paint(Canvas cv, Size s) {
+    final c = Offset(s.width / 2, s.height / 2);
+    final r = min(s.width, s.height) / 2 - stroke / 2;
+    if (r <= 0) return;
+    final filled = (segments * v.clamp(0, 1)).round();
+    final gap = 2 * pi / segments;
+    // Wide gaps between dashes so this reads as discrete beads, not a
+    // dashed-but-still-continuous arc.
+    final dashSweep = gap * 0.3;
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = stroke
+      ..strokeCap = StrokeCap.round;
+    for (var i = 0; i < segments; i++) {
+      cv.drawArc(
+        Rect.fromCircle(center: c, radius: r),
+        -pi / 2 + gap * i,
+        dashSweep,
+        false,
+        paint..color = i < filled ? color : track,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant DashedRing o) =>
+      o.v != v || o.color != color || o.track != track || o.segments != segments;
+}
+
 /// The small flat ring used in macro/nutrient clusters.
 class MacroRing extends CustomPainter {
   final double v;

--- a/lib/ui2/grammar.dart
+++ b/lib/ui2/grammar.dart
@@ -310,6 +310,10 @@ class SignalCard extends StatelessWidget {
 
   final VoidCallback? onTap;
 
+  /// A small dial in the header row's slack — steps is the only caller today,
+  /// showing progress toward its goal without a second card.
+  final Widget? trailing;
+
   const SignalCard(
     this.icon,
     this.color,
@@ -319,6 +323,7 @@ class SignalCard extends StatelessWidget {
     this.unit = '',
     this.sub = '',
     this.onTap,
+    this.trailing,
   });
 
   @override
@@ -342,6 +347,7 @@ class SignalCard extends StatelessWidget {
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
+              ?trailing,
             ],
           ),
           const SizedBox(height: S.x3),

--- a/lib/ui2/profile/settings.dart
+++ b/lib/ui2/profile/settings.dart
@@ -1295,7 +1295,13 @@ class EditProfile extends StatelessWidget {
         // a stale value alive and score the day against a body that is no
         // longer described.
         await app.updateProfile({
-          for (final k in const ['name', 'sex', 'age', 'height_cm', 'weight_kg'])
+          for (final k in const [
+            'name',
+            'sex',
+            'age',
+            'height_cm',
+            'weight_kg',
+          ])
             k: fields[k],
         });
         if (c.mounted) Navigator.of(c).maybePop();

--- a/lib/ui2/screens/home_screen.dart
+++ b/lib/ui2/screens/home_screen.dart
@@ -764,6 +764,11 @@ class _RingState {
   /// The arc is calibration progress, not the metric, and is drawn muted.
   final bool calibrating;
 
+  /// Nights banked / nights needed, set only while [calibrating] — the
+  /// dashed ring divides itself into exactly [need] beads and fills [have]
+  /// of them, rather than approximating that count from [frac].
+  final int? have, need;
+
   /// The absence's reason, as the pipeline gave it. Non-null only when the
   /// ring is [absent].
   final String? why;
@@ -777,6 +782,8 @@ class _RingState {
     this.sub = '',
     this.frac,
     this.calibrating = false,
+    this.have,
+    this.need,
     this.why,
   });
 
@@ -849,7 +856,9 @@ _RingState _gap(HomeRingKind k, String label, IconData icon, Color color,
             : (l?.homeCalibratingNights(counts.have, counts.need) ??
                 '${counts.have} of ${counts.need} nights'),
         frac: (counts.have / counts.need).clamp(0.0, 1.0),
-        calibrating: true);
+        calibrating: true,
+        have: counts.have,
+        need: counts.need);
   }
   return _RingState(k, label, icon, color,
       value: word,
@@ -876,12 +885,16 @@ class _Dial extends StatelessWidget {
     return Stack(alignment: Alignment.center, children: [
       CustomPaint(
         size: Size.infinite,
-        painter: Ring(r.frac ?? 0, r.arc(p), p.track,
-            stroke: stroke,
-            t: animate(c, 1),
-            // A measured ring draws solid; calibrating keeps the fade so the
-            // two do not read as the same thing at a glance.
-            solid: r.measured),
+        // Calibrating draws as discrete dashes filling in night by night;
+        // a finished (or absent-but-not-calibrating) ring draws the
+        // continuous arc, solid only once it is an actual measurement.
+        painter: r.calibrating
+            // One dash per night the baseline needs, not a fixed count —
+            // "6 of 14" draws as 14 divisions with 6 filled.
+            ? DashedRing(r.frac ?? 0, r.arc(p), p.track,
+                stroke: stroke, segments: r.need ?? 24)
+            : Ring(r.frac ?? 0, r.arc(p), p.track,
+                stroke: stroke, t: animate(c, 1), solid: r.measured),
       ),
       Icon(r.icon, size: icon, color: r.ink(p)),
     ]);
@@ -906,7 +919,7 @@ class _RingColumn extends StatelessWidget {
             constraints: const BoxConstraints(maxWidth: 96),
             child: AspectRatio(
               aspectRatio: 1,
-              child: _Dial(r, stroke: 10, icon: 20),
+              child: _Dial(r, stroke: 7, icon: 20),
             ),
           ),
           const SizedBox(height: S.x3),
@@ -932,7 +945,7 @@ class _RingRow extends StatelessWidget {
             SizedBox(
               width: 56,
               height: 56,
-              child: _Dial(r, stroke: 7, icon: 15),
+              child: _Dial(r, stroke: 5, icon: 15),
             ),
             const SizedBox(width: S.x3),
             Expanded(child: _RingText(r, align: TextAlign.start)),
@@ -1598,6 +1611,17 @@ class _HomeScreenState extends State<HomeScreen> with RevisionReload {
               ?stepSensorLabel(d.steps, l),
             ].join(' · '),
       onTap: () => go(c, const MetricDetail('steps')),
+      trailing: d.steps.value == null || d.stepGoal <= 0
+          ? null
+          : SizedBox(
+              width: 20,
+              height: 20,
+              child: CustomPaint(
+                painter: Ring(d.steps.value! / d.stepGoal, C.green,
+                    P.of(c).track,
+                    stroke: 3, solid: true),
+              ),
+            ),
     ));
     add(
       d.calories,

--- a/lib/ui2/screens/metric_detail.dart
+++ b/lib/ui2/screens/metric_detail.dart
@@ -598,6 +598,14 @@ class _MetricDetailState extends State<MetricDetail> {
                 : '',
             icon: spec.icon,
           ),
+        // Nothing recorded today is still zero steps against a goal, and the
+        // goal is editable regardless — the gate below matches the measured
+        // branch's, just with 0 for the steps this screen has not seen yet.
+        if (widget.metricKey == 'steps' && win == 1) ...[
+          const SizedBox(height: S.x5),
+          _StepGoalGauge(
+              steps: 0, goal: d.stepGoal, color: spec.color, onSaved: _load),
+        ],
         const SizedBox(height: S.x5),
         investigateRow(c, () => go(c, Investigate(widget.metricKey))),
       ] else ...[
@@ -1130,9 +1138,9 @@ class _MetricDetailState extends State<MetricDetail> {
 /// painter Home's recovery/strain/sleep dials use, at a size that reads as a
 /// detail beside the hero number rather than a fourth headline. The goal
 /// itself is editable in place: tap it, type, hit the check — no dialog.
-/// Same 500–100,000 bound and unreadable-input handling as EditProfile
-/// (settings.dart) — this is the other writer of `step_goal`, through the
-/// same `AppState.updateProfile`.
+/// Same 500–100,000 bound as `LocalRepositoryImpl.setStepGoal` — this is the
+/// UI writer of `step_goal`, through `AppState.updateProfile` directly rather
+/// than through that method.
 class _StepGoalGauge extends StatefulWidget {
   final double steps;
   final int goal;
@@ -1153,6 +1161,17 @@ class _StepGoalGaugeState extends State<_StepGoalGauge> {
   bool _editing = false;
   late final TextEditingController _ctrl =
       TextEditingController(text: '${widget.goal}');
+
+  @override
+  void didUpdateWidget(covariant _StepGoalGauge old) {
+    super.didUpdateWidget(old);
+    // The goal just saved (or changed under us some other way) — keep the
+    // field in sync so reopening the editor shows the current value, not
+    // the one it was first built with.
+    if (!_editing && old.goal != widget.goal) {
+      _ctrl.text = '${widget.goal}';
+    }
+  }
 
   @override
   void dispose() {
@@ -1176,6 +1195,9 @@ class _StepGoalGaugeState extends State<_StepGoalGauge> {
     }
     setState(() => _editing = false);
     await context.read<AppState>().updateProfile({'step_goal': typed});
+    // The parent's onSaved reloads and calls setState — never on a widget
+    // that navigated away while the write was in flight.
+    if (!mounted) return;
     await widget.onSaved();
   }
 

--- a/lib/ui2/screens/metric_detail.dart
+++ b/lib/ui2/screens/metric_detail.dart
@@ -600,8 +600,12 @@ class _MetricDetailState extends State<MetricDetail> {
           ),
         // The goal is editable even before today has a steps value — the
         // gate below matches the measured branch's. `steps: null` keeps the
-        // ring an empty track rather than fabricating a 0% reading.
-        if (widget.metricKey == 'steps' && win == 1) ...[
+        // ring an empty track rather than fabricating a 0% reading. Gated on
+        // `!_loading` too: before the real profile loads, `d` is the
+        // placeholder `MetricData()` and `d.stepGoal` is just the fallback
+        // default, not this user's goal — showing the editor pre-filled with
+        // that would risk saving it over their real one.
+        if (!_loading && widget.metricKey == 'steps' && win == 1) ...[
           const SizedBox(height: S.x5),
           _StepGoalGauge(
               steps: null, goal: d.stepGoal, color: spec.color, onSaved: _load),

--- a/lib/ui2/screens/metric_detail.dart
+++ b/lib/ui2/screens/metric_detail.dart
@@ -598,13 +598,13 @@ class _MetricDetailState extends State<MetricDetail> {
                 : '',
             icon: spec.icon,
           ),
-        // Nothing recorded today is still zero steps against a goal, and the
-        // goal is editable regardless — the gate below matches the measured
-        // branch's, just with 0 for the steps this screen has not seen yet.
+        // The goal is editable even before today has a steps value — the
+        // gate below matches the measured branch's. `steps: null` keeps the
+        // ring an empty track rather than fabricating a 0% reading.
         if (widget.metricKey == 'steps' && win == 1) ...[
           const SizedBox(height: S.x5),
           _StepGoalGauge(
-              steps: 0, goal: d.stepGoal, color: spec.color, onSaved: _load),
+              steps: null, goal: d.stepGoal, color: spec.color, onSaved: _load),
         ],
         const SizedBox(height: S.x5),
         investigateRow(c, () => go(c, Investigate(widget.metricKey))),
@@ -1142,7 +1142,9 @@ class _MetricDetailState extends State<MetricDetail> {
 /// UI writer of `step_goal`, through `AppState.updateProfile` directly rather
 /// than through that method.
 class _StepGoalGauge extends StatefulWidget {
-  final double steps;
+  /// Null when today has not produced a steps value yet — the ring then
+  /// shows only the empty track, never a fabricated 0%.
+  final double? steps;
   final int goal;
   final Color color;
   final Future<void> Function() onSaved;
@@ -1204,7 +1206,9 @@ class _StepGoalGaugeState extends State<_StepGoalGauge> {
   @override
   Widget build(BuildContext c) {
     final p = P.of(c);
-    final frac = widget.goal > 0 ? widget.steps / widget.goal : 0.0;
+    final steps = widget.steps;
+    final frac =
+        steps == null || widget.goal <= 0 ? null : steps / widget.goal;
     return Surface(
       child: Row(children: [
         SizedBox(
@@ -1213,10 +1217,14 @@ class _StepGoalGaugeState extends State<_StepGoalGauge> {
           child: Stack(alignment: Alignment.center, children: [
             CustomPaint(
               size: Size.infinite,
-              painter: Ring(frac, widget.color, p.track, stroke: 7, solid: true),
+              painter:
+                  Ring(frac ?? 0, widget.color, p.track, stroke: 7, solid: true),
             ),
-            Text('${(frac * 100).clamp(0, 999).round()}%',
-                style: F.over.copyWith(color: p.ink)),
+            // No steps recorded yet is absent, not zero — the track alone
+            // says that; a percentage here would fabricate a reading.
+            if (frac != null)
+              Text('${(frac * 100).clamp(0, 999).round()}%',
+                  style: F.over.copyWith(color: p.ink)),
           ]),
         ),
         const SizedBox(width: S.x3),

--- a/lib/ui2/screens/metric_detail.dart
+++ b/lib/ui2/screens/metric_detail.dart
@@ -11,15 +11,18 @@
 
 import 'package:flutter/material.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:provider/provider.dart';
 
 import '../../data/day_label.dart';
 import '../../data/local_repository.dart';
 import '../../l10n/app_localizations.dart';
+import '../../state/app_state.dart';
 import '../ui2.dart';
 import 'beats.dart';
 import 'day_steps.dart';
 import 'home_screen.dart';
 import 'investigate.dart';
+import 'journal_compose.dart' show OsTextField;
 import 'sleep_detail.dart';
 
 // ═══════════════════ the vocabulary ═══════════════════
@@ -361,6 +364,11 @@ class MetricData {
   /// readiness moved across them: 2026-08-08 went 43.8 → 47.9.
   final List<int> algoBreaks;
 
+  /// The daily step-goal target, read from the profile. Only ever loaded for
+  /// `key == 'steps'` — every other metric leaves it at the default and never
+  /// draws it.
+  final int stepGoal;
+
   const MetricData({
     this.series = const [],
     this.wear = const [],
@@ -368,6 +376,7 @@ class MetricData {
     this.movers = const [],
     this.daysAvailable = 0,
     this.algoBreaks = const [],
+    this.stepGoal = kDefaultStepGoal,
   });
 
   static Future<MetricData> load(LocalRepository repo, String key) async {
@@ -376,6 +385,10 @@ class MetricData {
     final chart = await repo.getChart(spec.chartKey);
     final days = await repo.availableDays();
     final outcome = _outcomeOf[key];
+    final stepGoal = key == 'steps'
+        ? ((await repo.getProfile())['step_goal'] as num?)?.toInt() ??
+            kDefaultStepGoal
+        : kDefaultStepGoal;
 
     Map<String, dynamic>? pct;
     var movers = const <Map<String, dynamic>>[];
@@ -401,6 +414,7 @@ class MetricData {
         for (final b in (chart['algo_breaks'] as List? ?? const []))
           if (b is Map && b['t'] is num) (b['t'] as num).round(),
       ],
+      stepGoal: stepGoal,
     );
   }
 }
@@ -590,6 +604,17 @@ class _MetricDetailState extends State<MetricDetail> {
         _ranges(c, d, spec.color),
         const SizedBox(height: S.x5),
         _hero(c, spec, all, series, vals, win, d.wear, d.algoBreaks),
+        // Today's count against the goal set on this screen's own edit
+        // affordance — a trend average has no goal to be measured against, so
+        // this stays win == 1 only, same gate as the Breakdown link below.
+        if (widget.metricKey == 'steps' && win == 1) ...[
+          const SizedBox(height: S.x5),
+          _StepGoalGauge(
+              steps: vals.last,
+              goal: d.stepGoal,
+              color: spec.color,
+              onSaved: _load),
+        ],
         // On Today the window holds one value, and its lowest, typical and
         // highest would all be that same number. The normal range is a
         // property of your history, not of the window — so on Today it reads
@@ -1099,6 +1124,116 @@ class _MetricDetailState extends State<MetricDetail> {
   }
 
   String _fmt(MetricSpec spec, double v) => metricValue(spec.unit, v);
+}
+
+/// Today's steps against the goal, as one small ring — the same [Ring]
+/// painter Home's recovery/strain/sleep dials use, at a size that reads as a
+/// detail beside the hero number rather than a fourth headline. The goal
+/// itself is editable in place: tap it, type, hit the check — no dialog.
+/// Same 500–100,000 bound and unreadable-input handling as EditProfile
+/// (settings.dart) — this is the other writer of `step_goal`, through the
+/// same `AppState.updateProfile`.
+class _StepGoalGauge extends StatefulWidget {
+  final double steps;
+  final int goal;
+  final Color color;
+  final Future<void> Function() onSaved;
+
+  const _StepGoalGauge(
+      {required this.steps,
+      required this.goal,
+      required this.color,
+      required this.onSaved});
+
+  @override
+  State<_StepGoalGauge> createState() => _StepGoalGaugeState();
+}
+
+class _StepGoalGaugeState extends State<_StepGoalGauge> {
+  bool _editing = false;
+  late final TextEditingController _ctrl =
+      TextEditingController(text: '${widget.goal}');
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final t = Typed.of(_ctrl.text);
+    final typed = (t.bad || t.value == null) ? null : t.value!.round();
+    if (typed == null) {
+      setState(() => _editing = false);
+      return;
+    }
+    if (typed < 500 || typed > 100000) {
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+        content:
+            Text('A step goal of 500–100,000 is a real one. Nothing was saved.'),
+      ));
+      return;
+    }
+    setState(() => _editing = false);
+    await context.read<AppState>().updateProfile({'step_goal': typed});
+    await widget.onSaved();
+  }
+
+  @override
+  Widget build(BuildContext c) {
+    final p = P.of(c);
+    final frac = widget.goal > 0 ? widget.steps / widget.goal : 0.0;
+    return Surface(
+      child: Row(children: [
+        SizedBox(
+          width: 56,
+          height: 56,
+          child: Stack(alignment: Alignment.center, children: [
+            CustomPaint(
+              size: Size.infinite,
+              painter: Ring(frac, widget.color, p.track, stroke: 7, solid: true),
+            ),
+            Text('${(frac * 100).clamp(0, 999).round()}%',
+                style: F.over.copyWith(color: p.ink)),
+          ]),
+        ),
+        const SizedBox(width: S.x3),
+        Expanded(
+          child: _editing
+              ? Row(children: [
+                  Expanded(
+                    child: OsTextField(
+                        controller: _ctrl,
+                        label: 'Goal',
+                        keyboard: TextInputType.number),
+                  ),
+                  const SizedBox(width: S.x2),
+                  Pressable(
+                    semanticLabel: 'Save step goal',
+                    onTap: _save,
+                    child: Icon(LucideIcons.check, size: 20, color: p.ink),
+                  ),
+                ])
+              : Pressable(
+                  semanticLabel: 'Edit daily step goal',
+                  onTap: () => setState(() => _editing = true),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(children: [
+                        Text('Goal', style: F.over.copyWith(color: p.ink3)),
+                        const SizedBox(width: S.x1),
+                        Icon(LucideIcons.pencil, size: 12, color: p.ink3),
+                      ]),
+                      Text('${thousands(widget.goal)} steps',
+                          style: F.body.copyWith(color: p.ink)),
+                    ],
+                  ),
+                ),
+        ),
+      ]),
+    );
+  }
 }
 
 // ═══════════════════ shared detail chrome ═══════════════════


### PR DESCRIPTION
## Summary
- step goal edit moved to the steps detail screen: inline tap-to-edit tile with a pencil icon (no popup), plus a small ring gauge (steps vs goal) there and on the home steps tile
- recovery's calibrating ring now draws as discrete dashes sized to the actual baseline count (e.g. 6 of 14 = 14 divisions, 6 filled) instead of a faded continuous arc
- ring stroke thinned uniformly across the three home rings

## Test plan
- [x] flutter analyze clean on changed files
- [x] step_goal / steps screen tests pass
- [x] golden suite diffed against unmodified main - no new failures (pre-existing golden drift unrelated to this change)

## Summary by Sourcery

Enable inline step-goal editing and clarify progress and calibration states across the steps and home screens.

New Features:
- Add inline editing for the daily step goal on the steps detail screen.
- Show step-goal progress gauges on the steps detail screen and home steps tile.
- Render calibrating home rings as discrete divisions based on the required baseline count.

Bug Fixes:
- Align the UI and data-layer default step goal at 8,000 steps.

Enhancements:
- Reduce the stroke width of the three home rings for a lighter, more uniform appearance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dashed progress rings to show calibration progress night by night.
  - Added step-goal progress indicators to the home screen and Today’s step details.
  - Step goals can now be edited directly from the step details view, with validation and immediate updates.
  - Added support for optional trailing content in signal cards.

- **Documentation**
  - Updated step-goal documentation to reflect current profile settings and coaching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->