### PR TITLE
fix a batch of small stuff: strain copy, flaky tests, readiness clobber, gen5 rr, health export, sleep reject

### DIFF
--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -1528,7 +1528,17 @@ import 'substrate.dart';
 // zone anchor. Two different derivations cannot share one number — that is
 // the whole contract of this constant, and main's 81 is the one already on
 // main, so it keeps it. Nothing about the zone change itself moved.
-const int kAlgoVersion = 82;
+//
+// 82 → 83 (edge#305): a re-derive at the retention-cutoff edge could produce
+// null rhr/rmssd/readiness for a day whose sleep-window substrate had aged
+// out while daytime HR survived, and — because `metric_series` is unversioned
+// — silently clobber a good historical baseline point, collapsing the
+// readiness baseline out from under later nights. That re-derive is now
+// declined (see the guard in `_derivePreparedDay` right after `producedNothing`)
+// so the older, complete row keeps being served. Also: the readiness z-cap
+// abstention now populates `readiness_absent_diag` with its own
+// `unstable_baseline:` reason instead of leaving it null (onehz_pipeline.dart).
+const int kAlgoVersion = 83;
 /// The sibling SHAs this version was derived against, asserted against
 /// pubspec.yaml in test/db_serve_version_and_reads_test.dart.
 ///
@@ -3684,6 +3694,50 @@ class DerivationEngine {
       }
     }
 
+    // ── NEVER WRITE NIGHT-NULL OVER NIGHT-REAL (edge#305) ───────────────────
+    // The guard above only catches a day with literally NOTHING. A day at the
+    // retention-cutoff EDGE can have plenty of daytime HR (daySub non-empty)
+    // while its sleep window's own RR/HR substrate has aged out from under it
+    // (sleepSub empty) — sleep STAGING survives regardless (it replays the
+    // durable `sleep_session_candidates` row, not raw), so `daySub`/`sleepSub`/
+    // `scMap` all look like "something" and `producedNothing` is false — but
+    // every night-physiology scalar (rhr/rmssd/readiness) comes back null.
+    // `putDayResult` replaces `metric_series` wholesale (it's UNVERSIONED), so
+    // this null silently overwrites a good historical baseline point and
+    // collapses every later night's readiness baseline out from under it.
+    //
+    // Detect the same shape the guard above already reasons about — a known
+    // sleep window whose substrate is now entirely gone, re-deriving over a
+    // day that already had a real result — and decline the SAME way: keep
+    // the existing (older-version) row being served (`_servedDayJoin` already
+    // serves the highest version <= ceiling, so nothing needs to change there)
+    // rather than writing a new, worse row. A `partial` row was considered
+    // instead, but `partial` still gets written to `day_result` and would
+    // still shadow the better older row for day-detail reads; declining is
+    // what actually protects it.
+    if (!producedNothing &&
+        nightSubstrateRegressed(
+          hasSleepWindow: day.sleepOffsetSec > day.sleepOnsetSec,
+          sleepSubEmpty: sleepSub.isEmpty,
+          nightScalarsNull: scMap == null ||
+              (scMap['rhr'] == null &&
+                  scMap['rmssd'] == null &&
+                  scMap['readiness'] == null),
+        )) {
+      final existingNight = await LocalDb.dayResult(day.date);
+      final existingHadNight = existingNight != null &&
+          (existingNight['rhr'] != null ||
+              existingNight['rmssd'] != null ||
+              existingNight['readiness'] != null);
+      if (existingHadNight) {
+        _log('derive ${day.date}: sleep-window substrate pruned out from '
+            "under a day that already had real night scalars — kept the "
+            'existing result rather than nulling the readiness baseline '
+            '(edge#305)');
+        return;
+      }
+    }
+
     // ── SECOND HALF — OFFLOADED to a background isolate ──────────────────────
     // Everything that turns the isolate-1 bundle into the full day result (wake
     // features, hybrid steps + TDEE, all-day HRV/RSA/skin-temp Timeline lines,
@@ -4140,6 +4194,22 @@ class DerivationEngine {
   /// rather than a permanently pathological day. These must never finalize:
   /// finalizing locks the day out of every future pass at this algo version.
   static const Set<String> _transientSkipReasons = {'timeout', 'error'};
+
+  /// edge#305 — whether THIS derive's night-physiology substrate has
+  /// regressed to nothing even though [producedNothing] (in
+  /// `_derivePreparedDay`) is false: plenty of daytime HR survives
+  /// ([hasSleepWindow] true, i.e. sleep STAGING still has a window — it
+  /// replays the durable `sleep_session_candidates` row, not raw — but
+  /// [sleepSubEmpty], the night's own RR/HR substrate, has aged out from
+  /// under it) and every night-physiology scalar ([nightScalarsNull]) came
+  /// back null. Pure so the shape is unit-testable without the full pipeline;
+  /// the caller still has to confirm an EXISTING result actually had real
+  /// night scalars before declining to write over it.
+  static bool nightSubstrateRegressed({
+    required bool hasSleepWindow,
+    required bool sleepSubEmpty,
+    required bool nightScalarsNull,
+  }) => hasSleepWindow && sleepSubEmpty && nightScalarsNull;
 
   /// Whether [row] is a REAL derived day result worth protecting — i.e. not a
   /// skip marker and not an all-absent shell.

--- a/lib/compute/onehz_pipeline.dart
+++ b/lib/compute/onehz_pipeline.dart
@@ -104,6 +104,25 @@ double? headlineReadinessScalar(Metric<Readiness> composite) {
   return r.score;
 }
 
+/// The `readiness_absent_diag` note for a composite that computed (unlike the
+/// `!composite.present` cold-start case) but got withheld by [kReadinessZCap]
+/// — a saturated, degenerate-baseline artefact. Null whenever
+/// [headlineReadinessScalar] would have returned a value, i.e. there is
+/// nothing to explain.
+///
+/// Deliberately NOT the `need_baseline:` note (edge#305): reaching a present
+/// composite already means every input cleared `readinessCompositeMinBaseline`,
+/// so "Need N more nights" would be a proven-false cause once this fires — the
+/// UI's baseline-note convention exists precisely to prevent stating a wrong
+/// cause. Pure so the gate + note format are unit-testable without the full
+/// pipeline.
+String? zCapAbsentNote(Metric<Readiness> composite) {
+  if (!composite.present) return null;
+  if (headlineReadinessScalar(composite) != null) return null;
+  final z = composite.value!.compositeZ;
+  return 'unstable_baseline:z=${z.toStringAsFixed(3)},cap=$kReadinessZCap';
+}
+
 /// Serializable input to the isolate: one physiological day's decoded 1 Hz
 /// substrate (the day slice), the PRECOMPUTED single-source sleep segmentation,
 /// the profile, and trailing baseline history for the readiness pass.
@@ -1042,6 +1061,32 @@ Map<String, dynamic> deriveDayBundle(Map<String, dynamic> inputJson) {
   // Abstain from a saturated, degenerate-baseline readiness rather than persist a
   // bogus ~100 that a cleaner re-derive would then snap back down (#117 bounce).
   final readinessScalar = headlineReadinessScalar(composite);
+  // The z-cap can abstain even when the composite itself is `present` — a
+  // saturated, degenerate-baseline artefact, not a cold-start — and that used
+  // to leave `readinessAbsentDiag` null (only the `!composite.present` branch
+  // above sets it), so the UI fell through to the composite's own prose, which
+  // names whichever driver its renormalisation happened to refuse (e.g. temp)
+  // rather than the real reason the headline is blank (edge#305). Do NOT reuse
+  // `need_baseline:` here: on main an input needs >=`readinessCompositeMinBaseline`
+  // points before the composite is even present, so by the time THIS branch can
+  // fire "Need N more nights" is a proven-false cause. Give it its own reason,
+  // carrying the z that tripped the cap plus the same per-input counts the
+  // cold-start diag carries, so it renders with an actual explanation instead
+  // of a bare blank.
+  final zCapNote = zCapAbsentNote(composite);
+  if (readinessAbsentDiag == null && zCapNote != null) {
+    readinessAbsentDiag = {
+      'hrv': {'value': lnToday != null, 'baseline_n': d.lnRmssdHistory.length},
+      'rhr': {'value': rhrToday != null, 'baseline_n': d.rhrHistory.length},
+      'resp': {'value': respToday != null, 'baseline_n': d.respHistory.length},
+      'temp': {
+        'value': skinTempAdc != null,
+        'baseline_n': d.skinTempAdcHistory.length,
+        'settled_frac': skinTempSettledFrac,
+      },
+      'note': zCapNote,
+    };
+  }
   final strainScalar = strainMetric.present ? strainMetric.value : null;
 
   // ── STRESS: Baevsky SI → a transparent 0–100 score (log-mapped over the

--- a/lib/compute/substrate.dart
+++ b/lib/compute/substrate.dart
@@ -941,7 +941,11 @@ class SleepWindowOverride {
   final String dayId;
   final int onsetSec;
   final int offsetSec;
-  final String source; // 'manual' | 'confirmed'
+  final String source; // 'manual' | 'confirmed' | 'rejected'
+  // 'rejected': onsetSec/offsetSec still carry the window being rejected (the
+  // auto-detected window at the time of rejection, same convention the
+  // already-shipped rejected-nap rows use), but the window is never staged —
+  // see calendarDays' `ov.source == 'rejected'` branch.
 
   const SleepWindowOverride({
     required this.dayId,
@@ -1070,7 +1074,14 @@ List<PhysioDay> calendarDays(
 
       ana.SleepSegmentation s;
       String src;
-      if (ov != null) {
+      if (ov != null && ov.source == 'rejected') {
+        // The user's word again, the other direction: this was NOT sleep at
+        // all. Skip detection/staging entirely rather than force a window —
+        // the day derives with no main sleep, same as the already-shipped
+        // rejected-nap path (`sleep_nap` source='rejected').
+        s = ana.SleepSegmentation.absent;
+        src = 'rejected';
+      } else if (ov != null) {
         // The user's word — force the window, skip detection entirely.
         s = ana.segmentSleep(
           accelSlice,
@@ -1156,6 +1167,11 @@ List<PhysioDay> calendarDays(
             ));
           }
         }
+      } else if (src == 'rejected') {
+        // No window to stage (deliberately), but the day still needs to know
+        // it was a rejection rather than an ordinary absence — sleep_detail
+        // reads this to keep the "not sleep" state from re-prompting.
+        sleepSource = 'rejected';
       }
     }
 
@@ -1174,7 +1190,9 @@ List<PhysioDay> calendarDays(
               : (sleepSource == 'manual' || sleepSource == 'confirmed'
                   ? const <String>['SLEEP_MANUAL']
                   : const <String>[]))
-          : const <String>['NO_SLEEP_DETECTED'],
+          : (sleepSource == 'rejected'
+              ? const <String>['SLEEP_REJECTED']
+              : const <String>['NO_SLEEP_DETECTED']),
     ));
     dayStart = dayEnd;
   }

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -4102,10 +4102,13 @@ Map<String, dynamic> _spotCheckCompute(List<String> records) {
   for (final hex in records) {
     final rr = proto.realtimeRr(hex);
     if (rr != null) {
-      // A duplicate or out-of-order packet timestamp cannot prove adjacency
-      // to whatever came before it — drop the whole packet rather than let
-      // it splice onto the series at the wrong place.
-      if (lastPacketTs == null || rr.ts > lastPacketTs) {
+      // rr.ts is whole SECONDS, and a live 0x2B packet can legitimately land
+      // more than once in the same second — only an out-of-order (strictly
+      // older) timestamp can't prove adjacency to what came before it, so
+      // only that gets dropped; an equal timestamp is accepted like normal
+      // (sourcery flagged the earlier strict `>` as silently losing real
+      // beats on any multi-packet-per-second burst).
+      if (lastPacketTs == null || rr.ts >= lastPacketTs) {
         lastPacketTs = rr.ts;
         final ts = rr.ts.toDouble() * 1000;
         for (final v in rr.rrMs) {
@@ -4153,7 +4156,10 @@ Map<String, dynamic> _breathingCoherenceCompute(
   for (final hex in records) {
     final rr = proto.realtimeRr(hex);
     if (rr != null) {
-      if (lastPacketTs == null || rr.ts > lastPacketTs) {
+      // See _spotCheckCompute above: rr.ts is whole seconds, so only a
+      // strictly older (out-of-order) timestamp gets dropped, not an equal
+      // one — a live packet can legitimately land more than once a second.
+      if (lastPacketTs == null || rr.ts >= lastPacketTs) {
         lastPacketTs = rr.ts;
         final ts = rr.ts.toDouble() * 1000;
         for (final v in rr.rrMs) {

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -4089,36 +4089,48 @@ Map<String, dynamic>? stressSummaryForToday(
 // Top-level (no `this` capture) + only file-scoped `proto`/`ana` top-level
 // functions + a List<String> of hex frames in, a plain Map out — all sendable.
 
-Map<String, dynamic> _spotCheckCompute(List<String> records) {
-  // Decode RR from the live RR-bearing frames (0x28 / R10), clean, compute HRV.
-  // rrTsMs carries each beat's packet timestamp (ms) alongside it — same seam
-  // getNightBeats uses (line ~867) — so correctRr can re-anchor at a dropout
-  // and hrvTime's seam detection can refuse to diff across it (edge#286: a
-  // flat rrMs-only list let a real packet gap read as two successive beats).
+/// Decode RR beats from the live RR-bearing frames (0x28 / R10), shared by
+/// [_spotCheckCompute] and [_breathingCoherenceCompute] (CodeRabbit noted the
+/// duplication on edge#308). rrTsMs carries each beat's packet timestamp
+/// (ms) alongside it — same seam getNightBeats uses (line ~867) — so
+/// correctRr can re-anchor at a dropout and hrvTime's/coherence's seam
+/// detection can refuse to diff across it (edge#286: a flat rrMs-only list
+/// let a real packet gap read as two successive beats). rr.ts is whole
+/// SECONDS, and a live 0x2B packet can legitimately land more than once in
+/// the same second — only an out-of-order (strictly older) timestamp can't
+/// prove adjacency to what came before it, so only that gets dropped; an
+/// equal timestamp is accepted like normal (sourcery flagged the earlier
+/// strict `>` as silently losing real beats on any multi-packet-per-second
+/// burst).
+({List<double> rrMs, List<double> rrTsMs}) _decodeLiveRr(
+  List<String> records,
+) {
   final rrMs = <double>[];
   final rrTsMs = <double>[];
-  final hrs = <double>[];
   int? lastPacketTs;
   for (final hex in records) {
     final rr = proto.realtimeRr(hex);
-    if (rr != null) {
-      // rr.ts is whole SECONDS, and a live 0x2B packet can legitimately land
-      // more than once in the same second — only an out-of-order (strictly
-      // older) timestamp can't prove adjacency to what came before it, so
-      // only that gets dropped; an equal timestamp is accepted like normal
-      // (sourcery flagged the earlier strict `>` as silently losing real
-      // beats on any multi-packet-per-second burst).
-      if (lastPacketTs == null || rr.ts >= lastPacketTs) {
-        lastPacketTs = rr.ts;
-        final ts = rr.ts.toDouble() * 1000;
-        for (final v in rr.rrMs) {
-          if (v > 0) {
-            rrMs.add(v.toDouble());
-            rrTsMs.add(ts);
-          }
-        }
+    if (rr == null || (lastPacketTs != null && rr.ts < lastPacketTs)) {
+      continue;
+    }
+    lastPacketTs = rr.ts;
+    final ts = rr.ts.toDouble() * 1000;
+    for (final v in rr.rrMs) {
+      if (v > 0) {
+        rrMs.add(v.toDouble());
+        rrTsMs.add(ts);
       }
     }
+  }
+  return (rrMs: rrMs, rrTsMs: rrTsMs);
+}
+
+Map<String, dynamic> _spotCheckCompute(List<String> records) {
+  final decoded = _decodeLiveRr(records);
+  final rrMs = decoded.rrMs;
+  final rrTsMs = decoded.rrTsMs;
+  final hrs = <double>[];
+  for (final hex in records) {
     try {
       final s = proto.decodeRecord(hex);
       if (s != null && s.hr > 0) hrs.add(s.hr.toDouble());
@@ -4145,32 +4157,14 @@ Map<String, dynamic> _breathingCoherenceCompute(
   List<String> records,
   double? pacedHz,
 ) {
-  // Decode RR from the live RR-bearing frames (0x28 / R10) — same seam
-  // spotCheck uses — then run McCraty & Zayas 2014 cardiac coherence.
-  // rrTsMs (see _spotCheckCompute above) lets correctRr re-anchor at a real
+  // Decode RR from the live RR-bearing frames (0x28 / R10) via the shared
+  // _decodeLiveRr helper (same seam spotCheck uses), then run McCraty &
+  // Zayas 2014 cardiac coherence. rrTsMs lets correctRr re-anchor at a real
   // packet gap so the coherence time axis is the real wall clock, not a
   // gap-free cumsum (edge#286).
-  final rrMs = <double>[];
-  final rrTsMs = <double>[];
-  int? lastPacketTs;
-  for (final hex in records) {
-    final rr = proto.realtimeRr(hex);
-    if (rr != null) {
-      // See _spotCheckCompute above: rr.ts is whole seconds, so only a
-      // strictly older (out-of-order) timestamp gets dropped, not an equal
-      // one — a live packet can legitimately land more than once a second.
-      if (lastPacketTs == null || rr.ts >= lastPacketTs) {
-        lastPacketTs = rr.ts;
-        final ts = rr.ts.toDouble() * 1000;
-        for (final v in rr.rrMs) {
-          if (v > 0) {
-            rrMs.add(v.toDouble());
-            rrTsMs.add(ts);
-          }
-        }
-      }
-    }
-  }
+  final decoded = _decodeLiveRr(records);
+  final rrMs = decoded.rrMs;
+  final rrTsMs = decoded.rrTsMs;
   if (rrMs.length < 20) {
     return {'ok': false, 'n_beats': rrMs.length};
   }

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -4083,13 +4083,29 @@ Map<String, dynamic>? stressSummaryForToday(
 
 Map<String, dynamic> _spotCheckCompute(List<String> records) {
   // Decode RR from the live RR-bearing frames (0x28 / R10), clean, compute HRV.
+  // rrTsMs carries each beat's packet timestamp (ms) alongside it — same seam
+  // getNightBeats uses (line ~867) — so correctRr can re-anchor at a dropout
+  // and hrvTime's seam detection can refuse to diff across it (edge#286: a
+  // flat rrMs-only list let a real packet gap read as two successive beats).
   final rrMs = <double>[];
+  final rrTsMs = <double>[];
   final hrs = <double>[];
+  int? lastPacketTs;
   for (final hex in records) {
     final rr = proto.realtimeRr(hex);
     if (rr != null) {
-      for (final v in rr.rrMs) {
-        if (v > 0) rrMs.add(v.toDouble());
+      // A duplicate or out-of-order packet timestamp cannot prove adjacency
+      // to whatever came before it — drop the whole packet rather than let
+      // it splice onto the series at the wrong place.
+      if (lastPacketTs == null || rr.ts > lastPacketTs) {
+        lastPacketTs = rr.ts;
+        final ts = rr.ts.toDouble() * 1000;
+        for (final v in rr.rrMs) {
+          if (v > 0) {
+            rrMs.add(v.toDouble());
+            rrTsMs.add(ts);
+          }
+        }
       }
     }
     try {
@@ -4100,7 +4116,7 @@ Map<String, dynamic> _spotCheckCompute(List<String> records) {
   if (rrMs.length < 20) {
     return {'ok': false, 'n_beats': rrMs.length};
   }
-  final cleaned = ana.correctRr(rrMs);
+  final cleaned = ana.correctRr(rrMs, rrTsMs: rrTsMs);
   final hrv = ana.hrvTime(cleaned.nn, nnTimesMs: cleaned.nnTimesMs);
   if (!hrv.present) return {'ok': false, 'n_beats': cleaned.nn.length};
   final meanHr = hrs.isEmpty ? null : hrs.reduce((a, b) => a + b) / hrs.length;
@@ -4120,19 +4136,31 @@ Map<String, dynamic> _breathingCoherenceCompute(
 ) {
   // Decode RR from the live RR-bearing frames (0x28 / R10) — same seam
   // spotCheck uses — then run McCraty & Zayas 2014 cardiac coherence.
+  // rrTsMs (see _spotCheckCompute above) lets correctRr re-anchor at a real
+  // packet gap so the coherence time axis is the real wall clock, not a
+  // gap-free cumsum (edge#286).
   final rrMs = <double>[];
+  final rrTsMs = <double>[];
+  int? lastPacketTs;
   for (final hex in records) {
     final rr = proto.realtimeRr(hex);
     if (rr != null) {
-      for (final v in rr.rrMs) {
-        if (v > 0) rrMs.add(v.toDouble());
+      if (lastPacketTs == null || rr.ts > lastPacketTs) {
+        lastPacketTs = rr.ts;
+        final ts = rr.ts.toDouble() * 1000;
+        for (final v in rr.rrMs) {
+          if (v > 0) {
+            rrMs.add(v.toDouble());
+            rrTsMs.add(ts);
+          }
+        }
       }
     }
   }
   if (rrMs.length < 20) {
     return {'ok': false, 'n_beats': rrMs.length};
   }
-  final cleaned = ana.correctRr(rrMs);
+  final cleaned = ana.correctRr(rrMs, rrTsMs: rrTsMs);
   final m = ana.cardiacCoherence(
     cleaned.nn,
     cleaned.nnTimesMs,

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -2536,6 +2536,15 @@ class LocalRepositoryImpl extends LocalRepository {
     if (existing['status'] == 'live') {
       throw StateError('setWorkoutWindow: session $id is still live');
     }
+    // Clear the OLD Health window before the retimed row overwrites it — the
+    // caller's subsequent exportWorkoutId only deletes inside the NEW window,
+    // so a narrowed/moved retime would otherwise leave the previous sample
+    // stranded outside it.
+    final oldStart = (existing['start_ts'] as num?)?.toInt();
+    final oldEnd = (existing['end_ts'] as num?)?.toInt();
+    if (oldStart != null && oldEnd != null) {
+      await HealthExporter.deleteWorkoutWindow(oldStart, oldEnd);
+    }
     // A retimed session keeps its id, so the OLD row is replaced rather than
     // orphaned — including its GPS route, which still belongs to it.
     return _writeManualSession(

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -13,6 +13,7 @@
 // Honesty: a metric whose value is absent stays absent ("—"); we never fabricate.
 // Profile-gated metrics are null when the profile field is missing.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:isolate';
 import 'dart:math' as math;
@@ -27,6 +28,7 @@ import 'package:openstrap_analytics/onehz.dart' as ana;
 
 import 'day_label.dart';
 import 'db.dart';
+import '../health/health_export.dart';
 import 'journal_fields.dart';
 import 'local_repository.dart';
 import 'series_codec.dart';
@@ -2475,6 +2477,12 @@ class LocalRepositoryImpl extends LocalRepository {
         'status': 'done',
         'end_ts': DateTime.now().millisecondsSinceEpoch ~/ 1000,
       });
+      // This is the choke point the AI coach's `end_workout` tool reaches
+      // directly (bypassing AppState.stopWorkout, the only other place this
+      // used to happen) — without it a coach-ended workout never reached
+      // Apple Health / Health Connect (edge#277). Idempotent + best-effort;
+      // exportWorkoutId re-reads the row and no-ops if sync is off.
+      unawaited(HealthExporter.exportWorkoutId(workoutId));
     }
     return {'workout_id': workoutId};
   }

--- a/lib/health/health_export.dart
+++ b/lib/health/health_export.dart
@@ -298,6 +298,29 @@ class HealthExporter {
     }
   }
 
+  /// Clear a stale workout's OLD window before the caller writes its retimed
+  /// replacement. [exportWorkout] only ever deletes inside the row's CURRENT
+  /// `[start,end]` — fine for a same-window re-export, but `setWorkoutWindow`
+  /// narrowing or moving a session leaves its previous Health sample outside
+  /// that window, so it survives untouched. Call this with the row's window
+  /// as it stood BEFORE the retime, then let the normal exportWorkoutId path
+  /// write the new one. Best-effort; never throws.
+  static Future<void> deleteWorkoutWindow(int startTs, int endTs) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      if (prefs.getBool(kHealthSyncPref) != true) return;
+      await shared._ensureConfigured();
+      if (await shared._androidUnavailable() != null) return;
+      await shared._deleteOwnSamples(
+        HealthDataType.WORKOUT,
+        DateTime.fromMillisecondsSinceEpoch(startTs * 1000),
+        DateTime.fromMillisecondsSinceEpoch(endTs * 1000),
+      );
+    } catch (e) {
+      debugPrint('[health] deleteWorkoutWindow: $e');
+    }
+  }
+
   /// True on iOS/macOS (Apple Health); false on Android (Health Connect).
   static bool get isApple => Platform.isIOS || Platform.isMacOS;
 

--- a/lib/import/whoop_import.dart
+++ b/lib/import/whoop_import.dart
@@ -11,6 +11,7 @@
 // labelled by the WAKE-onset local date (a night's recovery attributes to the day
 // you wake into — our day model). Marked BETA; values are WHOOP's own numbers.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -18,6 +19,7 @@ import '../compute/derivation_engine.dart' show kAlgoVersion, DerivationEngine;
 import '../compute/profile.dart';
 import '../compute/substrate.dart' show localDateLabel;
 import '../data/db.dart';
+import '../health/health_export.dart';
 import 'import_container.dart';
 import 'journal_csv_import.dart' show parseCsv;
 
@@ -330,8 +332,9 @@ class WhoopImporter {
     final end = _parseTs(get(['workout end time', 'end time']));
     if (start == null) return false;
     num? n(List<String> names) => double.tryParse(get(names));
+    final id = 'whoop_$start';
     await LocalDb.putSession({
-      'id': 'whoop_$start',
+      'id': id,
       'start_ts': start,
       'end_ts': end,
       'type': _slug(get(['activity name', 'activity'])),
@@ -343,6 +346,11 @@ class WhoopImporter {
       'duration_min': (end != null) ? ((end - start) / 60).round() : null,
       'created_at': DateTime.now().millisecondsSinceEpoch,
     });
+    // exportAll only scans dates already present in day_result, so an
+    // imported workout on a date this import brought no day_result row for
+    // would otherwise never reach Health export — trigger it directly off
+    // the completed session row instead (edge#277).
+    unawaited(HealthExporter.exportWorkoutId(id));
     return true;
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -9274,9 +9274,9 @@
   "@dayStrainChartTitle": {
     "description": "Chart title above the day's strain-over-time curve"
   },
-  "dayStrainChartFootnote": "Accumulated, so it only ever climbs — the STEEP parts are where the effort was. Built from {drawn} recorded waking minutes.",
+  "dayStrainChartFootnote": "Effort banked above your usual waking pace — it can ease later in the day if intensity drops back toward that pace, even though the STEEP parts already happened. Built from {drawn} recorded waking minutes.",
   "@dayStrainChartFootnote": {
-    "description": "Footnote under the strain curve chart explaining it is cumulative",
+    "description": "Footnote under the strain curve chart explaining it tracks effort above baseline pace, not a raw accumulator, so it can dip",
     "placeholders": {
       "drawn": {
         "type": "int"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -8169,6 +8169,22 @@
   "@sleepDetailBackToAutomatic": {
     "description": "Button: revert a manual sleep window override back to automatic staging."
   },
+  "sleepDetailNotSleep": "Not sleep",
+  "@sleepDetailNotSleep": {
+    "description": "Button: reject this window entirely — it was not sleep at all."
+  },
+  "sleepDetailRejectedTitle": "Marked as not sleep",
+  "@sleepDetailRejectedTitle": {
+    "description": "Status card title for a night the user rejected outright as not sleep."
+  },
+  "sleepDetailRejectedBody": "You told us this stretch was not sleep, so nothing is scored for it.",
+  "@sleepDetailRejectedBody": {
+    "description": "Status card body for a night the user rejected outright as not sleep."
+  },
+  "sleepDetailUndoRejection": "Undo — go back to automatic",
+  "@sleepDetailUndoRejection": {
+    "description": "Button: undo a not-sleep rejection and return the day to automatic staging."
+  },
   "sleepDetailReanalysing": "Re-analysing the night…",
   "@sleepDetailReanalysing": {
     "description": "Progress label shown while the night is being re-derived after a window edit."

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -5400,7 +5400,19 @@ class AppState extends ChangeNotifier {
           _deriveScheduler.setWorkoutActive(true);
           ScreenWake.enable();
         } else {
-          await LocalDb.putSession({...row, 'status': 'done'});
+          // A stale live row has no end_ts (it was never stopped), which
+          // permanently kept it un-exportable — Health export requires a real
+          // end. We don't know when the workout actually ended, so the
+          // honest stamp is reconcile-time (stated as such), not a guess at
+          // the real finish (edge#277).
+          final reconciledEndTs = nowMs ~/ 1000;
+          await LocalDb.putSession({
+            ...row,
+            'status': 'done',
+            'end_ts': row['end_ts'] ?? reconciledEndTs,
+          });
+          final id = row['id'] as String?;
+          if (id != null) unawaited(HealthExporter.exportWorkoutId(id));
           _log('[workout] finalized a stale live-session row from a previous run (id=${row['id']}).');
         }
       }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2644,7 +2644,11 @@ class AppState extends ChangeNotifier {
     // `breathingWindowOpen` is the MIND-06 quiet window either side of the
     // paced block — the same buffer, held open across the pacing's own start
     // and stop so a "before" and an "after" exist at all.
-    if ((breathingActive || breathingWindowOpen) && (pt == 0x28 || pt == 0x2B)) {
+    // A 0x2B envelope also carries gen5 Maverick's rev-21 100 Hz IMU record
+    // (byte[1] != 10) — realtimeRr already yields no beats from it, but it
+    // should not occupy the breathing R-R buffer at all (edge#286).
+    final isRrBearing = pt == 0x28 || (pt == 0x2B && _isR10Record(hex));
+    if ((breathingActive || breathingWindowOpen) && isRrBearing) {
       if (_breathingFrames.length < 8000) _breathingFrames.add(hex);
     }
     // LIVE STEP COUNTER. Gen4: dedicated 0x33 IMU (~10 frames/s × 10 samples)
@@ -2666,6 +2670,17 @@ class AppState extends ChangeNotifier {
         _ingestLiveMags(f);
         _trackCoverage(recTs);
       }
+    }
+  }
+
+  /// True iff a live inner packet's record-type byte ([1]) is 10 (R10, the
+  /// only R-R-bearing record a 0x2B envelope carries).
+  bool _isR10Record(String hex) {
+    if (hex.length < 4) return false;
+    try {
+      return int.parse(hex.substring(2, 4), radix: 16) == 10;
+    } catch (_) {
+      return false;
     }
   }
 

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1970,6 +1970,32 @@ class AppState extends ChangeNotifier {
     await _reanalyzeForOverride();
   }
 
+  /// Reject a day's detected main sleep entirely — "this was not sleep at
+  /// all", the missing counterpart to [confirmSleep] (naps already have this
+  /// via `sleep_nap` source='rejected'; main-sleep sessions didn't — edge#248).
+  /// Same table, same force-re-derive; `source: 'rejected'` tells
+  /// `calendarDays` (substrate.dart) to skip staging this window rather than
+  /// force it, so the day re-derives with no main sleep at all. Reversible
+  /// the same way as any other override: [clearSleepOverride].
+  Future<void> rejectSleep(String date) async {
+    if (repo == null) return;
+    final sleep = await repo!.getDaySleep(date);
+    final onset = (sleep['onset_ts'] as num?)?.toInt();
+    final offset = (sleep['wake_ts'] as num?)?.toInt();
+    // The rejected window is stored for the record, same as a rejected nap —
+    // it is never read back once source is 'rejected' (staging is skipped
+    // outright), so an absent detected window falls back to a harmless
+    // same-day placeholder rather than blocking the rejection.
+    final fallback = DateTime.parse(date).millisecondsSinceEpoch ~/ 1000;
+    await LocalDb.putSleepOverride(
+      dayId: date,
+      onsetTs: onset ?? fallback,
+      offsetTs: offset ?? (fallback + 1),
+      source: 'rejected',
+    );
+    await _reanalyzeForOverride();
+  }
+
   /// Remove a manual/confirmed override for [date] — revert to auto/fallback.
   Future<void> clearSleepOverride(String date) async {
     await LocalDb.deleteSleepOverride(date);

--- a/lib/ui2/activity/day_strain.dart
+++ b/lib/ui2/activity/day_strain.dart
@@ -280,9 +280,10 @@ class _DayStrainDetailState extends State<DayStrainDetail> {
             xLabels: const ['00:00', '12:00', '24:00'],
             series: d.curve,
             footnote: l?.dayStrainChartFootnote(drawn) ??
-                'Accumulated, so it only ever climbs — the STEEP parts '
-                    'are where the effort was. Built from $drawn recorded waking '
-                    'minutes.',
+                'Effort banked above your usual waking pace — it can ease '
+                    'later in the day if intensity drops back toward that '
+                    'pace, even though the STEEP parts already happened. '
+                    'Built from $drawn recorded waking minutes.',
             child: CustomPaint(
               size: Size.infinite,
               painter: LineChart(d.curve, p.on(C.purple),

--- a/lib/ui2/screens/sleep_detail.dart
+++ b/lib/ui2/screens/sleep_detail.dart
@@ -427,6 +427,12 @@ class _SleepDetailState extends State<SleepDetail> {
     }
 
     if (!d.hasNight) {
+      // "No night" also covers a night the user REJECTED outright (edge#248):
+      // staging was skipped on purpose, so this day has no window at all — but
+      // that must stay reversible the same way any other override is.
+      final rejectedDay = d.day;
+      final rejected =
+          (d.night['sleep_source'] as String?) == 'rejected' && rejectedDay != null;
       return detailScaffold(c, title, [
         ...dayNavRow(_day ?? d.day, d.days, _goDay),
         const SizedBox(height: S.x2),
@@ -435,13 +441,27 @@ class _SleepDetailState extends State<SleepDetail> {
         // those says so and leaves the stepper above it, so it is a day you
         // walk off rather than a dead end.
         StatusCard(
-          l?.sleepDetailNoNightTitle ?? 'No night to show',
-          l?.sleepDetailNoNightBody ??
-              'No stretch of band recordings long enough to score.',
-          fix: l?.sleepDetailNoNightFix ??
-              'Wear the band overnight and sync in the morning',
-          icon: LucideIcons.moon,
+          rejected
+              ? (l?.sleepDetailRejectedTitle ?? 'Marked as not sleep')
+              : (l?.sleepDetailNoNightTitle ?? 'No night to show'),
+          rejected
+              ? (l?.sleepDetailRejectedBody ??
+                  'You told us this stretch was not sleep, so nothing is '
+                      'scored for it.')
+              : (l?.sleepDetailNoNightBody ??
+                  'No stretch of band recordings long enough to score.'),
+          fix: rejected ? '' : (l?.sleepDetailNoNightFix ??
+              'Wear the band overnight and sync in the morning'),
+          icon: rejected ? LucideIcons.undo2 : LucideIcons.moon,
         ),
+        if (rejected) ...[
+          const SizedBox(height: S.x2),
+          TextButton(
+            onPressed: _saving ? null : () => _clearWindow(rejectedDay),
+            child: Text(
+                l?.sleepDetailUndoRejection ?? 'Undo — go back to automatic'),
+          ),
+        ],
       ]);
     }
 
@@ -655,6 +675,13 @@ class _SleepDetailState extends State<SleepDetail> {
                 child:
                     Text(l?.sleepDetailBackToAutomatic ?? 'Back to automatic'),
               ),
+            // The missing third answer next to "Looks right"/"Edit": naps
+            // already have a reject action (sleep_nap source='rejected');
+            // a whole-night main-sleep session didn't (edge#248).
+            TextButton(
+              onPressed: busy ? null : () => _rejectWindow(day),
+              child: Text(l?.sleepDetailNotSleep ?? 'Not sleep'),
+            ),
           ]),
           if (busy) ...[
             const SizedBox(height: S.x2),
@@ -680,6 +707,9 @@ class _SleepDetailState extends State<SleepDetail> {
 
   Future<void> _clearWindow(String day) =>
       _runOverride(() => context.read<AppState>().clearSleepOverride(day));
+
+  Future<void> _rejectWindow(String day) =>
+      _runOverride(() => context.read<AppState>().rejectSleep(day));
 
   /// Two pickers, seeded from the window we already have — the user is
   /// correcting times, not entering a date, so the DATES stay as measured and

--- a/test/derive_prepare_test.dart
+++ b/test/derive_prepare_test.dart
@@ -117,4 +117,58 @@ void main() {
     expect(inBed, greaterThan(3 * 3600));
     expect(inBed, lessThanOrEqualTo(4 * 3600 + 60));
   });
+
+  test(
+    'a "rejected" sleep override skips staging entirely (edge#248)',
+    () {
+      // Same still-wrist-plus-low-HR shape as the "forces + stages" case
+      // above — without the override this would stage as sleep.
+      final start = DateTime(2026, 6, 27, 0, 0).millisecondsSinceEpoch ~/ 1000;
+      final end = DateTime(2026, 6, 27, 5, 0).millisecondsSinceEpoch ~/ 1000;
+      final ts = <int>[];
+      final hr = <int>[];
+      for (var t = start; t <= end; t++) {
+        ts.add(t);
+        hr.add(50);
+      }
+      final sub = Substrate(
+        tsSec: ts,
+        hr: hr,
+        rrTsMs: const [],
+        rrMs: const [],
+        ax: List<double>.filled(ts.length, 0.02),
+        ay: List<double>.filled(ts.length, 0.02),
+        az: List<double>.filled(ts.length, 1.0),
+        spo2Red: List<int>.filled(ts.length, 0),
+        spo2Ir: List<int>.filled(ts.length, 0),
+        skinTemp: List<int>.filled(ts.length, 0),
+        skinContact: List<int>.filled(ts.length, 0),
+      );
+
+      final onsetSec =
+          DateTime(2026, 6, 27, 0, 30).millisecondsSinceEpoch ~/ 1000;
+      final offsetSec =
+          DateTime(2026, 6, 27, 4, 30).millisecondsSinceEpoch ~/ 1000;
+
+      final out = prepareDerivationPayload(
+        sub,
+        targetDay: '2026-06-27',
+        override: SleepWindowOverride(
+          dayId: '2026-06-27',
+          onsetSec: onsetSec,
+          offsetSec: offsetSec,
+          source: 'rejected',
+        ),
+      );
+      expect(out.days, hasLength(1));
+      final day = out.days.first;
+      // The rejection is on the record...
+      expect(day.sleepSource, 'rejected');
+      expect(day.flags, contains('SLEEP_REJECTED'));
+      // ...but nothing is staged from it — this day has no sleep at all.
+      expect(day.sleepJson['tst_sec'], isNull);
+      expect(day.sleepOnsetSec, 0);
+      expect(day.sleepOffsetSec, 0);
+    },
+  );
 }

--- a/test/derive_result_protection_test.dart
+++ b/test/derive_result_protection_test.dart
@@ -381,4 +381,80 @@ void main() {
       expect(DerivationEngine.isRicherSleep(night(null), night(null)), isFalse);
     });
   });
+
+  // 4. A re-derive at the retention-cutoff edge (edge#305): daytime HR
+  //    survives (so `producedNothing` is false) while the sleep window's own
+  //    RR/HR substrate has aged out from under it — sleep STAGING survives
+  //    regardless (it replays the durable `sleep_session_candidates` row, not
+  //    raw), so every night-physiology scalar comes back null and, because
+  //    `metric_series` is UNVERSIONED, silently clobbers a good historical
+  //    baseline point and collapses the readiness baseline out from under
+  //    every later night.
+  group('nightSubstrateRegressed (edge#305)', () {
+    test('a known sleep window with no surviving substrate and null night '
+        'scalars is a regression', () {
+      expect(
+        DerivationEngine.nightSubstrateRegressed(
+          hasSleepWindow: true,
+          sleepSubEmpty: true,
+          nightScalarsNull: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('no known sleep window at all is not a regression (honest no-sleep '
+        'day)', () {
+      expect(
+        DerivationEngine.nightSubstrateRegressed(
+          hasSleepWindow: false,
+          sleepSubEmpty: true,
+          nightScalarsNull: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('sleep substrate still present is not a regression, even with null '
+        'scalars (a genuine can\'t-compute night)', () {
+      expect(
+        DerivationEngine.nightSubstrateRegressed(
+          hasSleepWindow: true,
+          sleepSubEmpty: false,
+          nightScalarsNull: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('real night scalars computed is not a regression', () {
+      expect(
+        DerivationEngine.nightSubstrateRegressed(
+          hasSleepWindow: true,
+          sleepSubEmpty: true,
+          nightScalarsNull: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  // The full guard also requires an EXISTING result with real night scalars
+  // before it declines to write — a fresh day with nothing on disk yet must
+  // still get its (all-null) first result, same principle as producedNothing.
+  test('a night-substrate regression with NO existing result still writes',
+      () async {
+    const day = '2026-08-23';
+    expect(await LocalDb.dayResult(day), isNull, reason: 'precondition');
+    expect(
+      DerivationEngine.nightSubstrateRegressed(
+        hasSleepWindow: true,
+        sleepSubEmpty: true,
+        nightScalarsNull: true,
+      ),
+      isTrue,
+      reason: 'the shape alone says regression; the caller still checks for '
+          'an existing real result before declining to persist',
+    );
+  });
 }

--- a/test/health_workout_export_delete_gate_test.dart
+++ b/test/health_workout_export_delete_gate_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openstrap_edge/health/health_export.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// A stand-in for the platform health store, driven over the `health` plugin's
 /// own method channel — the only seam `HealthExporter` reaches the store
@@ -124,6 +125,40 @@ void main() {
 
       expect(ok, isTrue);
       expect(store.calls, containsAllInOrder(['delete', 'writeWorkoutData']));
+    });
+  });
+
+  group('deleteWorkoutWindow (retime cleanup)', () {
+    // setWorkoutWindow only has the OLD [start,end] before it overwrites the
+    // row — this is what it calls to clear that range so a narrowed/moved
+    // retime doesn't leave the previous Health sample stranded outside the
+    // new window (which is all `exportWorkoutId`'s own delete ever reaches).
+    late _FakeHealthStore store;
+
+    tearDown(() => store.remove());
+
+    test('clears the old window when health sync is on', () async {
+      SharedPreferences.setMockInitialValues({'health_sync': true});
+      store = _FakeHealthStore(deleteResult: true)..install();
+
+      final oldStart = DateTime(2026, 8, 26, 18, 30);
+      final oldEnd = DateTime(2026, 8, 26, 19, 15);
+      await HealthExporter.deleteWorkoutWindow(
+        oldStart.millisecondsSinceEpoch ~/ 1000,
+        oldEnd.millisecondsSinceEpoch ~/ 1000,
+      );
+
+      expect(store.calls, contains('delete'));
+      expect(store.calls, isNot(contains('writeWorkoutData')));
+    });
+
+    test('no-ops when health sync is off', () async {
+      SharedPreferences.setMockInitialValues({'health_sync': false});
+      store = _FakeHealthStore(deleteResult: true)..install();
+
+      await HealthExporter.deleteWorkoutWindow(0, 100);
+
+      expect(store.calls, isEmpty);
     });
   });
 }

--- a/test/phone_pedometer_hour_walk_test.dart
+++ b/test/phone_pedometer_hour_walk_test.dart
@@ -31,6 +31,12 @@ void main() {
     await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
   });
 
+  // LocalDb.instance caches its open Database keyed only on `db.isOpen`, not
+  // on `dbName` — leaving it open here hands the next suite this file's db
+  // instead of its own. This was the actual source of
+  // workout_reliability_test.dart's order-dependent flake (edge#259).
+  tearDownAll(() => LocalDb.close());
+
   setUp(() async {
     final db = await LocalDb.instance;
     await db.delete('live_coverage');

--- a/test/readiness_saturation_test.dart
+++ b/test/readiness_saturation_test.dart
@@ -98,4 +98,35 @@ void main() {
       expect(headlineReadinessScalar(flat), isNull);
     });
   });
+
+  // edge#305 — the z-cap abstention used to leave `readiness_absent_diag` null
+  // (only the `!composite.present` cold-start branch set it), so the UI fell
+  // through to the composite's own prose, which names whichever driver its
+  // renormalisation happened to refuse rather than the real reason the
+  // headline is blank. `zCapAbsentNote` gives it its own reason.
+  group('zCapAbsentNote', () {
+    test('a saturated composite gets its own note, not need_baseline', () {
+      final sat = composite(61.0, 59.0, degenerate);
+      final note = zCapAbsentNote(sat);
+      expect(note, isNotNull);
+      expect(note, startsWith('unstable_baseline:'));
+      expect(note, isNot(contains('need_baseline')));
+      expect(note, contains('cap=$kReadinessZCap'));
+    });
+
+    test('a clean composite (real score) has nothing to explain', () {
+      final ok = composite(70.0, 60.0, clean);
+      expect(zCapAbsentNote(ok), isNull);
+    });
+
+    test('an absent composite (cold-start) is the OTHER branch\'s job', () {
+      // The z-cap note only fires once the composite is already `present` —
+      // the `!composite.present` cold-start case has its own `need_baseline:`
+      // note built elsewhere and must not collide with this one.
+      final flat = composite(61.0, 59.0, List.filled(28, 60.0),
+          rhrBase: List.filled(28, 60.0));
+      expect(flat.present, isFalse);
+      expect(zCapAbsentNote(flat), isNull);
+    });
+  });
 }

--- a/test/workout_reliability_test.dart
+++ b/test/workout_reliability_test.dart
@@ -44,6 +44,13 @@ void main() {
     await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
   });
 
+  // LocalDb.instance caches its open Database keyed only on `db.isOpen`, not
+  // on `dbName` — a still-open handle left by an earlier suite is handed back
+  // as-is, ignoring the dbName set above. Close ours so whichever suite runs
+  // next doesn't inherit it (see phone_pedometer_hour_walk_test.dart, which
+  // was the actual source of this file's order-dependent flake: edge#259).
+  tearDownAll(() => LocalDb.close());
+
   group('DeriveScheduler — live-workout gate', () {
     late List<String> logs;
     late int runs;


### PR DESCRIPTION
### **User description**
grab bag of fixes from today's pass, one commit each:

- strain footnote said it only ever climbs, it doesn't — it's effort above your usual pace, can ease off
- workout tests were flaky because LocalDb.instance caches its open db keyed on isOpen not dbName, so an earlier suite's leftover handle leaked into the next one
- a re-derive right at the retention-cutoff edge could come back with null rhr/rmssd/readiness even though the day already had a real result, and since metric_series isn't versioned it'd silently clobber the readiness baseline — now it declines and keeps the older row. also gave the z-cap abstention its own diag note instead of leaving it blank
- gen5 rr consumers (spot check + breathing coherence) were feeding correctRr a flat list with no real timestamps, so a packet gap could read as two adjacent beats — now threaded through with rrTsMs
- workouts ended via the AI coach's end_workout tool, a stale reconciled session, or a whoop csv import never reached Health export — now all three paths call it directly
- added a real "not sleep" rejection for a full night, same idea as the existing rejected-nap path

Closes #296, #259, #305, #286, #277, #248

## Summary by Sourcery

Protect historical readiness data, improve workout health synchronization and Gen5 RR processing, and add reversible whole-night sleep rejection.

New Features:
- Allow users to reject an entire detected night as not sleep and undo that decision from the sleep detail view.

Bug Fixes:
- Prevent retention-edge derivations from overwriting valid night metrics and readiness baselines with null values.
- Preserve Gen5 RR packet gaps during spot checks and breathing-coherence calculations.
- Ensure coach-ended, reconciled, retimed, and WHOOP-imported workouts are correctly synchronized with Health platforms.
- Stabilize test suites by closing cached database handles between runs.
- Correct day-strain guidance so it reflects that effort can ease after intensity drops.

Enhancements:
- Provide explicit diagnostics when readiness is withheld because of an unstable baseline.

Documentation:
- Update localized strain guidance and add sleep-rejection text.

Tests:
- Add coverage for rejected sleep staging, retention-edge result protection, readiness abstention diagnostics, and Health workout cleanup.
- Harden workout-related test teardown to prevent order-dependent database leaks.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- **Analytics & Derivation**: Bumped `kAlgoVersion` to 83. Prevented retention-edge re-derivations from overwriting valid night metrics with nulls. Added specific diagnostic notes for readiness abstentions caused by unstable baselines (changes what is displayed when data is missing).

- **Sleep Staging**: Added support for rejecting an entire detected night as "not sleep", skipping staging entirely, with UI to undo the rejection.

- **Health Export**: Ensured workouts completed via AI coach, stale-session reconciliation, and WHOOP imports are exported to Apple Health / Health Connect.

- **Gen5 RR Processing**: Preserved real packet gaps by passing timestamps to `correctRr` in spot checks and breathing coherence.

- **UI & Tests**: Updated day strain guidance to clarify that strain can ease. Fixed test flakiness by closing database handles between suites.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Derivation Engine"] -- "Prevents null overwrites" --> B["Day Result"]
  C["Sleep UI"] -- "Reject night" --> D["Sleep Override"]
  E["Workout Paths"] -- "Trigger export" --> F["Health Export"]
  G["Gen5 RR"] -- "Pass timestamps" --> H["Correct RR"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>derivation_engine.dart</strong><dd><code>Bump kAlgoVersion and prevent null overwrites on retention edge</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/308/files#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6">+71/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>local_repository_impl.dart</strong><dd><code>Export coach-ended workouts and pass timestamps for Gen5 RR</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/308/files#diff-da6b8e6c3188825ab7c7d364093ccefbd9e40a284244154fdbffd372214f6352">+42/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>whoop_import.dart</strong><dd><code>Trigger Health export for imported WHOOP workouts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/308/files#diff-994c67130c9409a7edfd3f903856f24c5aacf09222dec49c5eb266573dbe9529">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>onehz_pipeline.dart</strong><dd><code>Add diagnostic note for readiness abstentions due to unstable </code><br><code>baselines</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/308/files#diff-fbeca04c08901aebd9a6c53f79a6d0e93a3d0ca685559234fb893e4e3cc43bfa">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>substrate.dart</strong><dd><code>Handle rejected sleep windows by skipping staging entirely</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/308/files#diff-6856ecdbe8e720625d74426718528d7cdcb26dfef98106ff08c75d13ad37a889">+21/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_state.dart</strong><dd><code>Add sleep rejection, filter Gen5 IMU, and export stale workouts</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/308/files#diff-d56ba858e512e18dc3962da198adee46d354aca39ff7c1b4a11d5f19b9afc1ae">+55/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sleep_detail.dart</strong><dd><code>Add UI for rejecting sleep windows and undoing rejections</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/308/files#diff-8ee14a9cd0b93685c68bd4f05cd13509c4c8579b550a20f7b4ead29a529e8093">+36/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>day_strain.dart</strong><dd><code>Update day strain chart footnote to reflect effort easing</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/308/files#diff-409d8323b675072e71bd65f9f579515a1fbb192d5f034aed3361a5555b2cfa2f">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_en.arb</strong><dd><code>Add localization strings for sleep rejection and update strain </code><br><code>footnote</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/308/files#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2">+18/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>derive_prepare_test.dart</strong><dd><code>Add test for rejected sleep override skipping staging</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/308/files#diff-3fb03940003c8d0fbcc1953d8343855798a57dd48639c5eaeeae4983e0d6c724">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>derive_result_protection_test.dart</strong><dd><code>Add tests for night substrate regression detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/308/files#diff-26d4d7e41f8ca359d0dc238a63c509fda2e4f498f45ed8821dd8edf3fdf6e44b">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>phone_pedometer_hour_walk_test.dart</strong><dd><code>Close database handle in teardown to prevent test leaks</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/308/files#diff-ed9c182b6123f380f3907dc56f2d04ee5953fd7ce02d8041220514e6a3e4017e">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>readiness_saturation_test.dart</strong><dd><code>Add tests for readiness saturation diagnostic notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/308/files#diff-ebbea331a75140c0bb58a1b4b86875b028d0800d493b99690d1c4e2da3bca4db">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>workout_reliability_test.dart</strong><dd><code>Close database handle in teardown to prevent test leaks</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/308/files#diff-c5b9c34639c83d87e642d9c389eb3f904c06e2440628719f998e0f43b7dd9a5e">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to mark detected sleep as “Not sleep,” with an option to undo and return to automatic detection.
  - Workouts completed, imported, or recovered through additional app flows are now exported to Apple Health or Health Connect.
- **Bug Fixes**
  - Prevented incomplete recalculations from replacing complete health results.
  - Improved HRV accuracy by filtering invalid sensor records and recognizing packet gaps.
  - Added clearer diagnostics when readiness is withheld due to baseline limits.
- **UI Improvements**
  - Updated day-strain guidance to explain how effort can ease during the day.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->