### PR TITLE
fix stale ui/ui2 docs + drop hand-rolled haversine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,11 @@
 # AGENTS.md — OpenStrap `edge`
 
-Reviewer context, verified against code at `kAlgoVersion 47`, schema `v25`,
-`0.9.19+50`. Where a source comment disagrees with an implementation, **the
-implementation wins** — header comments here go stale (e.g.
+Reviewer context. This doc drifts from code between edits — check
+`kAlgoVersion` (`lib/compute/derivation_engine.dart`), `schemaVersion`
+(`lib/data/db.dart`), and the `version:` line in `pubspec.yaml` directly
+rather than trusting a number written here. Where a source comment disagrees
+with an implementation, **the implementation wins** — header comments here go
+stale (e.g.
 `lib/compute/substrate.dart:10-12` still describes a wake-to-wake day model that
 `calendarDays()` at `:429` no longer implements; it walks local midnight to
 local midnight).
@@ -48,8 +51,10 @@ unless it is pure orchestration.
 - `notify/` — `notification_center.dart` is the **single emitter**;
   `fired_keys.dart` is the persistent fire-once guard.
 - `coach/` — read-only SQL over allow-listed `v_*` views behind a deny-list guard.
-- `ui/` — ~120 files: `ui/design` (design system), `ui/kit/charts.dart`,
-  `ui/screens/` (shared metric/trend IA).
+- `ui2/` — 66 files (`lib/ui` was deleted in the UI rebuild): `ui2/theme.dart`
+  and `ui2/grammar.dart` (design system), `ui2/charts.dart`, `ui2/screens/`
+  (shared metric/trend IA), plus `ui2/onboarding/`, `ui2/activity/`,
+  `ui2/profile/`.
 - Also `ai/` (BYOK), `gps/`, `health/` (HealthKit/Health Connect export),
   `telemetry/` (opt-in), `widget/` (App-Group snapshot for WidgetKit/watch).
 

--- a/README.md
+++ b/README.md
@@ -221,12 +221,21 @@ lib/ble/       Bluetooth + sync
 lib/data/      local storage + the repository seam the UI reads from
 lib/compute/   runs the analytics pipeline, writes results
 lib/state/     AppState, the one source of truth
-lib/ui/        every screen
+lib/ui2/       every screen
 ```
 
 Protocol decoding and analytics live in their own repos —
 [protocol](https://github.com/OpenStrap/protocol),
 [analytics](https://github.com/OpenStrap/analytics).
+
+## Guides
+
+- [`guides/IOS_INSTALLATION.md`](guides/IOS_INSTALLATION.md) — building and installing on an iPhone.
+- [`guides/IOS_SIDELOAD.md`](guides/IOS_SIDELOAD.md) — sideloading without a paid developer account.
+- [`guides/WATCH_SETUP.md`](guides/WATCH_SETUP.md) — the Apple Watch companion app.
+- [`guides/AI_COACH.md`](guides/AI_COACH.md) — bring-your-own-key AI coach, briefings, and journal.
+- [`guides/TASKER_INTEGRATION.md`](guides/TASKER_INTEGRATION.md) — buzzing the strap from Tasker/automation.
+- [`guides/BUZZ_MEANINGS.md`](guides/BUZZ_MEANINGS.md) — what each buzz pattern means.
 
 ## Contributing
 

--- a/lib/gps/route_math.dart
+++ b/lib/gps/route_math.dart
@@ -2,14 +2,17 @@
 //
 // Everything here is a pure function of its inputs (no DB, no I/O, no clock),
 // so it is directly unit-testable and shared by the repository (splits) and the
-// UI (zone-coloured polylines). Distances use the haversine great-circle
-// formula on WGS84 mean radius; good to well under a metre at running scale.
+// UI (zone-coloured polylines). Distance is latlong2's haversine great-circle
+// calculator (WGS84 equatorial radius, not our old mean-radius constant — a
+// ~0.1% difference, well under GPS fix noise); good to well under a metre at
+// running scale.
 
 import 'dart:math' as math;
 
+import 'package:latlong2/latlong.dart';
+
 import 'route_models.dart';
 
-const double kEarthRadiusM = 6371008.8; // WGS84 mean radius
 const double kMetersPerKm = 1000.0;
 const double kMetersPerMile = 1609.344;
 
@@ -65,18 +68,9 @@ double? fallbackSpeedMps(RoutePoint? prev, RoutePoint cur) {
 }
 
 /// Great-circle distance in metres between two lat/lng points.
-double haversineMeters(double lat1, double lng1, double lat2, double lng2) {
-  const deg2rad = math.pi / 180.0;
-  final dLat = (lat2 - lat1) * deg2rad;
-  final dLng = (lng2 - lng1) * deg2rad;
-  final a = math.sin(dLat / 2) * math.sin(dLat / 2) +
-      math.cos(lat1 * deg2rad) *
-          math.cos(lat2 * deg2rad) *
-          math.sin(dLng / 2) *
-          math.sin(dLng / 2);
-  final c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a));
-  return kEarthRadiusM * c;
-}
+const _distance = DistanceHaversine(roundResult: false);
+double haversineMeters(double lat1, double lng1, double lat2, double lng2) =>
+    _distance.distance(LatLng(lat1, lng1), LatLng(lat2, lng2));
 
 /// Total path length in metres over an ordered list of route points.
 /// Implausible segments (a teleport across a recording gap — see


### PR DESCRIPTION
### **User description**
readme/AGENTS still said lib/ui, that got renamed to lib/ui2 in the rebuild a while back. also unpinned the version banner at the top of AGENTS.md since it was ~36 algo versions stale and just going to rot again - points at the real constants now.

added a guides section to the readme since half the guides/ files weren't linked from anywhere.

route_math.dart had its own haversine, swapped it for latlong2 (already a dep for LatLng two files over).

no behavior changes except haversineMeters now uses latlong2's radius constant instead of our own - off by ~0.1%, way under GPS noise, tests still pass.

## Summary by Sourcery

Refresh repository documentation and standardize route distance calculations on the existing geospatial dependency.

Bug Fixes:
- Update repository guidance and README references to reflect the current `lib/ui2` layout.
- Replace the custom route-distance calculation with the shared `latlong2` implementation while preserving existing behavior within GPS accuracy.

Enhancements:
- Add a README Guides section linking the available installation, sideloading, watch, AI coach, automation, and buzz-pattern documentation.
- Remove stale version numbers from AGENTS.md and direct reviewers to the authoritative source files.

Documentation:
- Correct outdated UI directory documentation and link previously undiscoverable guides from the README.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Replaces custom haversine math with `latlong2` package.
  - Alters distance calculations by ~0.1 percent.

- Updates docs to reflect `lib/ui2` directory structure.

- Adds a Guides section to the README.

- Removes hardcoded version numbers from `AGENTS.md`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  id1["Custom haversineMeters()"] -- "Replaced by" --> id2["latlong2 DistanceHaversine"]
  id3["Hardcoded versions in AGENTS.md"] -- "Replaced by" --> id4["Pointers to source files"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route_math.dart</strong><dd><code>Refactor distance calculation to use latlong2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/gps/route_math.dart

<ul><li>Replaces the custom <code>haversineMeters</code> implementation with <code>latlong2</code>'s <br><code>DistanceHaversine</code>.<br> <li> Removes the <code>kEarthRadiusM</code> constant.<br> <li> Updates documentation to note the ~0.1% difference in distance <br>calculation.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/310/files#diff-ab49104df02501f953cdd4d761835b694eb10fef0f3f5f9e1798501a0c02837e">+9/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Update reviewer context and UI directory paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Removes hardcoded <code>kAlgoVersion</code>, schema, and app versions to prevent <br>documentation rot.<br> <li> Directs reviewers to check actual source files for version numbers.<br> <li> Updates the architecture map to reflect the <code>ui2/</code> directory instead of <br><code>ui/</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/310/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+10/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update directory structure and add Guides section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updates the directory structure documentation to use <code>lib/ui2/</code>.<br> <li> Adds a new "Guides" section linking to existing markdown documentation <br>files.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/310/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved GPS route distance calculations using a standardized Earth-distance model for more consistent results.

* **Documentation**
  * Updated repository layout references to reflect the current app structure.
  * Added guides for iPhone installation, sideloading, Apple Watch setup, AI coaching, Tasker integration, and buzz-pattern meanings.
  * Updated version and architecture guidance to direct readers to the current project metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->