### PR TITLE
round 2: nudge silence bug + day-label dedup + stale docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,11 @@ Reviewer context. This doc drifts from code between edits — check
 (`lib/data/db.dart`), and the `version:` line in `pubspec.yaml` directly
 rather than trusting a number written here. Where a source comment disagrees
 with an implementation, **the implementation wins** — header comments here go
-stale (e.g.
-`lib/compute/substrate.dart:10-12` still describes a wake-to-wake day model that
-`calendarDays()` at `:429` no longer implements; it walks local midnight to
-local midnight).
+stale (e.g. `lib/compute/substrate.dart`'s file header still describes a
+wake-to-wake day model that `calendarDays()` no longer implements; it walks
+local midnight to local midnight). The same drift applies to §2's table and
+every line-number citation in §3 below — line numbers move on every edit,
+symbol names don't; verify against the source, not this doc.
 
 ## 1. What this is
 
@@ -26,15 +27,17 @@ New opcode/record → protocol. New metric → analytics. New screen/flow/table 
 edge. A PR implementing a metric inside `edge/lib/compute` is in the wrong repo
 unless it is pure orchestration.
 
-## 2. Architecture map (`lib/`, 164 files, ~67k lines)
+## 2. Architecture map (`lib/`, well over 200 files — these five are the biggest by far)
 
-| file | lines | owns |
-|---|---|---|
-| `data/db.dart` | 3966 | `LocalDb`: schema v25, `onUpgrade` ladder, all CRUD, coach views |
-| `compute/derivation_engine.dart` | 3553 | `DerivationEngine`, `kAlgoVersion` (:267), day scheduling, isolate offload |
-| `state/app_state.dart` | 3456 | `AppState` ChangeNotifier — BLE↔DB↔UI orchestration |
-| `ble/ble_engine.dart` | 3267 | GATT connect/drain/history-sync state machine |
-| `data/local_repository_impl.dart` | 2518 | read seam: `day_result`/`metric_series` → screen shapes; zero compute on read |
+Line counts drift constantly; don't trust a number here, `wc -l` the file.
+
+| file | owns |
+|---|---|
+| `data/db.dart` | `LocalDb`: schema ladder (`onUpgrade`), all CRUD, coach views |
+| `compute/derivation_engine.dart` | `DerivationEngine`, `kAlgoVersion`, day scheduling, isolate offload |
+| `state/app_state.dart` | `AppState` ChangeNotifier — BLE↔DB↔UI orchestration |
+| `ble/ble_engine.dart` | GATT connect/drain/history-sync state machine |
+| `data/local_repository_impl.dart` | read seam: `day_result`/`metric_series` → screen shapes; zero compute on read |
 
 - `ble/` — engine + `ble_state.dart` **pure policies**: `ReconnectPolicy`,
   `SeqAllocator`, `DrainStopEvaluator`, `RecordGate`, `CounterRegressionDetector`,
@@ -74,7 +77,7 @@ a hotspot.
 
 ## 3. Hard invariants — violating these is a P0 regression
 
-1. **Commit before ACK.** In the history-sync drain (`ble/ble_engine.dart:~2116`)
+1. **Commit before ACK.** In the history-sync drain (`ble/ble_engine.dart`)
    decoded rows + cursor commit in one transaction *before*
    `buildHistoryResultOk` echoes the verbatim 8-byte HISTORY_END token. The band
    trims flash on ACK. Reordering, or echoing a regenerated/mangled token, causes
@@ -85,7 +88,7 @@ a hotspot.
 3. **Never fabricate a metric.** Absent input ⇒ null / `Metric.absent` / "—". No
    imputation, no substituted defaults, no deriving one metric from another as a
    fallback. Most-violated rule in the repo (§4.1).
-4. **Bump `kAlgoVersion`** (`compute/derivation_engine.dart:267`) whenever any
+4. **Bump `kAlgoVersion`** (`compute/derivation_engine.dart`) whenever any
    analytics *output* changes, including via a sibling re-pin. Rows are immutable
    per version; without a bump nothing recomputes. Add a changelog entry above
    the constant.
@@ -119,8 +122,9 @@ a hotspot.
 13. **The coach reads only allow-listed `v_*` views** — never `decoded_*`,
     `raw_*`, or base tables.
 14. **Live high-rate streams (0x28/0x2B/0x33) are never persisted** — RAM-only.
-15. **Dangerous opcodes are never auto-sent** (`dangerousCmds`, gated at
-    `ble/ble_engine.dart:1471`): force-trim, reboot, power-cycle, firmware load.
+15. **Dangerous opcodes are never auto-sent** (`dangerousCmds`, gated in
+    `ble/ble_engine.dart` wherever a write checks it): force-trim, reboot,
+    power-cycle, firmware load.
 
 ## 4. Recurring bug patterns — what actually ships broken here
 
@@ -228,12 +232,15 @@ visual bugs — check whether removed wrapper widgets were load-bearing.
 
 ## 5. How to review this repo
 
-**No CI gate runs on PRs.** `.github/workflows/build.yml` triggers only on
-`push: tags: ['v*']`. Nothing runs `flutter analyze` or `flutter test` on a pull
-request; `test/` (62 files, flat) is run manually. Several regression tests are
-named for the bug they pin (`readiness_flash_test`, `readiness_freeze_test`,
-`readiness_saturation_test`, `readiness_baseline_pollution_test`). A behavior
-change with no accompanying test is a real finding.
+**CI does run on PRs.** `.github/workflows/test.yml` runs `flutter analyze` +
+`flutter test` on every pull request and on push to `main`.
+`.github/workflows/build.yml` (the APK/IPA release) is the one gated to
+`push: tags: ['v*']` — it doesn't touch PRs. `test/` is large and not flat
+(it has `adapters/`, `support/`, and other subdirectories alongside the
+top-level test files). Several regression tests are named for the bug they pin
+(`readiness_flash_test`, `readiness_freeze_test`, `readiness_saturation_test`,
+`readiness_baseline_pollution_test`). A behavior change with no accompanying
+test is a real finding — CI passing doesn't mean the right test exists.
 
 `analysis_options.yaml` is stock `flutter_lints`: no custom rules, no excludes,
 no strict language modes.

--- a/README.md
+++ b/README.md
@@ -217,12 +217,33 @@ Full detail in [PRIVACY.md](PRIVACY.md).
 ## Repo layout
 
 ```
-lib/ble/       Bluetooth + sync
-lib/data/      local storage + the repository seam the UI reads from
+lib/ai/        BYOK AI assistant — briefings, journal AI, nightly sweep
+lib/ble/       Bluetooth link + history-sync state machine
+lib/cloud/     optional companion/backend + cloud import clients
+lib/coach/     read-only SQL coach over allow-listed views
 lib/compute/   runs the analytics pipeline, writes results
+lib/data/      local storage + the repository seam the UI reads from
+lib/debug/     debug-mode flags
+lib/gestures/  device action / gesture dispatch
+lib/gps/       GPS route tracking for outdoor activities
+lib/health/    HealthKit / Health Connect import + export
+lib/import/    backup + third-party data import
+lib/l10n/      translations (.arb)
+lib/live/      Live Activity / breathing session
+lib/models/    shared data models (Metric, payloads, app status)
+lib/notify/    the single notification emitter + alert policies
+lib/platform/  platform-channel glue (app icon, Tasker, device actions)
 lib/state/     AppState, the one source of truth
+lib/stress/    guided-breathing session logic
+lib/sync/      background/headless sync policies
+lib/telemetry/ opt-in error + usage telemetry
+lib/theme/     design tokens, theming, transitions
 lib/ui2/       every screen
+lib/widget/    App-Group snapshot for the home-screen/watch widget
 ```
+
+See `AGENTS.md` §2 for the full architecture map, invariants, and the biggest
+files by ownership.
 
 Protocol decoding and analytics live in their own repos —
 [protocol](https://github.com/OpenStrap/protocol),

--- a/lib/compute/crossday_pipeline.dart
+++ b/lib/compute/crossday_pipeline.dart
@@ -18,6 +18,8 @@ import 'dart:math' as math;
 
 import 'package:openstrap_analytics/onehz.dart' as ana;
 
+import '../data/day_label.dart';
+
 // Pure string helper only (the `need_input:name=…` note grammar) — no DB, no
 // IO, no Flutter binding, so importing it does not compromise this file's
 // isolate safety. One grammar for "a required input was missing" across both
@@ -752,15 +754,10 @@ List<double> _denseDailyTrimp(List<String> dates, List<double?> trimps) {
       // than an arbitrarily long zero-padded one.
       return [for (final v in trimps) v ?? 0.0];
     }
-    out.add(byDate[_dateKey(cursor)] ?? 0.0);
+    out.add(byDate[dayLabelOf(cursor)] ?? 0.0);
     cursor = DateTime(cursor.year, cursor.month, cursor.day + 1);
   }
   return out;
-}
-
-String _dateKey(DateTime d) {
-  String two(int x) => x.toString().padLeft(2, '0');
-  return '${d.year.toString().padLeft(4, '0')}-${two(d.month)}-${two(d.day)}';
 }
 
 /// Absolute value of each present element (used to orient skin-temp by |z|).

--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -3170,13 +3170,9 @@ class DerivationEngine {
   static List<String> _adjacentDayIds(String dayId) {
     final d = DateTime.tryParse(dayId);
     if (d == null) return const [];
-    String label(DateTime x) =>
-        '${x.year.toString().padLeft(4, '0')}-'
-        '${x.month.toString().padLeft(2, '0')}-'
-        '${x.day.toString().padLeft(2, '0')}';
     return [
-      label(DateTime(d.year, d.month, d.day - 1)),
-      label(DateTime(d.year, d.month, d.day + 1)),
+      dayLabelOf(DateTime(d.year, d.month, d.day - 1)),
+      dayLabelOf(DateTime(d.year, d.month, d.day + 1)),
     ];
   }
 

--- a/lib/compute/strain_backfill.dart
+++ b/lib/compute/strain_backfill.dart
@@ -32,6 +32,7 @@ import 'dart:convert';
 
 import 'package:openstrap_analytics/onehz.dart' as ana;
 
+import '../data/day_label.dart';
 import '../data/db.dart';
 import 'derivation_engine.dart' show kAlgoVersion, rawRetentionDays;
 
@@ -257,9 +258,5 @@ Map<String, dynamic>? _decode(Object? json) {
 }
 
 /// Shift a 'YYYY-MM-DD' label by [days] calendar days.
-String _shiftDays(String day, int days) {
-  final t = DateTime.parse(day).add(Duration(days: days));
-  final mm = t.month.toString().padLeft(2, '0');
-  final dd = t.day.toString().padLeft(2, '0');
-  return '${t.year}-$mm-$dd';
-}
+String _shiftDays(String day, int days) =>
+    dayLabelOf(DateTime.parse(day).add(Duration(days: days)));

--- a/lib/compute/substrate.dart
+++ b/lib/compute/substrate.dart
@@ -17,6 +17,8 @@ import 'dart:typed_data';
 import 'package:openstrap_analytics/onehz.dart' as ana;
 import 'package:openstrap_protocol/openstrap_protocol.dart' as proto;
 
+import '../data/day_label.dart';
+
 /// Minimum fraction of a nocturnal search window that must carry a REAL
 /// gravity vector before accel-led (van Hees) sleep detection is trusted.
 ///
@@ -956,11 +958,8 @@ class SleepWindowOverride {
 }
 
 /// Local YYYY-MM-DD label for an epoch-second instant.
-String localDateLabel(int epochSec) {
-  final d = DateTime.fromMillisecondsSinceEpoch(epochSec * 1000, isUtc: false);
-  String two(int x) => x.toString().padLeft(2, '0');
-  return '${d.year.toString().padLeft(4, '0')}-${two(d.month)}-${two(d.day)}';
-}
+String localDateLabel(int epochSec) =>
+    dayLabelOf(DateTime.fromMillisecondsSinceEpoch(epochSec * 1000));
 
 /// Split the substrate into CALENDAR days (local midnight → next local midnight).
 ///

--- a/lib/data/local_repository_impl.dart
+++ b/lib/data/local_repository_impl.dart
@@ -3479,10 +3479,7 @@ class LocalRepositoryImpl extends LocalRepository {
     if (range == 'all') return null;
     final m = RegExp(r'(\d+)').firstMatch(range);
     final days = m == null ? 30 : int.parse(m.group(1)!);
-    final d = DateTime.now().subtract(Duration(days: days));
-    return '${d.year.toString().padLeft(4, '0')}-'
-        '${d.month.toString().padLeft(2, '0')}-'
-        '${d.day.toString().padLeft(2, '0')}';
+    return dayLabelOf(DateTime.now().subtract(Duration(days: days)));
   }
 
   // ── menstrual cycle — local log + honest phase/prediction ───────────────────
@@ -3567,7 +3564,7 @@ class LocalRepositoryImpl extends LocalRepository {
     num? daysUntilNext;
     if (predictOk && lastStart != null && medianLength != null) {
       final next = lastStart.add(Duration(days: medianLength.round()));
-      predictedNext = _ymd(next);
+      predictedNext = dayLabelOf(next);
       final t0 = DateTime(today.year, today.month, today.day);
       daysUntilNext = DateTime(
         next.year,
@@ -3576,8 +3573,8 @@ class LocalRepositoryImpl extends LocalRepository {
       ).difference(t0).inDays;
       if (gapSpread != null) {
         final w = gapSpread.round();
-        predictedFrom = _ymd(next.subtract(Duration(days: w)));
-        predictedTo = _ymd(next.add(Duration(days: w)));
+        predictedFrom = dayLabelOf(next.subtract(Duration(days: w)));
+        predictedTo = dayLabelOf(next.add(Duration(days: w)));
       }
     }
 
@@ -3696,11 +3693,6 @@ class LocalRepositoryImpl extends LocalRepository {
       'overlay': overlay,
     };
   }
-
-  String _ymd(DateTime d) =>
-      '${d.year.toString().padLeft(4, '0')}-'
-      '${d.month.toString().padLeft(2, '0')}-'
-      '${d.day.toString().padLeft(2, '0')}';
 
   @override
   Future<void> postCycleLog(

--- a/lib/ui2/community_links.dart
+++ b/lib/ui2/community_links.dart
@@ -12,9 +12,16 @@ const kDiscordUrl = 'https://discord.gg/dUXds5MWkd';
 const kSponsorUrl = 'https://github.com/sponsors/abdulsaheel';
 
 /// Every link here is external — the browser/app the platform already picks
-/// for that URL scheme, never a WebView inside this app.
-Future<void> open3rdPartyLink(String url) =>
-    launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+/// for that URL scheme, never a WebView inside this app. Reports whether it
+/// actually opened, so callers that gate a permanent flag on it (nudges.dart)
+/// don't fire that flag when there was nowhere for the link to go.
+Future<bool> open3rdPartyLink(String url) async {
+  try {
+    return await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+  } catch (_) {
+    return false;
+  }
+}
 
 /// A brand mark (assets/icons/*.svg — official, single-fill-path logos),
 /// tinted to match whatever accent its row is drawn in, same 16×16 as the

--- a/lib/ui2/nudges.dart
+++ b/lib/ui2/nudges.dart
@@ -149,10 +149,15 @@ class _AskCard extends StatelessWidget {
               icon: LucideIcons.externalLink,
               color: color,
               soft: true,
-              onTap: () {
-                open3rdPartyLink(url);
-                // Acted on, not just seen — no reason to ask again.
-                onSilence(ask);
+              onTap: () async {
+                // Only silence permanently once the link actually opened —
+                // a failed launch (no app registered, no browser default)
+                // should not look "acted on".
+                if (await open3rdPartyLink(url)) {
+                  onSilence(ask);
+                } else {
+                  onSnooze(ask);
+                }
               }),
           const SizedBox(height: S.x2),
           Center(


### PR DESCRIPTION
### **User description**
fixes from the second audit pass:

- nudges.dart was silencing the discord/sponsor ask forever even when the link never opened (launchUrl failing was ignored). now it only silences on success, snoozes otherwise.
- collapsed 6 hand-rolled YYYY-MM-DD formatters into the existing day_label.dart helper (crossday_pipeline, substrate, derivation_engine, local_repository_impl x2, strain_backfill) - one place to fix the local/UTC bug class instead of six.
- AGENTS.md had a bunch of stale line numbers (kAlgoVersion, buildHistoryResultOk, dangerousCmds) and a wrong "no CI on PRs" claim - test.yml does run analyze+test on every PR, build.yml is the tag-only one. dropped the line numbers in favor of symbol names since they go stale immediately anyway.
- README's repo layout was missing most of lib/ (ai, health, gps, coach, etc) - filled it in.

ran flutter analyze on everything touched (clean) plus the relevant test files (day_label, crossday, substrate, derivation, local_repository, strain_backfill) - all green.

## Summary by Sourcery

Fix failed-link nudge handling, centralize calendar-day labels, and bring repository documentation up to date.

Bug Fixes:
- Prevent permanently silencing community-link nudges when opening the external link fails by snoozing them instead.
- Correct day-label generation across analytics, storage, and backfill code by consolidating duplicate date formatting behind the shared helper.

Enhancements:
- Refresh AGENTS.md architecture and review guidance, replacing unstable line-number references and correcting CI workflow details.

Documentation:
- Expand the README repository layout to document the broader lib/ directory structure.


___

### **PR Type**
Bug fix, Enhancement, Documentation


___

### **Description**
- Fixes community nudge silencing bug.
  - Snoozes instead of silencing on link failure.

- Consolidates day-label formatting.
  - Uses shared `dayLabelOf` across compute and data.

- Updates repository documentation.
  - Removes stale line numbers in `AGENTS.md`.
  - Expands directory layout in `README.md`.

- Notes missing tests.
  - Changes nudge behavior without adding new tests.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  NudgeUI["Nudge UI"] -- "Clicks link" --> OpenLink["open3rdPartyLink()"]
  OpenLink -- "Success" --> Silence["Silence Nudge"]
  OpenLink -- "Failure" --> Snooze["Snooze Nudge"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>crossday_pipeline.dart</strong><dd><code>Replace inline date formatter with dayLabelOf</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/311/files#diff-f49f9c4e2c750e6c359b5cb4f60d33104bfd226374b4dcbea389e143a61a5fb8">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>derivation_engine.dart</strong><dd><code>Replace inline date formatter with dayLabelOf</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/311/files#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>strain_backfill.dart</strong><dd><code>Replace inline date formatter with dayLabelOf</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/311/files#diff-445e44e72e4b9965ac53b6871e1cbfca2953eb85f18bc985e4de007f6c594c5f">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>substrate.dart</strong><dd><code>Replace inline date formatter with dayLabelOf</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/311/files#diff-6856ecdbe8e720625d74426718528d7cdcb26dfef98106ff08c75d13ad37a889">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>local_repository_impl.dart</strong><dd><code>Replace inline date formatter with dayLabelOf</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/311/files#diff-da6b8e6c3188825ab7c7d364093ccefbd9e40a284244154fdbffd372214f6352">+4/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>community_links.dart</strong><dd><code>Return boolean success status from open3rdPartyLink</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/311/files#diff-14cd0a8ab51d0cd773aa174f79325324d94b86d01745385036e1c675fca4f495">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>nudges.dart</strong><dd><code>Snooze instead of silence on link launch failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/311/files#diff-e678c5e6013d3cb079886950f8d2318475cfdba7d2588d1a30889d7e5afb304e">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>AGENTS.md</strong><dd><code>Remove stale line numbers and correct CI documentation</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/311/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+29/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Expand repository layout to include missing directories</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/311/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+23/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

