### PR TITLE
fix reconciled-orphan health export leak + stale telemetry docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ Being precise about the network, since "no cloud" gets said too loosely. Nothing
 is required for the app to work, and none of it carries health data except the two you
 turn on yourself:
 
-- **Anonymous diagnostics** (Firebase crash/performance). **On by default in GitHub
-  release builds** — switch it off in your profile and collection stops immediately.
-  **Not present at all** in App Store / Play Store builds. Never includes health data.
+- **Anonymous diagnostics** (Firebase crash/performance). **Off by default in every
+  build** — nothing is collected until you turn it on in your profile, and switching
+  it back off stops collection immediately. Never includes health data.
 - **OTA/announcement pointer** — checks whether there's a newer build.
 - **Legacy account import** — one-time, only if you had an old OpenStrap cloud account.
 - **BYOK AI assistant** — only if you configure a provider. Your key, your account. Be

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,8 +46,8 @@ data on-device, and there's no account or server holding it. Two qualifications,
 so the boundary is exact:
 
 - **Anonymous diagnostics** (Firebase crash/performance, never health data) are
-  **on by default in GitHub release builds** and absent from App Store / Play
-  Store builds. Switchable off in-app.
+  **off by default in every build** — nothing is collected until you turn it on
+  in-app, and switching it back off stops collection immediately.
 - **Health-data contribution** uploads the local database, but is opt-in, off by
   default, and compiled out of store builds entirely.
 

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -3267,6 +3267,18 @@ class LocalDb {
     // `ble/live_cadence.dart`). NULL means the session had no walking to have a
     // cadence for, which is most of them: it is an absence, never a 0.
     await _addColumnIfMissing(db, 'sessions', 'cadence_spm', 'INTEGER');
+    // Set only by `_reconcileOrphanedLiveWorkout` on a stale `status='live'`
+    // row it finalizes without ever having seen the real finish: `end_ts` there
+    // is reconcile-time, not a measurement. `_writeOneWorkout` skips any row
+    // with this set so that fabricated duration never reaches Apple
+    // Health/Health Connect on the next periodic export pass. NOT NULL DEFAULT
+    // 0: every existing/normal row really did finish for real.
+    await _addColumnIfMissing(
+      db,
+      'sessions',
+      'end_ts_fabricated',
+      'INTEGER NOT NULL DEFAULT 0',
+    );
     await _ensureSessionTraceColumns(db);
     // `sessions` is keyed by a TEXT id, so every read that matters — the
     // workouts list, the activity tab, both `decoded_onehz` HR joins,

--- a/lib/health/health_export.dart
+++ b/lib/health/health_export.dart
@@ -1211,6 +1211,12 @@ class HealthExporter {
     if ((r['status']?.toString() ?? '') == 'live') {
       return null; // skip, not a failure
     }
+    // Set by `_reconcileOrphanedLiveWorkout` on a crash-orphaned session it
+    // finalized without ever seeing the real finish — `end_ts` there is
+    // reconcile-time, not a measurement, so this must never reach Health.
+    if ((r['end_ts_fabricated'] as num?)?.toInt() == 1) {
+      return null; // skip, not a failure
+    }
     final st = (r['start_ts'] as num?)?.toInt();
     final en = (r['end_ts'] as num?)?.toInt();
     if (st == null || en == null || en <= st) {

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -5445,11 +5445,17 @@ class AppState extends ChangeNotifier {
           // (edge#277) — and for the same reason this is NEVER exported to
           // Health: [end_ts] here is fabricated, so a [start,end_ts] Health
           // workout sample would report a bogus duration as real data.
+          // `end_ts_fabricated` records that so `_writeOneWorkout` can skip it
+          // on every later periodic export pass too, not just this call site —
+          // without the flag the row looks like any other finished workout and
+          // gets exported on the next drain/derive cycle regardless.
           final reconciledEndTs = nowMs ~/ 1000;
+          final hadRealEnd = row['end_ts'] != null;
           await LocalDb.putSession({
             ...row,
             'status': 'done',
             'end_ts': row['end_ts'] ?? reconciledEndTs,
+            'end_ts_fabricated': hadRealEnd ? (row['end_ts_fabricated'] ?? 0) : 1,
           });
           _log('[workout] finalized a stale live-session row from a previous run (id=${row['id']}).');
         }

--- a/test/app_state_regressions_test.dart
+++ b/test/app_state_regressions_test.dart
@@ -232,6 +232,10 @@ void main() {
       final row = await LocalDb.session(staleId);
       expect(row?['status'], 'done');
       expect(row?['end_ts'], isNotNull);
+      expect(row?['end_ts_fabricated'], 1,
+          reason: 'without this flag the row looks like any other finished '
+              'workout and _writeOneWorkout would export it on the very next '
+              'periodic exportAll pass, minutes later');
     });
   });
 

--- a/test/health_workout_export_delete_gate_test.dart
+++ b/test/health_workout_export_delete_gate_test.dart
@@ -126,6 +126,22 @@ void main() {
       expect(ok, isTrue);
       expect(store.calls, containsAllInOrder(['delete', 'writeWorkoutData']));
     });
+
+    test(
+        'a reconciled orphan (end_ts_fabricated) is never written, even '
+        'though it looks like any other finished row', () async {
+      store = _FakeHealthStore(deleteResult: true)..install();
+
+      final ok = await HealthExporter().exportWorkout({
+        ..._session(),
+        'end_ts_fabricated': 1,
+      });
+
+      expect(ok, isFalse);
+      expect(store.calls, isNot(contains('writeWorkoutData')),
+          reason: 'end_ts here is reconcile-time, not a measurement — this '
+              'must never reach Health, on the periodic export path either');
+    });
   });
 
   group('deleteWorkoutWindow (retime cleanup)', () {


### PR DESCRIPTION
### **User description**
round 3 only skipped the direct exportWorkoutId call for a crash-orphaned live workout, but the periodic exportAll pass still picked the row up a few minutes later since nothing on it said the end_ts was fake. added an end_ts_fabricated flag set at reconcile time and checked in _writeOneWorkout so it's skipped everywhere, not just that one call site.

also fixed README.md and SECURITY.md saying diagnostics telemetry is "on by default in github release builds" - it isn't, it's off by default everywhere until you flip it in settings, code and PRIVACY.md both already agreed on that.

## Summary by Sourcery

Prevent fabricated completion times from leaking into health exports and align telemetry documentation with the actual opt-in behavior.

Bug Fixes:
- Prevent reconciled orphaned workouts with fabricated end times from being exported to Apple Health or Health Connect through any export path.
- Correct diagnostics telemetry documentation to state that collection is disabled by default in every build.

Documentation:
- Update README.md and SECURITY.md to accurately describe diagnostics telemetry defaults.

Tests:
- Add regression coverage for marking reconciled orphan sessions and preventing their health export.


___

### **PR Type**
Bug fix, Documentation, Tests


___

### **Description**
- Prevents crash-orphaned workouts with fabricated end times from leaking into Apple Health or Health Connect during periodic exports.

- Adds a database migration appending the `end_ts_fabricated` column to the `sessions` table to persistently flag reconciled orphans.

- Updates `README.md` and `SECURITY.md` to accurately reflect that diagnostics telemetry is disabled by default across all builds.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Stale Live Workout"] -- "Reconciled" --> B["AppState"]
  B -- "Sets end_ts_fabricated=1" --> C["LocalDb (sessions)"]
  C -- "Periodic Export" --> D["HealthExporter"]
  D -- "Skips export" --> E["Apple Health / Health Connect"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Database schema</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>db.dart</strong><dd><code>Adds end_ts_fabricated column to sessions table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/313/files#diff-b96f416000a07a912224053a34f440c27993e014d324d6ae8c9dfe88bb0617e6">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>health_export.dart</strong><dd><code>Skips health export for workouts with fabricated end times</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/313/files#diff-7688da159b76fc36f532ed153ea690343655e60ab0436820d1bcbc54113e15f5">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_state.dart</strong><dd><code>Flags reconciled stale live workouts with end_ts_fabricated</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/313/files#diff-d56ba858e512e18dc3962da198adee46d354aca39ff7c1b4a11d5f19b9afc1ae">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>app_state_regressions_test.dart</strong><dd><code>Adds assertion for end_ts_fabricated flag on stale orphans</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/313/files#diff-4b616ea72013dae65bc6ef742de36cdbf157389efd8adbd83542ddd976de21cf">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_workout_export_delete_gate_test.dart</strong><dd><code>Adds test verifying fabricated workouts are not exported</code>&nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/313/files#diff-6080ad6b25af20ee49b3adab7b01cd517361582cfc93e0d4b03e1eef180c3001">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Corrects telemetry default state documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/313/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SECURITY.md</strong><dd><code>Corrects telemetry default state documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/313/files#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

