### PR TITLE
repin + fix #305 + fix #40

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -39,100 +39,100 @@ PODS:
   - file_picker (0.0.1):
     - DKImagePickerController/PhotoGallery
     - Flutter
-  - Firebase/CoreOnly (12.15.0):
-    - FirebaseCore (~> 12.15.0)
-  - Firebase/Crashlytics (12.15.0):
+  - Firebase/CoreOnly (12.18.0):
+    - FirebaseCore (~> 12.18.0)
+  - Firebase/Crashlytics (12.18.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 12.15.0)
-  - Firebase/Performance (12.15.0):
+    - FirebaseCrashlytics (~> 12.18.0)
+  - Firebase/Performance (12.18.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 12.15.0)
-  - firebase_analytics (12.4.3):
+    - FirebasePerformance (~> 12.18.0)
+  - firebase_analytics (12.5.0):
     - firebase_core
-    - FirebaseAnalytics (= 12.15.0)
+    - FirebaseAnalytics (= 12.18.0)
     - Flutter
-  - firebase_core (4.11.0):
-    - Firebase/CoreOnly (= 12.15.0)
+  - firebase_core (4.14.0):
+    - Firebase/CoreOnly (= 12.18.0)
     - Flutter
-  - firebase_crashlytics (5.2.4):
-    - Firebase/Crashlytics (= 12.15.0)
-    - firebase_core
-    - Flutter
-  - firebase_performance (0.11.4-3):
-    - Firebase/Performance (= 12.15.0)
+  - firebase_crashlytics (5.3.0):
+    - Firebase/Crashlytics (= 12.18.0)
     - firebase_core
     - Flutter
-  - FirebaseABTesting (12.15.0):
-    - FirebaseCore (~> 12.15.0)
-  - FirebaseAnalytics (12.15.0):
-    - FirebaseAnalytics/Default (= 12.15.0)
-    - FirebaseCore (~> 12.15.0)
-    - FirebaseInstallations (~> 12.15.0)
+  - firebase_performance (0.11.5):
+    - Firebase/Performance (= 12.18.0)
+    - firebase_core
+    - Flutter
+  - FirebaseABTesting (12.18.0):
+    - FirebaseCore (~> 12.18.0)
+  - FirebaseAnalytics (12.18.0):
+    - FirebaseAnalytics/Default (= 12.18.0)
+    - FirebaseCore (~> 12.18.0)
+    - FirebaseInstallations (~> 12.18.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
     - nanopb (~> 3.30910.0)
-  - FirebaseAnalytics/Default (12.15.0):
-    - FirebaseCore (~> 12.15.0)
-    - FirebaseInstallations (~> 12.15.0)
-    - GoogleAppMeasurement/Default (= 12.15.0)
+  - FirebaseAnalytics/Default (12.18.0):
+    - FirebaseCore (~> 12.18.0)
+    - FirebaseInstallations (~> 12.18.0)
+    - GoogleAppMeasurement/Default (= 12.18.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
     - nanopb (~> 3.30910.0)
-  - FirebaseCore (12.15.0):
-    - FirebaseCoreInternal (~> 12.15.0)
+  - FirebaseCore (12.18.0):
+    - FirebaseCoreInternal (~> 12.18.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/Logger (~> 8.1)
-  - FirebaseCoreExtension (12.15.0):
-    - FirebaseCore (~> 12.15.0)
-  - FirebaseCoreInternal (12.15.0):
+  - FirebaseCoreExtension (12.18.0):
+    - FirebaseCore (~> 12.18.0)
+  - FirebaseCoreInternal (12.18.0):
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
-  - FirebaseCrashlytics (12.15.0):
-    - FirebaseCore (~> 12.15.0)
-    - FirebaseInstallations (~> 12.15.0)
-    - FirebaseRemoteConfigInterop (~> 12.15.0)
-    - FirebaseSessions (~> 12.15.0)
+  - FirebaseCrashlytics (12.18.0):
+    - FirebaseCore (~> 12.18.0)
+    - FirebaseInstallations (~> 12.18.0)
+    - FirebaseRemoteConfigInterop (~> 12.18.0)
+    - FirebaseSessions (~> 12.18.0)
     - GoogleDataTransport (~> 10.1)
     - GoogleUtilities/Environment (~> 8.1)
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseInstallations (12.15.0):
-    - FirebaseCore (~> 12.15.0)
+  - FirebaseInstallations (12.18.0):
+    - FirebaseCore (~> 12.18.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - PromisesObjC (~> 2.4)
-  - FirebasePerformance (12.15.0):
-    - FirebaseCore (~> 12.15.0)
-    - FirebaseInstallations (~> 12.15.0)
-    - FirebaseRemoteConfig (~> 12.15.0)
-    - FirebaseSessions (~> 12.15.0)
+  - FirebasePerformance (12.18.0):
+    - FirebaseCore (~> 12.18.0)
+    - FirebaseInstallations (~> 12.18.0)
+    - FirebaseRemoteConfig (~> 12.18.0)
+    - FirebaseSessions (~> 12.18.0)
     - GoogleDataTransport (~> 10.1)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
-  - FirebaseRemoteConfig (12.15.0):
-    - FirebaseABTesting (~> 12.15.0)
-    - FirebaseCore (~> 12.15.0)
-    - FirebaseInstallations (~> 12.15.0)
-    - FirebaseRemoteConfigInterop (~> 12.15.0)
-    - FirebaseSharedSwift (~> 12.15.0)
+  - FirebaseRemoteConfig (12.18.0):
+    - FirebaseABTesting (~> 12.18.0)
+    - FirebaseCore (~> 12.18.0)
+    - FirebaseInstallations (~> 12.18.0)
+    - FirebaseRemoteConfigInterop (~> 12.18.0)
+    - FirebaseSharedSwift (~> 12.18.0)
     - GoogleUtilities/Environment (~> 8.1)
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
-  - FirebaseRemoteConfigInterop (12.15.0)
-  - FirebaseSessions (12.15.0):
-    - FirebaseCore (~> 12.15.0)
-    - FirebaseCoreExtension (~> 12.15.0)
-    - FirebaseInstallations (~> 12.15.0)
+  - FirebaseRemoteConfigInterop (12.18.0)
+  - FirebaseSessions (12.18.0):
+    - FirebaseCore (~> 12.18.0)
+    - FirebaseCoreExtension (~> 12.18.0)
+    - FirebaseInstallations (~> 12.18.0)
     - GoogleDataTransport (~> 10.1)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (12.15.0)
+  - FirebaseSharedSwift (12.18.0)
   - Flutter (1.0.0)
   - flutter_blue_plus_darwin (0.0.2):
     - Flutter
@@ -152,23 +152,23 @@ PODS:
     - GoogleUtilities/Logger (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/Core (12.15.0):
+  - GoogleAppMeasurement/Core (12.18.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/Default (12.15.0):
+  - GoogleAppMeasurement/Default (12.18.0):
     - GoogleAdsOnDeviceConversion (~> 3.6.0)
-    - GoogleAppMeasurement/Core (= 12.15.0)
-    - GoogleAppMeasurement/IdentitySupport (= 12.15.0)
+    - GoogleAppMeasurement/Core (= 12.18.0)
+    - GoogleAppMeasurement/IdentitySupport (= 12.18.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/IdentitySupport (12.15.0):
-    - GoogleAppMeasurement/Core (= 12.15.0)
+  - GoogleAppMeasurement/IdentitySupport (12.18.0):
+    - GoogleAppMeasurement/Core (= 12.18.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
@@ -177,31 +177,31 @@ PODS:
   - GoogleDataTransport (10.1.1):
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - GoogleUtilities/AppDelegateSwizzler (8.1.2):
+  - GoogleUtilities/AppDelegateSwizzler (8.1.3):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Environment (8.1.2):
+  - GoogleUtilities/Environment (8.1.3):
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Logger (8.1.2):
+  - GoogleUtilities/Logger (8.1.3):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/MethodSwizzler (8.1.2):
+  - GoogleUtilities/MethodSwizzler (8.1.3):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Network (8.1.2):
+  - GoogleUtilities/Network (8.1.3):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (8.1.2)":
+  - "GoogleUtilities/NSData+zlib (8.1.3)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (8.1.2)
-  - GoogleUtilities/Reachability (8.1.2):
+  - GoogleUtilities/Privacy (8.1.3)
+  - GoogleUtilities/Reachability (8.1.3):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/UserDefaults (8.1.2):
+  - GoogleUtilities/UserDefaults (8.1.3):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - health (12.2.1):
@@ -345,23 +345,23 @@ SPEC CHECKSUMS:
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
   file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
-  Firebase: a8539b633d474fbeb654c7043f9c1649e274045b
-  firebase_analytics: 5e356f558625ce2d8b21deff00946b56d6e8d0d5
-  firebase_core: fc23178af8ea070194d09031ae4198a9608a3d22
-  firebase_crashlytics: 344bb168f55aee1086c6cdd0b105a9db018cd344
-  firebase_performance: 0102afafdc394249305ce255b4c5bc8f2a0194a1
-  FirebaseABTesting: 04cab3e6db77b86af50b6cf7c825a13e04beca52
-  FirebaseAnalytics: 9c9fa7915fc52ea03077000d5a7b6a8947b2d76e
-  FirebaseCore: 2e86a4ea1684d4381707069e4a6d89ac808e901e
-  FirebaseCoreExtension: 10d2a627977b39418759ad88ada80fbbd34f1c4f
-  FirebaseCoreInternal: 6ab6a02c94446c026d2cf35cf5383842ebaa4992
-  FirebaseCrashlytics: 87e76cc33259b076dd1f96cd829db76849338e08
-  FirebaseInstallations: eb29ccbf64eaedf86fd5b2ccc7fabde567660b52
-  FirebasePerformance: 4817b556f47b991e8cd42761ec47d6c31150b037
-  FirebaseRemoteConfig: d8b57e994277aabef7cca708e671ce676eefed7a
-  FirebaseRemoteConfigInterop: 7e3d57ce4b1e958bb1d15403faa7178f46bbb5b7
-  FirebaseSessions: acfe7eadca47cda94ac86592737204581bb1abf6
-  FirebaseSharedSwift: 3f5c2758484d32099d693f269f110d3249c3f7e3
+  Firebase: 5523dd53ebe603451b4e1befcd99fa20a5c015cd
+  firebase_analytics: eabab995ffa6e93bf1888e573eda3a8264c0f30f
+  firebase_core: 22b31970001508f6e63945bedcb7b9de68819aa5
+  firebase_crashlytics: f849aa211acedd808e8edc055d57d5aaeb7a2633
+  firebase_performance: 800d10ed1dffe4516c0dbe06eced28b8001817fc
+  FirebaseABTesting: 7060ad22592c1ae86cccf9cc0f886f470084cbd5
+  FirebaseAnalytics: 651ecdc96c7dd8df0c15d55b6c6b70f78c2987b9
+  FirebaseCore: 96787d19ee32dc2242cc487b301bc616afeb398b
+  FirebaseCoreExtension: a86bab02524ca2bff95dddab7a3fcad505c2ddeb
+  FirebaseCoreInternal: 93b2d5f9e184c6818a04433891c358b0720a6a38
+  FirebaseCrashlytics: bd160cfa074ad21ed708a466e15d1928ded1642a
+  FirebaseInstallations: 933b2747e8594084c9117b65e8358fce29d7ced7
+  FirebasePerformance: 502e1ef68686852307416a331d73a4844aa28922
+  FirebaseRemoteConfig: 263cc3d8306e5ec83727bca18fc245fb7027d3ca
+  FirebaseRemoteConfigInterop: 3cbd659033c3129ea81a756a52e4bf1cfc20c3a7
+  FirebaseSessions: 3eaac5fd8077513b95f9723efd940438e3e35fb2
+  FirebaseSharedSwift: 9d9404eea60b650d3e549898bfebbb8f665fe601
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_blue_plus_darwin: 20a08bfeaa0f7804d524858d3d8744bcc1b6dbc3
   flutter_local_notifications: 395056b3175ba4f08480a7c5de30cd36d69827e4
@@ -369,9 +369,9 @@ SPEC CHECKSUMS:
   flutter_timezone: ee50ce7786b5fde27e2fe5375bbc8c9661ffc13f
   geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   GoogleAdsOnDeviceConversion: e3b71da24ff4cf01cf520756ac1c2b93c07b86ff
-  GoogleAppMeasurement: a6d37949071d456e9147dac6789c4342e0e7a8c5
+  GoogleAppMeasurement: d70df385587c4175fc0836c11e413d5cbcaa3c7b
   GoogleDataTransport: a24e58982ab3ba2f64d79613e027fe7f57e88539
-  GoogleUtilities: 766ace00c6b10d8148408f329d10c4f051931850
+  GoogleUtilities: 4e0c2ad9fa0d0d18b5c4df8bf57b461cba35b0bb
   health: fe206e65f13a9b88623605fbd8af8f029e23dc35
   home_widget: f169fc41fd807b4d46ab6615dc44d62adbf9f64f
   mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
@@ -385,7 +385,7 @@ SPEC CHECKSUMS:
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
-  workmanager_apple: 904529ae31e97fc5be632cf628507652294a0778
+  workmanager_apple: 1fc2a64e6a63ed3540fbb91b65f0c0d501881248
 
 PODFILE CHECKSUM: b50997058227f33b81189532a9f3fc5007ec070b
 

--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -1538,7 +1538,19 @@ import 'substrate.dart';
 // so the older, complete row keeps being served. Also: the readiness z-cap
 // abstention now populates `readiness_absent_diag` with its own
 // `unstable_baseline:` reason instead of leaving it null (onehz_pipeline.dart).
-const int kAlgoVersion = 83;
+//
+// 83 → 84: repins both siblings to their main #-audit merges. protocol
+// 6664854 -> 471034c (#42, live-decode-path fixes only — no persisted
+// decoder moves, see the protocol pin comment). analytics 187e026 -> 1fa8144
+// (#59): `sessionHrCeiling`'s corroboration window no longer lets a single
+// un-averaged sample count as sustained motion (was reachable at the very
+// first trailing-window iteration), and `irregularBeatScreen`'s
+// sustained-window check no longer diffs across a beat that artifact
+// rejection removed as if it were adjacent. Both feed stored scalars
+// (`hr_ceiling_bpm` via `sessionHrCeiling` at :7662; the 24 h and sleep
+// irregular-rhythm screens via `irregularBeatScreen` in onehz_pipeline.dart),
+// so this bump is real, not a repin-only formality.
+const int kAlgoVersion = 84;
 /// The sibling SHAs this version was derived against, asserted against
 /// pubspec.yaml in test/db_serve_version_and_reads_test.dart.
 ///
@@ -1652,8 +1664,8 @@ const int kAlgoVersion = 83;
 // main took analytics 7105256 → 187e026 (the v80 gate above); this branch
 // took protocol 19d7291 → 6664854. kAlgoVersion is main's 81 — this branch
 // moves no derivation maths, which is why its own note says NO bump.
-const String kAnalyticsPin = '187e026fd975d3885ff1a22af5e125d1c8c1825e';
-const String kProtocolPin = '6664854062d6e0e6099eac39b3ee73d96703a49e';
+const String kAnalyticsPin = '1fa8144a5e3b728ce91eeed6ecbc15d482933b44';
+const String kProtocolPin = '471034cb84b85edb37e72b6f6add79a2d7929294';
 
 // Fold idempotency, the minimum-nights warm-up, and legacy-payload handling
 // all live in SleepProfilePolicy (pure, unit-tested) — see

--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -3746,7 +3746,7 @@ class DerivationEngine {
     // this null silently overwrites a good historical baseline point and
     // collapses every later night's readiness baseline out from under it.
     //
-    // v84 (edge#305 fully closed): this no longer requires THIS pass to have
+    // v85 (edge#305 fully closed): this no longer requires THIS pass to have
     // found a sleep window. A re-stage whose RR/HR substrate aged out can come
     // back with no window at all (`NO_SLEEP_DETECTED`), not just a truncated
     // one — that shape is exactly as much a regression against an existing

--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -1539,6 +1539,17 @@ import 'substrate.dart';
 // abstention now populates `readiness_absent_diag` with its own
 // `unstable_baseline:` reason instead of leaving it null (onehz_pipeline.dart).
 //
+// v83's guard was `hasSleepWindow && sleepSubEmpty && nightScalarsNull`
+// (:4204) — #305's own writeup named this exact shape ("a sleep-window
+// boundary check") as insufficient, with a counterexample: a day whose stager
+// found NO window at all (`hasSleepWindow` false) still hit the original
+// clobber, unprotected. The v83 fix also declined by early `return` rather
+// than writing a protected row state, which is the OTHER approach #305 names
+// and rejects ("wedges the pruner... retried every pass forever") —
+// mitigated only by the pre-existing generic `_maxRawHoldDays` bound (14
+// days), not by anything added for #305. v83 did ship #305's third proposed
+// fix in full (the dedicated `unstable_baseline:` diagnostic).
+//
 // 83 → 84: repins both siblings to their main #-audit merges. protocol
 // 6664854 -> 471034c (#42, live-decode-path fixes only — no persisted
 // decoder moves, see the protocol pin comment). analytics 187e026 -> 1fa8144
@@ -1550,7 +1561,17 @@ import 'substrate.dart';
 // (`hr_ceiling_bpm` via `sessionHrCeiling` at :7662; the 24 h and sleep
 // irregular-rhythm screens via `irregularBeatScreen` in onehz_pipeline.dart),
 // so this bump is real, not a repin-only formality.
-const int kAlgoVersion = 84;
+//
+// 84 → 85 (edge#305, closing the gap left by v83): `nightSubstrateRegressed`
+// no longer requires THIS pass to have found a sleep window (:4232). The
+// counterexample v83 missed — a re-stage whose RR/HR substrate aged out and
+// came back `NO_SLEEP_DETECTED` instead of a truncated window — is now
+// declined the same way as the truncated-window case. Safety against
+// clobbering a genuinely-honest "no sleep that night" derive still comes from
+// the caller's existingHadNight check, not from this shape test: a day that
+// never had real sleep never had an existing result with real night scalars
+// to protect. #305 is now fully closed.
+const int kAlgoVersion = 85;
 /// The sibling SHAs this version was derived against, asserted against
 /// pubspec.yaml in test/db_serve_version_and_reads_test.dart.
 ///
@@ -3714,18 +3735,23 @@ class DerivationEngine {
     // this null silently overwrites a good historical baseline point and
     // collapses every later night's readiness baseline out from under it.
     //
-    // Detect the same shape the guard above already reasons about — a known
-    // sleep window whose substrate is now entirely gone, re-deriving over a
-    // day that already had a real result — and decline the SAME way: keep
-    // the existing (older-version) row being served (`_servedDayJoin` already
-    // serves the highest version <= ceiling, so nothing needs to change there)
-    // rather than writing a new, worse row. A `partial` row was considered
-    // instead, but `partial` still gets written to `day_result` and would
-    // still shadow the better older row for day-detail reads; declining is
-    // what actually protects it.
+    // v84 (edge#305 fully closed): this no longer requires THIS pass to have
+    // found a sleep window. A re-stage whose RR/HR substrate aged out can come
+    // back with no window at all (`NO_SLEEP_DETECTED`), not just a truncated
+    // one — that shape is exactly as much a regression against an existing
+    // real result, and v83's `hasSleepWindow` requirement missed it (the exact
+    // counterexample #305 named). What actually distinguishes this from an
+    // honest "this day never had sleep" derive is the existingHadNight check
+    // right below, not whether this pass sees a window — a day that never had
+    // real sleep never had an existing result with real night scalars either.
+    // Decline the same way: keep the existing (older-version) row being served
+    // (`_servedDayJoin` already serves the highest version <= ceiling, so
+    // nothing needs to change there) rather than writing a new, worse row. A
+    // `partial` row was considered instead, but `partial` still gets written
+    // to `day_result` and would still shadow the better older row for
+    // day-detail reads; declining is what actually protects it.
     if (!producedNothing &&
         nightSubstrateRegressed(
-          hasSleepWindow: day.sleepOffsetSec > day.sleepOnsetSec,
           sleepSubEmpty: sleepSub.isEmpty,
           nightScalarsNull: scMap == null ||
               (scMap['rhr'] == null &&
@@ -4205,19 +4231,24 @@ class DerivationEngine {
 
   /// edge#305 — whether THIS derive's night-physiology substrate has
   /// regressed to nothing even though [producedNothing] (in
-  /// `_derivePreparedDay`) is false: plenty of daytime HR survives
-  /// ([hasSleepWindow] true, i.e. sleep STAGING still has a window — it
-  /// replays the durable `sleep_session_candidates` row, not raw — but
-  /// [sleepSubEmpty], the night's own RR/HR substrate, has aged out from
-  /// under it) and every night-physiology scalar ([nightScalarsNull]) came
-  /// back null. Pure so the shape is unit-testable without the full pipeline;
-  /// the caller still has to confirm an EXISTING result actually had real
-  /// night scalars before declining to write over it.
+  /// `_derivePreparedDay`) is false: plenty of daytime HR survives, but
+  /// [sleepSubEmpty] (the night's own RR/HR substrate) is gone and every
+  /// night-physiology scalar ([nightScalarsNull]) came back null. Deliberately
+  /// NOT gated on this pass finding a sleep window: v83 required
+  /// `hasSleepWindow` and missed the exact counterexample #305 named — a
+  /// re-stage whose RR/HR substrate aged out can come back `NO_SLEEP_DETECTED`
+  /// too, not just a truncated-but-present window, and that shape is just as
+  /// much a regression against an existing real result. A genuinely-honest
+  /// "this day never had sleep" case is still safe: it never had an existing
+  /// result with real night scalars, so the caller's existing-result check is
+  /// what actually distinguishes the two, not this shape test. Pure so the
+  /// shape is unit-testable without the full pipeline; the caller still has to
+  /// confirm an EXISTING result actually had real night scalars before
+  /// declining to write over it.
   static bool nightSubstrateRegressed({
-    required bool hasSleepWindow,
     required bool sleepSubEmpty,
     required bool nightScalarsNull,
-  }) => hasSleepWindow && sleepSubEmpty && nightScalarsNull;
+  }) => sleepSubEmpty && nightScalarsNull;
 
   /// Whether [row] is a REAL derived day result worth protecting — i.e. not a
   /// skip marker and not an all-absent shell.

--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -1571,7 +1571,18 @@ import 'substrate.dart';
 // the caller's existingHadNight check, not from this shape test: a day that
 // never had real sleep never had an existing result with real night scalars
 // to protect. #305 is now fully closed.
-const int kAlgoVersion = 85;
+//
+// 85 → 86 (analytics#40, closing edge#204's workaround): `_attachNaps`'s
+// midnight dedup used to guess a bout was already-counted from
+// `nap.startSec == 0`, which only ever matched the FIRST bout of the day's
+// window — a fragment chained onto it by a brief arousal (`napChainGapSec`)
+// has `startSec > 0` but is just as edge-anchored, and slipped through
+// uncounted, double-crediting its minutes to both days. Analytics now
+// propagates a real `NapWindow.startsAtRecordEdge` flag through the whole
+// chain (nap.dart); `_attachNaps` tests that flag directly instead of
+// re-deriving it from the index. Real output change (nap minutes / sleep
+// need on days with a midnight-arousal-split nap), so the bump is real.
+const int kAlgoVersion = 86;
 /// The sibling SHAs this version was derived against, asserted against
 /// pubspec.yaml in test/db_serve_version_and_reads_test.dart.
 ///
@@ -7074,30 +7085,36 @@ class DerivationEngine {
       }
 
       final t0 = s.tsSec.first;
-      // The window opens AT local midnight and is contiguous into it, so a bout
-      // that begins at the very first sample was already in progress when we
-      // started looking — it is the tail of something that started YESTERDAY,
-      // and yesterday's buffered window (which runs `napBoundaryBufferSec` past
-      // its own midnight) saw it whole and emitted it whole.
+      // The window opens AT local midnight and is contiguous into it, so a
+      // bout [NapWindow.startsAtRecordEdge] flags — already in progress when
+      // we started looking — is the tail of something that started
+      // YESTERDAY, and yesterday's buffered window (which runs
+      // `napBoundaryBufferSec` past its own midnight) saw it whole and
+      // emitted it whole.
       //
-      // Analytics guards the trailing edge only: `unfinished` walks BACKWARD
-      // from the array end (nap.dart), while `stillAt(0)` short-circuits its
-      // discontinuity check at `k == 0` — so a bout at index 0 is always
-      // emitted, with no way for the detector to know what preceded it. Before
-      // `minNapSec` dropped to 15 min this was unreachable (the old nocturnal
-      // detector needed 60+ min and an HR dip); it is reachable now.
+      // analytics#40 (closing edge#204's workaround): this used to be
+      // guessed from `nap.startSec == 0`, which only ever caught the FIRST
+      // bout of the window — a bout chained onto it within `napChainGapSec`
+      // (a brief arousal right at midnight) has `startSec > 0` but is just as
+      // edge-anchored, and the old check let it through uncounted. Analytics
+      // now propagates the flag through the whole chain (nap.dart), so
+      // testing it directly instead of re-deriving it from the index catches
+      // those fragments too.
       //
-      // Gated on contiguity, NOT on index alone: if the record only STARTS
-      // hours into the day (band off overnight), yesterday's detector broke on
-      // that same discontinuity and dropped the bout too, so dropping it here
-      // as well would lose a real nap rather than de-duplicate one.
+      // Still gated on contiguity, NOT on the flag alone: if the record only
+      // STARTS hours into the day (band off overnight), yesterday's detector
+      // broke on that same discontinuity and dropped the bout too, so
+      // dropping it here as well would lose a real nap rather than
+      // de-duplicate one.
       final leadingEdgeOwnedByYesterday = attributionStartSec != null &&
           t0 <= attributionStartSec + napLeadingEdgeContiguitySec;
       // A nap STARTING at/after the real day boundary is tomorrow's — its own
       // (unbuffered) window finds it independently, so keeping it here too
       // would double-count it.
       final naps = m.value!.where((nap) {
-        if (leadingEdgeOwnedByYesterday && nap.startSec == 0) return false;
+        if (leadingEdgeOwnedByYesterday && nap.startsAtRecordEdge) {
+          return false;
+        }
         if (attributionEndSec == null) return true;
         return t0 + nap.startSec < attributionEndSec;
       }).toList();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -857,10 +857,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -937,8 +937,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "187e026fd975d3885ff1a22af5e125d1c8c1825e"
-      resolved-ref: "187e026fd975d3885ff1a22af5e125d1c8c1825e"
+      ref: "1fa8144a5e3b728ce91eeed6ecbc15d482933b44"
+      resolved-ref: "1fa8144a5e3b728ce91eeed6ecbc15d482933b44"
       url: "https://github.com/OpenStrap/analytics.git"
     source: git
     version: "1.0.0"
@@ -946,8 +946,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "6664854062d6e0e6099eac39b3ee73d96703a49e"
-      resolved-ref: "6664854062d6e0e6099eac39b3ee73d96703a49e"
+      ref: "471034cb84b85edb37e72b6f6add79a2d7929294"
+      resolved-ref: "471034cb84b85edb37e72b6f6add79a2d7929294"
       url: "https://github.com/OpenStrap/protocol.git"
     source: git
     version: "1.0.0"
@@ -1376,26 +1376,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   timezone:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -126,7 +126,24 @@ dependencies:
       # so no stored number can move. Reasoning also sits beside kProtocolPin
       # in lib/compute/derivation_engine.dart, which moves together with this
       # ref and pubspec.lock (the pin-equality test fails a partial repin).
-      ref: 6664854062d6e0e6099eac39b3ee73d96703a49e
+      #
+      # REPIN: protocol main @ 471034c, the #42 (audit/consolidated-fixes)
+      # merge — 6 commits on top of 6664854: decodeFrame's short-packet
+      # dispatch now tries the v2 realtime-HR parser before falling back to
+      # v1 (rev-2 packets were being misdecoded); R10 live dispatch no longer
+      # drops hr==0 (off-wrist) records to a bare data_record and now carries
+      # ts_epoch like the other realtime_hr branches; the copy-pasted LE
+      # (sec, subsec) byte packing used by 5 command builders and the
+      # hand-rolled _pow10/gen5 u16/i16/u32 readers were deduped; and #36
+      # lands raw R11 frame decoding (`R11Raw`/`decodeR11Raw`, meaning
+      # unconfirmed — see live.dart).
+      #
+      # NO kAlgoVersion bump: every changed decoder here is on the live
+      # realtime path (decodeFrame's `realtime_hr`/`realtime_small`, R11) —
+      # live high-rate streams are never persisted (see invariant #1), so no
+      # stored day_result number moves. R11's meaning is still unconfirmed
+      # and edge does not read it.
+      ref: 471034cb84b85edb37e72b6f6add79a2d7929294
   openstrap_analytics:
     git:
       url: https://github.com/OpenStrap/analytics.git
@@ -280,7 +297,29 @@ dependencies:
       # that onehz_pipeline.dart (edge #289 / 3120774) already calls -- the
       # pin was never moved when that landed, which broke `flutter analyze`
       # (undefined_named_parameter, both call sites). No other symbol changed.
-      ref: 187e026fd975d3885ff1a22af5e125d1c8c1825e
+      #
+      # REPIN: analytics main @ 1fa8144, the #59 (audit/consolidated-fixes)
+      # merge — 3 commits on top of 187e026, two output-affecting:
+      # `sessionHrCeiling`'s trailing-motion corroboration window could be
+      # satisfied by a single un-averaged sample at the very first iteration
+      # (one noisy sample "corroborating" a hold before the trailing window
+      # had actually accumulated its ~3 s span) — now only updates `bestTrail`
+      # once the window has matured to a full span; `irregularBeatScreen`'s
+      # sustained-window check diffed consecutive elements of the
+      # artifact-compacted beat array even when a removed beat sat between
+      # them, understating the true gap and risking a false sustained-flag —
+      # now carries an alignment flag (`nnAdjacent`) so a diff across a
+      # dropped beat is skipped the same way the aggregate diff already does.
+      # The third commit is doc-only (README quick-start's `nnTimesMs`
+      # numbers were off by one cumulative sum; `dailyActiveMinutes`'s
+      # AN-2554 citation was wrong, relabeled internal ESTIMATE).
+      #
+      # kAlgoVersion bumped (84) for this hop: `sessionHrCeiling` feeds the
+      # stored `hr_ceiling_bpm` (derivation_engine.dart:7662) and
+      # `irregularBeatScreen` feeds the stored 24 h and sleep irregular-rhythm
+      # screens (onehz_pipeline.dart) — both are real, if narrow, output
+      # changes, not NaN/±inf-only rejections.
+      ref: 1fa8144a5e3b728ce91eeed6ecbc15d482933b44
 
   # BLE — flutter_blue_plus is the maintained cross-platform GATT client.
   flutter_blue_plus: ^1.36.8

--- a/test/derive_result_protection_test.dart
+++ b/test/derive_result_protection_test.dart
@@ -395,7 +395,6 @@ void main() {
         'scalars is a regression', () {
       expect(
         DerivationEngine.nightSubstrateRegressed(
-          hasSleepWindow: true,
           sleepSubEmpty: true,
           nightScalarsNull: true,
         ),
@@ -403,15 +402,17 @@ void main() {
       );
     });
 
-    test('no known sleep window at all is not a regression (honest no-sleep '
-        'day)', () {
+    test('the v83 counterexample: a re-stage that finds NO window at all '
+        '(NO_SLEEP_DETECTED) with null night scalars is STILL a regression '
+        '— the shape test does not require this pass to have found a '
+        'window; the caller\'s existing-result check is what protects an '
+        'honest no-sleep day', () {
       expect(
         DerivationEngine.nightSubstrateRegressed(
-          hasSleepWindow: false,
           sleepSubEmpty: true,
           nightScalarsNull: true,
         ),
-        isFalse,
+        isTrue,
       );
     });
 
@@ -419,7 +420,6 @@ void main() {
         'scalars (a genuine can\'t-compute night)', () {
       expect(
         DerivationEngine.nightSubstrateRegressed(
-          hasSleepWindow: true,
           sleepSubEmpty: false,
           nightScalarsNull: true,
         ),
@@ -430,7 +430,6 @@ void main() {
     test('real night scalars computed is not a regression', () {
       expect(
         DerivationEngine.nightSubstrateRegressed(
-          hasSleepWindow: true,
           sleepSubEmpty: true,
           nightScalarsNull: false,
         ),
@@ -448,7 +447,6 @@ void main() {
     expect(await LocalDb.dayResult(day), isNull, reason: 'precondition');
     expect(
       DerivationEngine.nightSubstrateRegressed(
-        hasSleepWindow: true,
         sleepSubEmpty: true,
         nightScalarsNull: true,
       ),

--- a/test/nap_attribution_test.dart
+++ b/test/nap_attribution_test.dart
@@ -322,6 +322,79 @@ void main() {
       expect(sc['nap_min'], 0.0);
     });
 
+    test(
+      'analytics#40: a fragment CHAINED onto the edge bout by a brief arousal '
+      'is also yesterday\'s, even though it does not itself start at index 0',
+      () {
+        // bout0 [0, 6min) is too short to be a nap on its own (< 15 min) but
+        // still touches index 0, so analytics flags it (and anything chained
+        // to it within napChainGapSec) as record-edge. A 10 min arousal
+        // separates it from bout1 [16min, 36min) — far enough to NOT bridge
+        // into one bout (> napBridgeSec = 5 min) but close enough to still
+        // chain as one edge-anchored episode (< napChainGapSec = 1 h). Only
+        // bout1 is long enough to be emitted as a nap, with `startSec > 0` —
+        // the old `nap.startSec == 0` proxy would have missed it and double
+        // -counted the same physical episode today.
+        const lengthSec = 6 * 3600;
+        final ts = <int>[];
+        final hr = <int>[];
+        final ax = <double>[], ay = <double>[], az = <double>[];
+        for (var i = 0; i < lengthSec; i++) {
+          ts.add(midnight + i);
+          final inBout0 = i < 6 * 60;
+          final inBout1 = i >= 16 * 60 && i < 36 * 60;
+          final still = inBout0 || inBout1;
+          hr.add(still ? 56 : 78);
+          if (still) {
+            ax.add(0.0);
+            ay.add(0.0);
+            az.add(1.0);
+          } else {
+            final deg = (i % 9) * 10.0;
+            final rad = deg * math.pi / 180.0;
+            ax.add(math.cos(rad));
+            ay.add(0.0);
+            az.add(math.sin(rad));
+          }
+        }
+        final s = Substrate(
+          tsSec: ts,
+          hr: hr,
+          rrTsMs: const [],
+          rrMs: const [],
+          ax: ax,
+          ay: ay,
+          az: az,
+          spo2Red: List<int>.filled(lengthSec, 0),
+          spo2Ir: List<int>.filled(lengthSec, 0),
+          skinTemp: List<int>.filled(lengthSec, 0),
+          skinContact: List<int>.filled(lengthSec, 0),
+        );
+        final bundle = <String, dynamic>{};
+        final sc = <String, dynamic>{};
+
+        final periods = DerivationEngine.debugAttachNaps(
+          bundle,
+          sc,
+          s,
+          0,
+          0,
+          attributionStartSec: midnight,
+          attributionEndSec: midnight + 86400,
+        );
+
+        expect(periods, isNotNull, reason: 'the day WAS judged');
+        expect(
+          periods,
+          isEmpty,
+          reason:
+              'bout1 is chained to the edge-anchored bout0, so it is still '
+              "yesterday's tail, not a fresh nap today",
+        );
+        expect(sc['nap_min'], 0.0);
+      },
+    );
+
     test('a nap-shaped block fully inside a CHARGING span is not a nap', () {
       final s = _daySubstrate(
         startSec: midnight,


### PR DESCRIPTION
### **User description**
release prep cleanup, three separate things stacked on main:

- repin protocol -> 471034c and analytics -> 1fa8144, bump kAlgoVersion to 84 (irregular-rhythm + hr-ceiling fixes feed stored scalars, so it's a real bump not just a repin)
- fixes #305 the rest of the way: nightSubstrateRegressed no longer requires this pass to have found a sleep window, so a re-stage that comes back NO_SLEEP_DETECTED (not just truncated) gets the same protection. kAlgoVersion 85.
- closes #40: analytics now exposes NapWindow.startsAtRecordEdge properly propagated through the chain, so _attachNaps no longer has to guess the day-boundary dedup from nap.startSec == 0 (which missed a fragment chained on by a brief midnight arousal, double-crediting minutes to both days). kAlgoVersion 86.

added a regression test for the chained-fragment case in nap_attribution_test.dart.

## test plan
- [x] `flutter test test/nap_attribution_test.dart test/derive_result_protection_test.dart test/nap_edits_test.dart test/db_serve_version_and_reads_test.dart` all green

## Summary by Sourcery

Harden derivation results and nap attribution while updating audited sibling dependencies for release.

Bug Fixes:
- Protect historical night scalars when restaging returns NO_SLEEP_DETECTED after the underlying sleep substrate regresses.
- Prevent double-counting midnight nap fragments that are chained to an edge-anchored bout.
- Adopt audited protocol and analytics revisions, including corrections to persisted heart-rate and irregular-rhythm outputs.

Build:
- Repin the protocol and analytics dependencies and update the algorithm version to 86.

Tests:
- Add regression coverage for NO_SLEEP_DETECTED derivation protection and chained midnight nap attribution.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Repins `protocol` and `analytics` sibling packages in `pubspec.yaml` to their latest audited revisions.

- Bumps `kAlgoVersion` to 86 due to changes in analytics output (HR ceiling, irregular rhythm, and nap attribution).

- Prevents historical night scalars from being overwritten with nulls when a re-stage returns `NO_SLEEP_DETECTED` (fixes #305).

- Fixes double-counting of midnight nap minutes by using `startsAtRecordEdge` to correctly attribute chained fragments (fixes #40).


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph "Derivation Engine Updates"
    A["nightSubstrateRegressed"] -- "Removed hasSleepWindow check" --> B["Protects NO_SLEEP_DETECTED days"]
    C["_attachNaps"] -- "Uses startsAtRecordEdge" --> D["Prevents double-counting chained naps"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>derivation_engine.dart</strong><dd><code>Update derivation logic and bump algorithm version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/compute/derivation_engine.dart

<ul><li>Bumps <code>kAlgoVersion</code> to 86 and updates <code>kAnalyticsPin</code> and <code>kProtocolPin</code>.<br> <li> Removes the <code>hasSleepWindow</code> requirement from <code>nightSubstrateRegressed</code> to <br>protect days that re-stage as <code>NO_SLEEP_DETECTED</code>.<br> <li> Updates <code>_attachNaps</code> to use <code>nap.startsAtRecordEdge</code> instead of <br><code>nap.startSec == 0</code> for accurate midnight nap deduplication.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/316/files#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6">+99/-39</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>derive_result_protection_test.dart</strong><dd><code>Update derivation protection tests for NO_SLEEP_DETECTED</code>&nbsp; </dd></summary>
<hr>

test/derive_result_protection_test.dart

<ul><li>Removes the <code>hasSleepWindow</code> argument from <code>nightSubstrateRegressed</code> calls <br>in existing tests.<br> <li> Updates the test case for <code>NO_SLEEP_DETECTED</code> to assert that it is now <br>correctly identified as a regression.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/316/files#diff-26d4d7e41f8ca359d0dc238a63c509fda2e4f498f45ed8821dd8edf3fdf6e44b">+6/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nap_attribution_test.dart</strong><dd><code>Add regression test for chained nap fragments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/nap_attribution_test.dart

<ul><li>Adds a regression test to verify that a nap fragment chained onto an <br>edge bout by a brief arousal is correctly attributed to yesterday.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/316/files#diff-c5d65f657d9e1ff388288e2819ce650e20454e7a4fb63d3a3688ee6465d251c4">+73/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pubspec.yaml</strong><dd><code>Repin protocol and analytics dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pubspec.yaml

<ul><li>Repins <code>openstrap_protocol</code> to <code>471034c</code> (live-decode-path fixes).<br> <li> Repins <code>openstrap_analytics</code> to <code>1fa8144</code> (HR ceiling and irregular rhythm <br>fixes).<br> <li> Adds detailed comments explaining the repins and the justification for <br>the <code>kAlgoVersion</code> bumps.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/316/files#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25">+41/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sleep analysis when overnight data changes, reducing unnecessary recalculations.
  * Fixed nap processing across midnight so chained nap fragments are not counted twice.
  * Improved handling of live-decoded data and sustained sleep windows.

* **Improvements**
  * Updated sleep-analysis components with the latest fixes and accuracy improvements.
  * Advanced the sleep algorithm version for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->