### PR TITLE
docs: SEO/GEO fixes for the marketing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ couple of Siri shortcuts.
 
 Every screenshot above is real output from a WHOOP 4.0. 
 
+## Supports
+
+- **WHOOP 4, WHOOP 5, MG** — full support. Everything below is computed from these.
+- **Any standard Bluetooth heart-rate strap** — pairs for workout tracking today (heart
+  rate + beat timing, stored and shown). Feeding it into recovery/strain is on the roadmap.
+- **Oura Ring** — protocol groundwork exists in the codebase; not pairable in the app yet.
+
 ## What works
 
 **Health** — heart rate, HRV, sleep staging, recovery/readiness, strain, stress, an HRV

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,15 +3,30 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>OpenStrap Edge — use your WHOOP 4.0 without a subscription</title>
-<meta name="description" content="An open-source app that makes a WHOOP 4.0 useful without a WHOOP subscription. Pairs over Bluetooth, computes everything on your phone. No cloud, no account, MIT licensed.">
-<meta property="og:title" content="OpenStrap Edge — use your WHOOP 4.0 without a subscription">
+<title>OpenStrap Edge — use your WHOOP 4.0, 5, or MG without a subscription</title>
+<meta name="description" content="An open-source app that makes a WHOOP band useful without a WHOOP subscription. Pairs over Bluetooth, computes recovery, strain and sleep entirely on your phone. No cloud, no account, MIT licensed.">
+<meta property="og:title" content="OpenStrap Edge — use your WHOOP band without a subscription">
 <meta property="og:description" content="Pairs over Bluetooth, computes everything on your phone. No cloud, no account, MIT licensed.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://openstrap.github.io/edge/">
+<meta property="og:url" content="https://openstrap.site/">
 <meta property="og:image" content="https://raw.githubusercontent.com/OpenStrap/edge/main/screenshots/today.png">
 <meta name="twitter:card" content="summary_large_image">
+<link rel="canonical" href="https://openstrap.site/">
 <link rel="stylesheet" href="style.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "MobileApplication",
+  "name": "OpenStrap Edge",
+  "url": "https://openstrap.site/",
+  "description": "Open-source app that reads a WHOOP 4.0, WHOOP 5, or MG band over Bluetooth and computes recovery, strain and sleep entirely on-device, without a WHOOP subscription.",
+  "operatingSystem": "iOS, Android",
+  "applicationCategory": "HealthApplication",
+  "license": "https://github.com/OpenStrap/edge/blob/main/LICENSE",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+  "author": { "@type": "Organization", "name": "OpenStrap", "url": "https://github.com/OpenStrap" }
+}
+</script>
 </head>
 <body>
 <div class="wrap">

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,9 +41,9 @@
 
   <main>
     <section class="hero">
-      <h1>Your WHOOP&nbsp;4.0 doesn&rsquo;t stop working when the subscription does.</h1>
+      <h1>Your strap doesn&rsquo;t stop working when the subscription does.</h1>
       <p class="lede">
-        Only the app goes dark. Edge pairs with the band over Bluetooth, decodes what it
+        Only the app goes dark. Edge pairs with your band over Bluetooth, decodes what it
         recorded, and works out your sleep, recovery, strain and the rest &mdash;
         entirely on your phone. No account, no subscription, and no server that ever
         receives your health data.
@@ -62,7 +62,24 @@
 
       <p class="fineprint">
         Free and MIT licensed. Not affiliated with WHOOP.
-        Tested on WHOOP&nbsp;4.0 &mdash; 5.0&nbsp;/&nbsp;MG support is experimental.
+      </p>
+    </section>
+
+    <section class="honest" aria-label="Device support">
+      <h2>Supports</h2>
+      <ul>
+        <li><strong>WHOOP 4, WHOOP 5, MG</strong> &mdash; full support: sleep, recovery,
+          strain, everything computed on-device. WHOOP 4 gets the most daily wear-testing.</li>
+        <li><strong>Any standard Bluetooth heart-rate strap</strong> &mdash; pairs for
+          workout tracking today (heart rate and beat timing, stored and shown). Full
+          metrics from it are on the roadmap.</li>
+        <li><strong>Oura Ring</strong> &mdash; the protocol groundwork is in the codebase;
+          not pairable in the app yet.</li>
+      </ul>
+      <p class="fineprint">
+        More device support is ongoing work, not a promise with a date &mdash; see the
+        <a href="https://github.com/OpenStrap/protocol">protocol</a> repo for what's decoded
+        so far.
       </p>
     </section>
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://openstrap.site/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://openstrap.site/</loc></url>
+  <url><loc>https://openstrap.site/terms.html</loc></url>
+  <url><loc>https://openstrap.site/privacy.html</loc></url>
+  <url><loc>https://openstrap.site/legal.html</loc></url>
+  <url><loc>https://openstrap.site/notice.html</loc></url>
+</urlset>


### PR DESCRIPTION
### **User description**
- og:url + rel=canonical were pointing at openstrap.github.io/edge instead of openstrap.site — two properties serving identical content with no signal of which is authoritative
- added robots.txt + sitemap.xml (neither existed)
- added SoftwareApplication JSON-LD so AI/search engines can identify the entity distinctly from noop/goose
- title/description no longer say "WHOOP 4.0" only

## Summary by Sourcery

Improve the marketing site’s search discoverability and accurately present supported devices and application details.

New Features:
- Add a public device-support section covering WHOOP 4, WHOOP 5, MG, Bluetooth heart-rate straps, and Oura Ring status.
- Add crawler-facing robots.txt and sitemap.xml files for the marketing site.
- Add structured application metadata describing OpenStrap Edge for search engines.

Bug Fixes:
- Correct the marketing page’s Open Graph and canonical URLs to use openstrap.site.

Enhancements:
- Update marketing copy and metadata to reflect broader WHOOP device support and on-device functionality.

Documentation:
- Expand README and marketing-page documentation with current device compatibility and support details.


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Set canonical URL to openstrap.site

- Add robots.txt and sitemap.xml

- Inject JSON-LD structured application data

- Update metadata to include WHOOP 5/MG


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SE["Search Engine"] -- "Reads" --> R["robots.txt"]
  SE -- "Crawls" --> SM["sitemap.xml"]
  SE -- "Parses" --> LD["JSON-LD Metadata"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Update SEO metadata and structured data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/index.html

<ul><li>Updated title and description to include WHOOP 5 and MG.<br> <li> Changed <code>og:url</code> and added canonical link to <code>openstrap.site</code>.<br> <li> Added JSON-LD structured data for <code>MobileApplication</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/319/files#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350ae">+19/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>robots.txt</strong><dd><code>Add robots.txt for web crawlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/robots.txt

- Created file to allow all user-agents.
- Linked to the new sitemap.


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/319/files#diff-e0fdde07b3efacb76ad37f5f65c6afc0360dbbfb674c4df11ea276869ec0bba3">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sitemap.xml</strong><dd><code>Add XML sitemap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/sitemap.xml

- Created sitemap listing main site pages.


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/319/files#diff-ddea54b0678e2cbb923d1cf5b67962ff79722f22c09b95d53235635edc516183">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated site metadata to highlight support for WHOOP 4.0, 5, and MG bands.
  * Clarified that recovery, strain, and sleep metrics are computed on-device.
  * Added improved search-engine metadata, structured data, canonical links, robots guidance, and a sitemap.
  * Included key site pages in the sitemap, including terms, privacy, legal, and notice pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->