### PR TITLE
readme: stop framing the whole app as WHOOP-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Openstrap Edge
 
-An app that makes a WHOOP band useful without a WHOOP subscription. Connects over Bluetooth, computes everything on your phone, iOS and Android.
+An app that makes your wearable useful without its subscription. Pairs over Bluetooth, computes everything on your phone, iOS and Android. WHOOP 4/5/MG get full support today; see [Supports](#supports) for what else it talks to.
 
 [![test](https://github.com/OpenStrap/edge/actions/workflows/test.yml/badge.svg)](https://github.com/OpenStrap/edge/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -174,7 +174,7 @@ longer story — see `guides/IOS_INSTALLATION.md`.
 ## How it works
 
 ```
-WHOOP band → Bluetooth → protocol decoder → local storage → analytics → the UI
+wearable → Bluetooth → protocol decoder → local storage → analytics → the UI
 ```
 
 - `openstrap_protocol` turns bytes off the band into records.


### PR DESCRIPTION
### **User description**
Tagline and the how-it-works pipeline diagram still said 'WHOOP band' even though the Supports section further down already lists BLE straps + Oura roadmap. Genericized both, pointed the tagline at the Supports section.

## Summary by Sourcery

Generalize the README to reflect Openstrap Edge’s broader wearable support.

Enhancements:
- Update README wording and the pipeline overview to describe Openstrap Edge as supporting wearables generally rather than framing it as WHOOP-only, while linking readers to the support details.

Documentation:
- Clarify current WHOOP support and direct users to the Supports section for additional device compatibility.


___

### **PR Type**
Documentation


___

### **Description**
- Generalize tagline for broader wearable support

- Update pipeline diagram removing WHOOP-only framing

- Direct users to the Supports section


___

### Diagram Walkthrough


```mermaid
flowchart LR
  id1["README.md"] -- "Update tagline" --> id2["Broader wearable support"]
  id1 -- "Update pipeline diagram" --> id3["Generic 'wearable' term"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Generalize wearable support in README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated the main tagline to mention generic wearables instead of just <br>WHOOP.<br> <li> Added a reference to the Supports section for device compatibility.<br> <li> Changed the pipeline diagram to start with <code>wearable</code> instead of <code>WHOOP </code><br><code>band</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenStrap/edge/pull/320/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

