### PR TITLE
prep for F-Droid: isolate firebase and mobile_scanner behind seams

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,6 +243,89 @@ jobs:
           files: ${{ steps.rename.outputs.apk }}
           generate_release_notes: true
 
+  # Keeps the F-Droid build recipe (docs/fdroid/*.yml) in sync with each
+  # release and, once a fdroiddata fork is configured, pushes the updated
+  # recipe there as a merge request. F-Droid builds from source itself (see
+  # docs/fdroid/wtf.openstrap.openstrap_edge.yml's header for the full
+  # rationale/verification) — this job never ships a binary to F-Droid, it
+  # only keeps the recipe's versionName/versionCode/commit current so the
+  # inclusion (or an update) has something correct to build. After the FIRST
+  # inclusion is merged, F-Droid's own AutoUpdateMode:Version +
+  # UpdateCheckMode:Tags bot picks up ordinary tags on its own — this job's
+  # ongoing job is mainly a safety net for now, and the sole mechanism before
+  # that first inclusion exists.
+  #
+  # Deliberately does NOT fail the release if fdroiddata isn't configured yet
+  # (no FDROID_GITLAB_TOKEN secret) — F-Droid isn't wired up until the first
+  # inclusion MR is manually opened and merged; this job just keeps the draft
+  # recipe current in the meantime and does the rest once it is wired up.
+  fdroid:
+    needs: preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false   # nothing here writes to THIS repo
+
+      # Stamp the release's real versionName/versionCode/commit into the
+      # checked-in draft recipe. Plain sed rather than a YAML library: the
+      # three fields each appear in exactly one recognizable spot in the file
+      # (see docs/fdroid/wtf.openstrap.openstrap_edge.yml), and keeping this
+      # a shell one-liner means no extra Python deps for a 3-line edit.
+      - name: Stamp release version into the fdroid recipe
+        run: |
+          set -euo pipefail
+          ver=$(grep -E '^version:' pubspec.yaml | head -1 | awk '{print $2}')
+          name=${ver%%+*}
+          build=${ver#*+}
+          tag="$GITHUB_REF_NAME"
+          f=docs/fdroid/wtf.openstrap.openstrap_edge.yml
+          sed -i \
+            -e "s/^\([[:space:]-]*versionName:[[:space:]]*\).*/\1$name/" \
+            -e "s/^\([[:space:]]*versionCode:[[:space:]]*\).*/\1$build/" \
+            -e "s/^\([[:space:]]*commit:[[:space:]]*\)[^ ]*/\1$tag/" \
+            -e "s/^CurrentVersion:.*/CurrentVersion: $name/" \
+            -e "s/^CurrentVersionCode:.*/CurrentVersionCode: $build/" \
+            "$f"
+          echo "Stamped $f -> versionName=$name versionCode=$build commit=$tag"
+
+      # Push the stamped recipe to a fdroiddata fork and open/update a merge
+      # request, ONLY once that fork + token are configured. Until then this
+      # step just explains what's missing and exits clean — the release
+      # itself must never fail on account of F-Droid plumbing.
+      - name: Sync recipe to fdroiddata fork
+        env:
+          FDROID_GITLAB_TOKEN: ${{ secrets.FDROID_GITLAB_TOKEN }}
+          FDROID_FORK_REPO: ${{ vars.FDROID_FORK_REPO }}   # e.g. https://gitlab.com/yourname/fdroiddata.git
+        run: |
+          set -euo pipefail
+          if [ -z "${FDROID_GITLAB_TOKEN:-}" ] || [ -z "${FDROID_FORK_REPO:-}" ]; then
+            echo "::notice::FDROID_GITLAB_TOKEN / FDROID_FORK_REPO not set — skipping fdroiddata sync."
+            echo "::notice::One-time setup: fork https://gitlab.com/fdroid/fdroiddata, add a GitLab"
+            echo "::notice::personal access token as the FDROID_GITLAB_TOKEN secret and the fork's"
+            echo "::notice::clone URL as the FDROID_FORK_REPO repo variable. Until the first"
+            echo "::notice::inclusion MR is opened and merged by hand, this step has nothing to do."
+            exit 0
+          fi
+
+          branch="update-openstrap-edge-${GITHUB_REF_NAME}"
+          workdir="$RUNNER_TEMP/fdroiddata"
+          repo_url="${FDROID_FORK_REPO/https:\/\//https:\/\/oauth2:${FDROID_GITLAB_TOKEN}@}"
+
+          git clone --depth 1 "$repo_url" "$workdir"
+          cp docs/fdroid/wtf.openstrap.openstrap_edge.yml \
+            "$workdir/metadata/wtf.openstrap.openstrap_edge.yml"
+
+          cd "$workdir"
+          git checkout -b "$branch"
+          git -c user.name="openstrap-release-bot" -c user.email="noreply@openstrap.wtf" \
+            commit -am "wtf.openstrap.openstrap_edge: update to ${GITHUB_REF_NAME}" \
+            --allow-empty -- metadata/wtf.openstrap.openstrap_edge.yml
+          git push -u origin "$branch" \
+            -o merge_request.create \
+            -o merge_request.title="wtf.openstrap.openstrap_edge: update to ${GITHUB_REF_NAME}" \
+            -o merge_request.target=fdroid/fdroiddata
+
   # Unsigned iOS .ipa for sideloading (AltStore / Sideloadly / TrollStore). It is
   # NOT App Store signed — users re-sign it with their own Apple ID on install.
   # Note: free-account sideloads re-sign with a different team id, so App Group

--- a/docs/fdroid/barcode_reader.floss.dart
+++ b/docs/fdroid/barcode_reader.floss.dart
@@ -1,0 +1,98 @@
+// barcode_reader.dart (F-Droid / FLOSS variant) — flutter_zxing-backed
+// stand-in with the exact API of lib/scan/barcode_reader.dart, zero Google
+// dependencies (mobile_scanner's ML Kit pulls play-services-basement/base/
+// tasks on Android either way — checked its build.gradle directly).
+//
+// Not compiled by default. The F-Droid build recipe (see
+// docs/fdroid/wtf.openstrap.openstrap_edge.yml) copies this over
+// lib/scan/barcode_reader.dart and adds flutter_zxing + camera to
+// pubspec.yaml before building. scan_barcode.dart (the only caller) is
+// unaffected — it only ever sees this API.
+//
+// flutter_zxing (pub.dev, 2.3.0, Apache-2.0, pure Dart FFI over the ZXing
+// C++ library via the `camera` plugin — no Google Play Services / ML Kit)
+// verified to cover every format this app scans: Format.ean13/ean8/upca/
+// upce/dataBar/dataBarExpanded all exist (lib/src/models/format.dart).
+// ReaderWidget's error surface is onControllerCreated(controller, error) —
+// a non-null error there is how the underlying `camera` plugin reports
+// camera failures, including permission denial via a CameraException whose
+// `code` is 'CameraAccessDenied' (or 'CameraAccessDeniedWithoutPrompt' on
+// iOS, kept here for API parity though this file only ever ships on
+// Android).
+
+import 'package:camera/camera.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_zxing/flutter_zxing.dart' as zx;
+
+enum BarcodeFormat { ean13, ean8, upcA, upcE, dataBar, dataBarExpanded }
+
+class BarcodeReaderError {
+  const BarcodeReaderError({required this.permissionDenied});
+  final bool permissionDenied;
+}
+
+typedef BarcodeReaderErrorBuilder = Widget Function(BuildContext, BarcodeReaderError);
+
+class BarcodeReaderWidget extends StatefulWidget {
+  const BarcodeReaderWidget({
+    super.key,
+    required this.formats,
+    required this.onDetect,
+    required this.errorBuilder,
+  });
+
+  final List<BarcodeFormat> formats;
+  final ValueChanged<String> onDetect;
+  final BarcodeReaderErrorBuilder errorBuilder;
+
+  @override
+  State<BarcodeReaderWidget> createState() => _BarcodeReaderWidgetState();
+}
+
+class _BarcodeReaderWidgetState extends State<BarcodeReaderWidget> {
+  bool _done = false;
+  BarcodeReaderError? _error;
+
+  static const Map<BarcodeFormat, int> _formatBits = {
+    BarcodeFormat.ean13: zx.Format.ean13,
+    BarcodeFormat.ean8: zx.Format.ean8,
+    BarcodeFormat.upcA: zx.Format.upca,
+    BarcodeFormat.upcE: zx.Format.upce,
+    BarcodeFormat.dataBar: zx.Format.dataBar,
+    BarcodeFormat.dataBarExpanded: zx.Format.dataBarExpanded,
+  };
+
+  int get _codeFormat =>
+      widget.formats.fold(0, (acc, f) => acc | (_formatBits[f] ?? 0));
+
+  void _onScan(zx.Code code) {
+    if (_done || !code.isValid) return;
+    final text = code.text;
+    if (text == null || text.trim().isEmpty) return;
+    _done = true;
+    widget.onDetect(text.trim());
+  }
+
+  void _onControllerCreated(CameraController? controller, Exception? error) {
+    if (error == null) return;
+    final denied = error is CameraException &&
+        (error.code == 'CameraAccessDenied' ||
+            error.code == 'CameraAccessDeniedWithoutPrompt');
+    if (mounted) setState(() => _error = BarcodeReaderError(permissionDenied: denied));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final err = _error;
+    if (err != null) return widget.errorBuilder(context, err);
+    return zx.ReaderWidget(
+      codeFormat: _codeFormat,
+      onScan: _onScan,
+      onControllerCreated: _onControllerCreated,
+      showFlashlight: false,
+      showToggleCamera: false,
+      showGallery: false,
+      allowPinchZoom: false,
+    );
+  }
+}

--- a/docs/fdroid/firebase_bridge.floss.dart
+++ b/docs/fdroid/firebase_bridge.floss.dart
@@ -1,0 +1,38 @@
+// firebase_bridge.dart (F-Droid / FLOSS variant) — no-op stand-in with the
+// exact API of lib/telemetry/firebase_bridge.dart, zero firebase_* imports.
+//
+// Not compiled by default. The F-Droid build recipe (see
+// docs/fdroid/wtf.openstrap.openstrap_edge.yml) copies this over
+// lib/telemetry/firebase_bridge.dart and drops the four firebase_* lines
+// from pubspec.yaml before building, so the FLOSS build contains zero
+// Google Play Services / Firebase code. Every caller (telemetry_service.dart,
+// main.dart) is unaffected — they only ever see this API.
+
+import 'package:flutter/foundation.dart';
+
+class FirebaseTraceHandle {
+  const FirebaseTraceHandle._();
+  Future<void> stop() async {}
+  void putAttribute(String name, String value) {}
+}
+
+class FirebaseBridge {
+  static Future<void> initialize({Duration? timeout}) async {}
+
+  static bool get isInitialized => false;
+
+  static void setCollectionEnabled(bool value) {}
+
+  static void recordFlutterError(FlutterErrorDetails details, {required bool fatal}) {}
+
+  static void recordError(Object error, StackTrace stack, {required bool fatal, String? reason}) {}
+
+  static void log(String message) {}
+
+  static void setCustomKey(String key, Object value) {}
+
+  static Future<FirebaseTraceHandle> startTrace(String name) async =>
+      const FirebaseTraceHandle._();
+
+  static void logEvent(String name, Map<String, Object> parameters) {}
+}

--- a/docs/fdroid/wtf.openstrap.openstrap_edge.yml
+++ b/docs/fdroid/wtf.openstrap.openstrap_edge.yml
@@ -1,0 +1,117 @@
+# F-Droid build recipe for OpenStrap edge — VERIFIED locally, full combined
+# build (all three patches below applied together): `flutter build apk
+# --release` succeeds, and the resulting APK's classes.dex has zero
+# com/google/firebase and zero com/google/mlkit references. The only
+# remaining com/google/android/gms/* strings are microG's own FOSS
+# reimplementation classes (Apache-2.0, published under that namespace by
+# design so Google-API-compiled code links against them unmodified).
+#
+# This is NOT read by F-Droid from this repo — it's the file to copy into
+# fdroiddata (https://gitlab.com/fdroid/fdroiddata) as
+# metadata/wtf.openstrap.openstrap_edge.yml when opening the inclusion MR.
+# Keeping it here, versioned next to the app it describes.
+#
+# ── FIRST blocker: Firebase ─────────────────────────────────────────────────
+# pubspec.yaml depends on firebase_core/firebase_crashlytics/
+# firebase_performance/firebase_analytics. Firebase is already fully
+# optional at RUNTIME (see lib/telemetry/telemetry_service.dart and
+# android/app/build.gradle.kts — the app builds and runs with zero Firebase
+# credentials), but F-Droid rejects apps that bundle the Play Services /
+# Firebase Android libraries at all, used or not.
+#
+# Fix landed in this repo: every firebase_* import is confined to ONE file,
+# lib/telemetry/firebase_bridge.dart (see its header comment). A FLOSS-build
+# stand-in with the identical API and zero firebase_* imports lives at
+# docs/fdroid/firebase_bridge.floss.dart. The recipe just swaps that one file
+# and drops the four firebase_* pubspec lines — no other source edits
+# needed, so it survives future changes to telemetry_service.dart without
+# hand-patching call sites.
+#
+# ── SECOND blocker: geolocator's GMS location backend ───────────────────────
+# geolocator_android pulls com.google.android.gms:play-services-location
+# (used for GPS workout routes). Verified in its actual source
+# (GeolocationManager.java:72-88, geolocator_android 4.6.2): it already falls
+# back to plain android.location.LocationManager whenever Google Play
+# Services isn't available, via the SAME com.google.android.gms.location.*
+# package/class names either way. That's exactly what microG's FOSS
+# reimplementation (org.microg.gms:play-services-location, Apache-2.0)
+# ships, so a Gradle dependency substitution swaps it in with ZERO Dart/
+# Kotlin source changes — same technique used by organicmaps' F-Droid flavor
+# (github.com/organicmaps/organicmaps PR #9575). Appended to
+# android/app/build.gradle.kts by the recipe, not a permanent change to this
+# repo's checked-in file — the Play Store / GitHub-release build keeps
+# Google's real fused location provider. Must substitute the whole
+# basement/base/tasks family, not just play-services-location, or anything
+# else in the graph still pulling the real ones causes a duplicate-class
+# build failure (hit this locally before adding mobile_scanner's fix below —
+# see THIRD item).
+#
+# ── THIRD blocker: mobile_scanner's ML Kit ───────────────────────────────────
+# mobile_scanner (food barcode scan) bundles Google ML Kit on Android either
+# way — checked its build.gradle directly: both the bundled
+# com.google.mlkit:barcode-scanning and the useUnbundled
+# play-services-mlkit-barcode-scanning paths pull the REAL
+# com.google.android.gms:play-services-basement/base/tasks, which is also
+# what caused the SECOND item's duplicate-class conflict until this was
+# fixed. No Gradle-only escape hatch exists for ML Kit itself (unlike
+# geolocator, whose own code already had a non-GMS fallback path).
+#
+# Fix landed in this repo: every mobile_scanner import is confined to ONE
+# file, lib/scan/barcode_reader.dart (see its header comment) — same seam
+# pattern as firebase_bridge.dart. A FLOSS-build stand-in backed by
+# flutter_zxing (pub.dev, Apache-2.0, pure Dart FFI over the ZXing C++
+# library, zero Google dependencies) with the identical API lives at
+# docs/fdroid/barcode_reader.floss.dart. Verified to cover every barcode
+# format this app scans (EAN13/EAN8/UPC-A/UPC-E/DataBar/DataBarExpanded —
+# checked flutter_zxing's Format enum directly) and to build clean alongside
+# both fixes above. iOS and the Play Store / GitHub-release Android build
+# keep mobile_scanner unchanged; F-Droid never builds iOS at all.
+
+Categories:
+  - Health
+License: MIT
+SourceCode: https://github.com/OpenStrap/edge
+IssueTracker: https://github.com/OpenStrap/edge/issues
+
+AutoName: OpenStrap
+
+RepoType: git
+Repo: https://github.com/OpenStrap/edge.git
+
+Builds:
+  - versionName: 0.9.29
+    versionCode: 62
+    commit: v0.9.29           # TODO: tag this release before submitting
+    subdir: android
+    sudo:
+      # Firebase → no-op stub (see FIRST blocker above).
+      - cp docs/fdroid/firebase_bridge.floss.dart lib/telemetry/firebase_bridge.dart
+      - sed -i '/^[[:space:]]*firebase_core:/d;/^[[:space:]]*firebase_crashlytics:/d;/^[[:space:]]*firebase_performance:/d;/^[[:space:]]*firebase_analytics:/d' pubspec.yaml
+      - rm -f app/google-services.json
+      # Barcode scanner → flutter_zxing (see THIRD blocker above). Must run
+      # BEFORE the geolocator substitution below, or the real
+      # play-services-basement/base/tasks mobile_scanner still pulls in
+      # duplicates microG's substituted classes.
+      - cp docs/fdroid/barcode_reader.floss.dart lib/scan/barcode_reader.dart
+      - |
+        sed -i "s/^\([[:space:]]*mobile_scanner:.*\)/\1\n  flutter_zxing: ^2.3.0\n  camera: ^0.11.0/" pubspec.yaml
+      - sed -i '/^[[:space:]]*mobile_scanner:/d' pubspec.yaml
+      # geolocator's GMS location backend → microG (see SECOND blocker above).
+      - |
+        cat >> app/build.gradle.kts <<'EOF'
+        configurations.all {
+            resolutionStrategy.dependencySubstitution {
+                val microg = "0.3.14.250932"
+                substitute(module("com.google.android.gms:play-services-location")).using(module("org.microg.gms:play-services-location:$microg"))
+                substitute(module("com.google.android.gms:play-services-base")).using(module("org.microg.gms:play-services-base:$microg"))
+                substitute(module("com.google.android.gms:play-services-basement")).using(module("org.microg.gms:play-services-basement:$microg"))
+                substitute(module("com.google.android.gms:play-services-tasks")).using(module("org.microg.gms:play-services-tasks:$microg"))
+            }
+        }
+        EOF
+    output: app/build/outputs/apk/release/app-release-unsigned.apk
+
+AutoUpdateMode: Version
+UpdateCheckMode: Tags
+CurrentVersion: 0.9.29
+CurrentVersionCode: 62

--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -31,13 +31,12 @@ import 'package:flutter/foundation.dart';
 import 'findings.dart';
 import 'nap_edits.dart';
 import 'package:openstrap_analytics/onehz.dart' as ana;
-import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_performance/firebase_performance.dart';
 
 import '../data/db.dart';
 import '../data/day_label.dart';
 import '../data/series_codec.dart';
 import '../notify/fired_keys.dart';
+import '../telemetry/firebase_bridge.dart';
 import '../notify/notification_center.dart';
 import '../notify/notification_event.dart';
 import '../notify/tap_router.dart' show workoutSuggestionRoute;
@@ -2190,15 +2189,14 @@ class DerivationEngine {
       ..['concurrency'] = _deriveConcurrency
       ..['last_error'] = null;
       
-    Trace? runTrace;
+    FirebaseTraceHandle? runTrace;
     try {
       // Heavy/force passes only. Light passes run many times a day (including
       // all night in the background), and each trace is buffered + eventually
       // uploaded — periodic radio wakeups from a local-first app, for timings
       // the _diag map already captures locally.
-      if (Firebase.apps.isNotEmpty && (heavy || force)) {
-        runTrace = FirebasePerformance.instance.newTrace('derivation_engine_run');
-        await runTrace.start();
+      if (FirebaseBridge.isInitialized && (heavy || force)) {
+        runTrace = await FirebaseBridge.startTrace('derivation_engine_run');
         runTrace.putAttribute('mode', force ? 'force' : (heavy ? 'heavy' : 'light'));
       }
     } catch (_) {}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,8 +15,7 @@ import 'sync/headless_boot.dart';
 import 'sync/ios_bg_task.dart';
 import 'theme/theme_controller.dart';
 import 'widget/widget_service.dart';
-import 'package:firebase_core/firebase_core.dart';
-import 'firebase_options.dart';
+import 'telemetry/firebase_bridge.dart';
 import 'package:workmanager/workmanager.dart';
 import 'dart:async';
 import 'dart:io';
@@ -37,9 +36,7 @@ Future<void> main() async {
   // OPTIONAL: a build with no real google-services.json / GoogleService-Info.plist
   // throws here and the app carries on without any Firebase at all.
   try {
-    await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    ).timeout(_kStartupInitTimeout);
+    await FirebaseBridge.initialize(timeout: _kStartupInitTimeout);
   } catch (e) {
     debugPrint('Firebase init failed (run flutterfire configure!): $e');
   }

--- a/lib/scan/barcode_reader.dart
+++ b/lib/scan/barcode_reader.dart
@@ -1,0 +1,89 @@
+// barcode_reader.dart — the ONLY file that imports mobile_scanner.
+//
+// Same pattern as lib/telemetry/firebase_bridge.dart: mobile_scanner bundles
+// Google ML Kit on Android (checked its build.gradle directly — both the
+// bundled and "unbundled" modes pull play-services-basement/base/tasks), so
+// F-Droid's build recipe swaps this ONE file for
+// docs/fdroid/barcode_reader.floss.dart (a flutter_zxing-backed stand-in
+// with the identical API, zero Google deps) instead of touching the caller.
+// iOS and the Play Store / GitHub-release Android build keep mobile_scanner
+// unchanged — this only matters for the F-Droid recipe.
+//
+// Keep every mobile_scanner import confined to this file.
+
+import 'package:flutter/widgets.dart';
+import 'package:mobile_scanner/mobile_scanner.dart' as ms;
+
+/// Product-barcode formats this app ever scans. A QR code is not a food, so
+/// it is deliberately not in this list — see scan_barcode.dart.
+enum BarcodeFormat { ean13, ean8, upcA, upcE, dataBar, dataBarExpanded }
+
+/// Why the reader can't show a preview — permission refused, or the device
+/// simply has no usable camera.
+class BarcodeReaderError {
+  const BarcodeReaderError({required this.permissionDenied});
+  final bool permissionDenied;
+}
+
+typedef BarcodeReaderErrorBuilder = Widget Function(BuildContext, BarcodeReaderError);
+
+/// Camera preview that reports the first detected code and stops. Callers
+/// own the sheet chrome; this widget only owns the camera.
+class BarcodeReaderWidget extends StatefulWidget {
+  const BarcodeReaderWidget({
+    super.key,
+    required this.formats,
+    required this.onDetect,
+    required this.errorBuilder,
+  });
+
+  final List<BarcodeFormat> formats;
+  final ValueChanged<String> onDetect;
+  final BarcodeReaderErrorBuilder errorBuilder;
+
+  @override
+  State<BarcodeReaderWidget> createState() => _BarcodeReaderWidgetState();
+}
+
+class _BarcodeReaderWidgetState extends State<BarcodeReaderWidget> {
+  late final ms.MobileScannerController _controller =
+      ms.MobileScannerController(formats: widget.formats.map(_map).toList());
+  bool _done = false;
+
+  static ms.BarcodeFormat _map(BarcodeFormat f) => switch (f) {
+        BarcodeFormat.ean13 => ms.BarcodeFormat.ean13,
+        BarcodeFormat.ean8 => ms.BarcodeFormat.ean8,
+        BarcodeFormat.upcA => ms.BarcodeFormat.upcA,
+        BarcodeFormat.upcE => ms.BarcodeFormat.upcE,
+        BarcodeFormat.dataBar => ms.BarcodeFormat.dataBar,
+        BarcodeFormat.dataBarExpanded => ms.BarcodeFormat.dataBarExpanded,
+      };
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onDetect(ms.BarcodeCapture capture) {
+    if (_done) return;
+    final code = capture.barcodes
+        .map((b) => b.rawValue)
+        .firstWhere((v) => v != null && v.trim().isNotEmpty, orElse: () => null);
+    if (code == null) return;
+    _done = true;
+    widget.onDetect(code.trim());
+  }
+
+  @override
+  Widget build(BuildContext context) => ms.MobileScanner(
+        controller: _controller,
+        onDetect: _onDetect,
+        errorBuilder: (_, e) => widget.errorBuilder(
+          context,
+          BarcodeReaderError(
+            permissionDenied: e.errorCode == ms.MobileScannerErrorCode.permissionDenied,
+          ),
+        ),
+      );
+}

--- a/lib/telemetry/firebase_bridge.dart
+++ b/lib/telemetry/firebase_bridge.dart
@@ -1,0 +1,71 @@
+// firebase_bridge.dart — the ONLY file in this app that imports a firebase_*
+// package. Every Firebase type/call telemetry_service.dart and main.dart need
+// is re-exposed here through plain Dart signatures.
+//
+// Why this exists: Firebase is fully optional already (see
+// telemetry_service.dart's `enabled` gate and android/app/build.gradle.kts'
+// conditional plugin application), but F-Droid rejects apps that bundle the
+// Play Services / Firebase Android libraries at all, used or not. Because
+// every firebase_* import in the app funnels through this one file, an
+// F-Droid build recipe can ship a Firebase-free build by replacing just this
+// file with docs/fdroid/firebase_bridge.floss.dart (a no-op stub with the
+// same API) and dropping the four firebase_* deps from pubspec.yaml — no
+// other source file changes needed.
+//
+// Keep every firebase_* import confined to this file when touching telemetry.
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:firebase_performance/firebase_performance.dart' as perf;
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flutter/foundation.dart';
+
+import '../firebase_options.dart';
+
+/// Handle for an in-flight Performance trace; opaque to callers.
+class FirebaseTraceHandle {
+  FirebaseTraceHandle._(this._trace);
+  final perf.Trace? _trace;
+  Future<void> stop() async => _trace?.stop();
+  void putAttribute(String name, String value) => _trace?.putAttribute(name, value);
+}
+
+class FirebaseBridge {
+  /// Initializes Firebase; no-op (throws internally, caught) if no real
+  /// google-services.json / GoogleService-Info.plist is bundled.
+  static Future<void> initialize({Duration? timeout}) async {
+    final future = Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+    await (timeout == null ? future : future.timeout(timeout));
+  }
+
+  static bool get isInitialized => Firebase.apps.isNotEmpty;
+
+  static void setCollectionEnabled(bool value) {
+    FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(value);
+    perf.FirebasePerformance.instance.setPerformanceCollectionEnabled(value);
+    FirebaseAnalytics.instance.setAnalyticsCollectionEnabled(value);
+  }
+
+  static void recordFlutterError(FlutterErrorDetails details, {required bool fatal}) {
+    FirebaseCrashlytics.instance.recordFlutterError(details, fatal: fatal);
+  }
+
+  static void recordError(Object error, StackTrace stack, {required bool fatal, String? reason}) {
+    FirebaseCrashlytics.instance.recordError(error, stack, fatal: fatal, reason: reason);
+  }
+
+  static void log(String message) => FirebaseCrashlytics.instance.log(message);
+
+  static void setCustomKey(String key, Object value) =>
+      FirebaseCrashlytics.instance.setCustomKey(key, value);
+
+  static Future<FirebaseTraceHandle> startTrace(String name) async {
+    final trace = perf.FirebasePerformance.instance.newTrace(name);
+    await trace.start();
+    return FirebaseTraceHandle._(trace);
+  }
+
+  static void logEvent(String name, Map<String, Object> parameters) {
+    FirebaseAnalytics.instance.logEvent(name: name, parameters: parameters);
+  }
+}

--- a/lib/telemetry/telemetry_service.dart
+++ b/lib/telemetry/telemetry_service.dart
@@ -21,13 +21,10 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_crashlytics/firebase_crashlytics.dart';
-import 'package:firebase_performance/firebase_performance.dart';
-import 'package:firebase_analytics/firebase_analytics.dart';
 
 import '../cloud/companion_client.dart';
 import 'error_classification.dart';
+import 'firebase_bridge.dart';
 import 'jank_policy.dart';
 
 /// A band-side snapshot AppState supplies (it owns the live DeviceState).
@@ -80,10 +77,8 @@ class TelemetryService {
       return;
     }
     try {
-      if (Firebase.apps.isNotEmpty) {
-        FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(value);
-        FirebasePerformance.instance.setPerformanceCollectionEnabled(value);
-        FirebaseAnalytics.instance.setAnalyticsCollectionEnabled(value);
+      if (FirebaseBridge.isInitialized) {
+        FirebaseBridge.setCollectionEnabled(value);
       }
     } catch (_) {}
   }
@@ -138,7 +133,7 @@ class TelemetryService {
     FlutterError.onError = (FlutterErrorDetails details) {
       prior?.call(details);
       try {
-        if (Firebase.apps.isNotEmpty && _enabled) {
+        if (FirebaseBridge.isInitialized && _enabled) {
           // Flutter itself marks a FlutterErrorDetails `silent: true` for
           // errors it considers expected/non-actionable noise — e.g. an
           // image/tile network fetch that fails after the requesting widget
@@ -151,10 +146,7 @@ class TelemetryService {
           // fatal crashes (inflating crash-free-users) even though the app
           // kept running fine. Still fully captured — just filed as
           // non-fatal so it doesn't count against crash-free-rate.
-          FirebaseCrashlytics.instance.recordFlutterError(
-            details,
-            fatal: !details.silent,
-          );
+          FirebaseBridge.recordFlutterError(details, fatal: !details.silent);
         }
       } catch (_) {}
       record(
@@ -167,16 +159,12 @@ class TelemetryService {
     };
     PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
       try {
-        if (Firebase.apps.isNotEmpty && _enabled) {
+        if (FirebaseBridge.isInitialized && _enabled) {
           // Same reasoning as the `silent` check above, for the errors the
           // framework never sees: a dropped tile fetch or a TLS handshake that
           // died with no network is not a crash, and filing it as one both
           // understates crash-free users and buries the real crashes.
-          FirebaseCrashlytics.instance.recordError(
-            error,
-            stack,
-            fatal: !isTransientError(error),
-          );
+          FirebaseBridge.recordError(error, stack, fatal: !isTransientError(error));
         }
       } catch (_) {}
       record(kind: 'crash', level: 'error', message: '$error', stack: '$stack');
@@ -210,8 +198,8 @@ class TelemetryService {
   /// transitions (screen changes, BLE state changes, derivation passes).
   void breadcrumb(String message) {
     try {
-      if (Firebase.apps.isNotEmpty && _enabled) {
-        FirebaseCrashlytics.instance.log(message);
+      if (FirebaseBridge.isInitialized && _enabled) {
+        FirebaseBridge.log(message);
       }
     } catch (_) {}
   }
@@ -221,8 +209,8 @@ class TelemetryService {
   /// Unlike breadcrumb(), this is STATE (last-write-wins), not an event log.
   void setContext(String key, Object value) {
     try {
-      if (Firebase.apps.isNotEmpty && _enabled) {
-        FirebaseCrashlytics.instance.setCustomKey(key, value);
+      if (FirebaseBridge.isInitialized && _enabled) {
+        FirebaseBridge.setCustomKey(key, value);
       }
     } catch (_) {}
   }
@@ -232,28 +220,22 @@ class TelemetryService {
   /// vanishes into a debug console nobody in production ever reads.
   void recordNonFatal(Object error, StackTrace stack, {String? reason}) {
     try {
-      if (Firebase.apps.isNotEmpty && _enabled) {
-        FirebaseCrashlytics.instance.recordError(
-          error,
-          stack,
-          fatal: false,
-          reason: reason,
-        );
+      if (FirebaseBridge.isInitialized && _enabled) {
+        FirebaseBridge.recordError(error, stack, fatal: false, reason: reason);
       }
     } catch (_) {}
   }
 
-  final Map<String, Trace> _activeTraces = {};
+  final Map<String, FirebaseTraceHandle> _activeTraces = {};
 
   /// Wrap [body] in a named Firebase Performance trace. Safe to nest under
   /// different names; a given [name] running concurrently with itself is not
   /// supported (the later start wins) — use distinct names per call site.
   Future<T> traced<T>(String name, Future<T> Function() body) async {
-    Trace? trace;
+    FirebaseTraceHandle? trace;
     try {
-      if (Firebase.apps.isNotEmpty && _enabled) {
-        trace = FirebasePerformance.instance.newTrace(name);
-        await trace.start();
+      if (FirebaseBridge.isInitialized && _enabled) {
+        trace = await FirebaseBridge.startTrace(name);
         _activeTraces[name] = trace;
       }
     } catch (_) {
@@ -346,7 +328,7 @@ class TelemetryService {
     
     // Remote Firebase Analytics integration (only if event)
     try {
-      if (Firebase.apps.isNotEmpty && _enabled && kind == 'event' && message != null) {
+      if (FirebaseBridge.isInitialized && _enabled && kind == 'event' && message != null) {
         final params = <String, Object>{};
         if (context != null) {
           context.forEach((k, v) {
@@ -357,9 +339,9 @@ class TelemetryService {
             }
           });
         }
-        FirebaseAnalytics.instance.logEvent(
-          name: message.replaceAll(RegExp(r'[^a-zA-Z0-9_]'), '_'),
-          parameters: params,
+        FirebaseBridge.logEvent(
+          message.replaceAll(RegExp(r'[^a-zA-Z0-9_]'), '_'),
+          params,
         );
       }
     } catch (_) {}

--- a/lib/ui2/screens/scan_barcode.dart
+++ b/lib/ui2/screens/scan_barcode.dart
@@ -10,9 +10,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
-import 'package:mobile_scanner/mobile_scanner.dart';
 
 import '../../l10n/app_localizations.dart';
+import '../../scan/barcode_reader.dart';
 import '../ui2.dart';
 
 /// Read one barcode. Resolves the digits, or null if the sheet was closed,
@@ -38,35 +38,23 @@ class _ScanSheet extends StatefulWidget {
 class _ScanSheetState extends State<_ScanSheet> {
   /// The formats printed on packaged food. `all` would also read QR codes,
   /// which are not products.
-  final _controller = MobileScannerController(
-    formats: const [
-      BarcodeFormat.ean13,
-      BarcodeFormat.ean8,
-      BarcodeFormat.upcA,
-      BarcodeFormat.upcE,
-      BarcodeFormat.dataBar,
-      BarcodeFormat.dataBarExpanded,
-    ],
-  );
+  static const _formats = [
+    BarcodeFormat.ean13,
+    BarcodeFormat.ean8,
+    BarcodeFormat.upcA,
+    BarcodeFormat.upcE,
+    BarcodeFormat.dataBar,
+    BarcodeFormat.dataBarExpanded,
+  ];
 
   /// One code per sheet. The detector fires repeatedly on the same packet, and
   /// without this each repeat would be another pop and another lookup.
   bool _done = false;
 
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  void _onDetect(BarcodeCapture capture) {
+  void _onDetect(String code) {
     if (_done) return;
-    final code = capture.barcodes
-        .map((b) => b.rawValue)
-        .firstWhere((v) => v != null && v.trim().isNotEmpty, orElse: () => null);
-    if (code == null) return;
     _done = true;
-    Navigator.of(context).pop(code.trim());
+    Navigator.of(context).pop(code);
   }
 
   @override
@@ -98,8 +86,8 @@ class _ScanSheetState extends State<_ScanSheet> {
               borderRadius: R.rLg,
               child: AspectRatio(
                 aspectRatio: 1,
-                child: MobileScanner(
-                  controller: _controller,
+                child: BarcodeReaderWidget(
+                  formats: _formats,
                   onDetect: _onDetect,
                   errorBuilder: (_, e) => _CameraProblem(e),
                 ),
@@ -123,12 +111,12 @@ class _ScanSheetState extends State<_ScanSheet> {
 /// so the card says which one happened and stops there.
 class _CameraProblem extends StatelessWidget {
   const _CameraProblem(this.error);
-  final MobileScannerException error;
+  final BarcodeReaderError error;
 
   @override
   Widget build(BuildContext c) {
     final l = AppLocalizations.of(c);
-    final denied = error.errorCode == MobileScannerErrorCode.permissionDenied;
+    final denied = error.permissionDenied;
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(S.x4),


### PR DESCRIPTION
### **User description**
## Summary
- Firebase and mobile_scanner (both bundle Google Play Services / ML Kit) are now isolated behind two seams — `lib/telemetry/firebase_bridge.dart` and `lib/scan/barcode_reader.dart` — the only files that import them.
- `docs/fdroid/` has floss stand-ins for both plus the actual F-Droid build recipe. Verified locally: the full combined patch set (firebase stub + zxing scanner + geolocator's GMS location swapped for microG) builds a real `flutter build apk --release`, and the resulting dex has zero `com/google/firebase` / `com/google/mlkit` references.
- No behavior change for the Play Store / GitHub-release build or iOS — same libraries, same code paths, just the imports moved behind a seam.
- New `fdroid` CI job (same `v*` tag trigger as the release build) stamps the recipe's version and pushes it to a fdroiddata fork once one's configured (secrets absent today, so it no-ops without failing the release).

## Test plan
- [x] `flutter analyze lib/` clean
- [x] `flutter test` — no new failures (pre-existing golden/export failures unrelated, verified by grep)
- [x] Local dry-run: full F-Droid patch set applied, `flutter build apk --release` succeeds, dex inspected for GMS/Firebase/ML Kit classes (zero found)
- [ ] Real-device test of barcode scanning on an actual F-Droid-style build (no camera in this sandbox — flagging for manual verification before fdroiddata submission)

## Summary by Sourcery

Prepare the app for F-Droid distribution by isolating proprietary integrations and supplying verified FLOSS build substitutions without changing standard build behavior.

New Features:
- Add an F-Droid build recipe with FLOSS replacements for Firebase and barcode scanning dependencies.
- Add release CI support for stamping and optionally syncing the F-Droid recipe to fdroiddata.

Enhancements:
- Isolate Firebase integrations and mobile_scanner behind replaceable application seams while preserving existing Play Store, GitHub-release, and iOS behavior.
- Provide a Firebase-free telemetry stub and a ZXing-based barcode reader for F-Droid builds, alongside microG location dependency substitution.

CI:
- Add a non-blocking release-triggered job that prepares and optionally submits updated F-Droid metadata.

Documentation:
- Document the F-Droid build requirements, dependency substitutions, verification, and inclusion workflow in the checked-in recipe.


___

### **PR Type**
Enhancement


___

### **Description**
- Isolates proprietary dependencies behind application seams.
  - Moves Firebase and `mobile_scanner` behind `FirebaseBridge` and `BarcodeReaderWidget`.

- Adds FLOSS alternatives for F-Droid builds.
  - Uses `flutter_zxing` for barcodes and no-op stubs for Firebase.

- Preserves standard Play Store and iOS behavior.
  - Standard builds continue using Google Play Services and ML Kit.

- Adds F-Droid build recipe and CI job.
  - Automates stamping and syncing the recipe to a `fdroiddata` fork.
  - Note: Changes behavior for F-Droid builds but adds no tests under `test/`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  App["App Code"] -- "Uses" --> Seam["Seams (FirebaseBridge, BarcodeReaderWidget)"]
  Seam -- "Standard Build" --> Prop["Proprietary SDKs (Firebase, ML Kit)"]
  Seam -- "F-Droid Build" --> FLOSS["FLOSS Alternatives (No-op, flutter_zxing)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>barcode_reader.floss.dart</strong><dd><code>Add FLOSS barcode reader stand-in using flutter_zxing</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/321/files#diff-61be0bdb4b819304b2f29065bf76b5caa761c590802445b47580056272210d24">+98/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>firebase_bridge.floss.dart</strong><dd><code>Add FLOSS Firebase stand-in with no-op methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/321/files#diff-dfe39c0f274e1c2360fd9c7c01d1f935c5c8d9cf928d13e839ce9f5cc9068894">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>barcode_reader.dart</strong><dd><code>Create seam for mobile_scanner to allow F-Droid swapping</code>&nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/321/files#diff-b47fe93208e97a5e5e315478e1c9c200032e9c12fc7f93990eb7e0508e60adbe">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>firebase_bridge.dart</strong><dd><code>Create seam for Firebase SDKs to isolate proprietary dependencies</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/321/files#diff-ec7daa0f25b766a706016d7b3b032a73f054eb4f385825e79c599373250fbd44">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>derivation_engine.dart</strong><dd><code>Replace direct Firebase performance tracing with FirebaseBridge</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/321/files#diff-0e401d8cdb1091d9a9591e9d92c4c5e979293f8480da203b22011a7cf9072ea6">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.dart</strong><dd><code>Replace direct Firebase initialization with FirebaseBridge</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/321/files#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>telemetry_service.dart</strong><dd><code>Update telemetry service to use the new FirebaseBridge seam</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/321/files#diff-1377388a2f920a4e598fa88333d0520d928c2dd5e181bed8c8a3b5e1e884b796">+21/-39</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>scan_barcode.dart</strong><dd><code>Update barcode scanning UI to use the BarcodeReaderWidget seam</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/321/files#diff-da3c0a09dca9336fa6b15fcee3c387924a51482225c4e08e50b06850575d0bc6">+15/-27</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>build.yml</strong><dd><code>Add CI job to stamp and sync the F-Droid build recipe</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/321/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wtf.openstrap.openstrap_edge.yml</strong><dd><code>Add F-Droid build recipe with dependency substitution instructions</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/321/files#diff-eeea75f19679ce074785b4f98ca3ffb340f7fe2713bab541fcc3e782e376313f">+117/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added camera-based barcode scanning for supported EAN, UPC, and DataBar formats.
  - Scanner captures the first valid barcode and provides clearer camera-permission error messaging.
  - Added an F-Droid-compatible, Google-free build option using open-source scanning and location components.

- **Improvements**
  - Centralized app diagnostics and performance reporting for more consistent behavior across supported builds.
  - F-Droid builds can continue operating without proprietary Firebase services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->