### PR TITLE
feat(alarm): weekly schedule + latch-failure & 7pm no-alarm safety notifications

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -22,6 +22,7 @@ import 'ui2/onboarding/pairing.dart';
 import 'ui2/onboarding/profile_setup.dart';
 import 'ui2/onboarding/splash.dart';
 import 'ui2/onboarding/welcome.dart';
+import 'ui2/profile/alarm.dart';
 import 'ui2/profile/profile.dart';
 import 'ui2/screens/ai_briefing.dart';
 import 'ui2/screens/calm_breathing.dart';
@@ -362,6 +363,9 @@ ShellDomain domainForRoute(String route) => switch (routePath(route)) {
       // recap (`notification_center.dart`), and declared in `tap_router`
       // alongside every other deep link — see the note below.
       kRouteProfile => ShellDomain.home,
+      // The two alarm safety notifications. Reached the same way as the
+      // battery/band alerts above — Profile lives on Home.
+      kRouteAlarm => ShellDomain.home,
       // No recap screen exists. Health is where a week of sleep, strain and
       // recovery actually lives, so it is the nearest true destination — but
       // the notification promises a REPORT, and until one is built the honest
@@ -416,6 +420,9 @@ Widget? screenForRoute(String route) => switch (routePath(route)) {
         WorkoutSuggestionScreen(focusId: routeId(route)),
       // Battery, band and sources all live behind this one.
       kRouteProfile => const ProfileHome(),
+      // The alarm safety notifications land where either can actually be
+      // fixed — the schedule itself.
+      kRouteAlarm => const AlarmScreen(),
       // The weekly recap used to land on the Health tab and push nothing,
       // because there was no recap screen to push. There is now: the sweep's
       // findings, which the app has been computing every night and delivering

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -5715,6 +5715,24 @@ class LocalDb {
     );
   }
 
+  /// Whether an ALARM_SET (event 56) row landed at or after [sinceMs]
+  /// (`captured_at`, device receive time — the band's own `ts` can be
+  /// RTC-skewed). The headless alarm-arm path (background_sync.dart) polls
+  /// this for a short grace window to confirm a SET actually latched before
+  /// the background connection closes, since there's no live AppState there
+  /// to catch a late event 56 the way the foreground confirmation machine
+  /// does.
+  static Future<bool> alarmSetConfirmedSince(int sinceMs) async {
+    final db = await instance;
+    final rows = await db.query(
+      'events',
+      where: 'event_id = ? AND captured_at >= ?',
+      whereArgs: [56, sinceMs],
+      limit: 1,
+    );
+    return rows.isNotEmpty;
+  }
+
   static Future<void> deleteEvents(List<String> hexes) async {
     if (hexes.isEmpty) return;
     final db = await instance;

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -337,7 +337,7 @@ class LocalDb {
   /// pass it: sqflite throws `ArgumentError('onCreate must be null if no
   /// version is specified')` BEFORE opening anything when `onCreate` is given
   /// without `version` (sqflite_common database_mixin.dart).
-  static const int schemaVersion = 49;
+  static const int schemaVersion = 50;
 
   /// SQLite caps host parameters per statement (`SQLITE_MAX_VARIABLE_NUMBER` —
   /// only 999 on the builds shipped with older Android/iOS). Any `IN (?, ?, …)`
@@ -427,6 +427,7 @@ class LocalDb {
         await _createSleepNap(db);
         await _createWorkoutRoute(db);
         await _createNotifFired(db);
+        await _createAlarmSchedule(db);
         await _ensureCoachViews(db);
       },
       onUpgrade: (db, oldV, newV) async {
@@ -921,6 +922,25 @@ class LocalDb {
           await _createDevice(db);
           await _ensureLiveCoverageDeviceId(db);
         }
+        if (oldV < 50) {
+          // The weekly alarm schedule — one row per weekday (0=Mon..6=Sun,
+          // matching the 0-indexed convention `workout_screen.dart` already
+          // uses for weekday array positions; DateTime.weekday itself stays
+          // 1=Mon..7=Sun everywhere else). CREATE TABLE IF NOT EXISTS and
+          // NOTHING else: a new empty table has no existing row for the PK to
+          // reject, so a throw here has nothing to roll back onto — which
+          // matters, because a throw in here rolls the WHOLE ladder back and
+          // quarantines the user's database (invariant 11). The legacy
+          // single-alarm value (`alarm_epoch` in SharedPreferences) is seeded
+          // into this table from AppState at startup, not here — this layer
+          // never touches SharedPreferences (see the doc on _createDevice's
+          // neighbours), and a plugin-channel read has no place inside a
+          // migration ladder step running under iOS's CPU watchdog.
+          //
+          // Ships without a kAlgoVersion bump: the alarm is not a health
+          // metric and nothing here changes a derived number.
+          await _createAlarmSchedule(db);
+        }
       },
       onOpen: (db) async {
         await _repairOpenSchema(db);
@@ -998,6 +1018,7 @@ class LocalDb {
     await _ensureDayResultSkippedColumn(db);
     await _ensureDayResultPartialColumn(db);
     await _createNotifFired(db);
+    await _createAlarmSchedule(db);
     // Views LAST — they depend on metric_series / day_result / baselines / sessions
     // / notifications all existing. DROP+CREATE so a shape change takes effect.
     await _ensureCoachViews(db);
@@ -1414,6 +1435,61 @@ class LocalDb {
       ),
       bestEffort: true,
     );
+  }
+
+  // ── alarm_schedule — the weekly wake-alarm schedule ─────────────────────
+
+  static Future<void> _createAlarmSchedule(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS alarm_schedule (
+        weekday INTEGER NOT NULL,
+        hour    INTEGER NOT NULL,
+        minute  INTEGER NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        PRIMARY KEY (weekday)
+      )
+    ''');
+  }
+
+  /// Every configured weekday row, in no particular order — callers that care
+  /// about weekday order (the UI, [nextAlarmOccurrence]) sort/fill it
+  /// themselves. A weekday absent from this list has never been configured;
+  /// it is NOT the same as a row with `enabled = 0`, and callers must not
+  /// collapse the two (see `AlarmScheduleEntry` / `fillDefaultAlarmSchedule`
+  /// in state/alarm_schedule.dart, which is where that distinction is made).
+  static Future<List<Map<String, Object?>>> alarmScheduleRows() async {
+    final db = await instance;
+    return db.query('alarm_schedule');
+  }
+
+  /// Upsert one weekday's slot. [weekday] is 0=Mon..6=Sun (see
+  /// `_createAlarmSchedule`'s doc); out-of-range values are the caller's bug,
+  /// not something this layer silently clamps.
+  static Future<void> setAlarmScheduleDay({
+    required int weekday,
+    required int hour,
+    required int minute,
+    required bool enabled,
+  }) async {
+    final db = await instance;
+    await db.insert(
+      'alarm_schedule',
+      {
+        'weekday': weekday,
+        'hour': hour,
+        'minute': minute,
+        'enabled': enabled ? 1 : 0,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  /// Wipe the whole weekly schedule — the "Cancel-all" half of disabling the
+  /// alarm (see AppState.disableAlarm), so a cancelled alarm cannot silently
+  /// re-arm itself from a schedule the user thought they'd cleared.
+  static Future<void> clearAlarmSchedule() async {
+    final db = await instance;
+    await db.delete('alarm_schedule');
   }
 
   /// sleep_nap — the user's edits to a day's naps.

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -244,11 +244,23 @@
   "@alarmArmedFor": {
     "description": "Armed-for section label."
   },
+  "alarmNextLabel": "NEXT",
+  "@alarmNextLabel": {
+    "description": "Next-occurrence section label."
+  },
+  "alarmScheduleGroup": "Weekly schedule",
+  "@alarmScheduleGroup": {
+    "description": "Settings group: the 7-day alarm schedule."
+  },
+  "alarmWakeTimeRowTitle": "Wake time",
+  "@alarmWakeTimeRowTitle": {
+    "description": "Row: a weekday's configured wake time."
+  },
   "alarmNotConnectedTitle": "The band is not connected",
   "@alarmNotConnectedTitle": {
     "description": "Status card: band not connected."
   },
-  "alarmNotConnectedBody": "Setting, testing and cancelling all write to the band, so they need a live connection. An alarm that is already armed is unaffected — it lives on the band.",
+  "alarmNotConnectedBody": "Changing the schedule, testing and cancelling all write to the band, so they need a live connection. An alarm that is already armed is unaffected — it lives on the band.",
   "@alarmNotConnectedBody": {
     "description": "Status card body: band not connected."
   },
@@ -11096,6 +11108,22 @@
   "settingsBandAlertsRowSub": "Flat battery, on the charger, gone quiet",
   "@settingsBandAlertsRowSub": {
     "description": "Notification row subtitle for band device alerts"
+  },
+  "settingsAlarmLatchFailedRowTitle": "Alarm not confirmed",
+  "@settingsAlarmLatchFailedRowTitle": {
+    "description": "Notification row title for the alarm latch-failure alert"
+  },
+  "settingsAlarmLatchFailedRowSub": "Warn when the band never confirms an alarm this app just armed",
+  "@settingsAlarmLatchFailedRowSub": {
+    "description": "Notification row subtitle for the alarm latch-failure alert"
+  },
+  "settingsAlarmNightCheckRowTitle": "No-alarm check-in",
+  "@settingsAlarmNightCheckRowTitle": {
+    "description": "Notification row title for the 7pm no-alarm-tonight check"
+  },
+  "settingsAlarmNightCheckRowSub": "A 7pm heads-up on any night with no wake alarm armed — silent otherwise",
+  "@settingsAlarmNightCheckRowSub": {
+    "description": "Notification row subtitle for the 7pm no-alarm-tonight check"
   },
   "settingsAlertMeAtRowTitle": "Alert me at",
   "@settingsAlertMeAtRowTitle": {

--- a/lib/notify/notification_center.dart
+++ b/lib/notify/notification_center.dart
@@ -212,6 +212,13 @@ class NotificationCenter {
   /// in here for the same reason [weeklyFinding] does: this method is the
   /// policy, and a policy that opens the database cannot be tested without
   /// one.
+  ///
+  /// [armedTonight]: whether the REAL armed alarm (AppState.alarmEpoch, not
+  /// merely an enabled schedule row) falls on today's calendar date — see
+  /// [alarmNightCheckSlot]. Always a real answer (never null): unlike
+  /// `checkInDoneToday`/`medDefs`, it costs no extra read (AppState already
+  /// holds the armed epoch), so there is no "caller doesn't know" case to
+  /// preserve through.
   Future<void> scheduleStandingReminders(
     NotificationPrefs prefs, {
     double? bedtimeMinOfDay,
@@ -219,9 +226,14 @@ class NotificationCenter {
     bool? checkInDoneToday,
     List<MedDef>? medDefs,
     Map<String, Map<int, Map<String, Object?>>> medDosesToday = const {},
+    bool armedTonight = false,
   }) async {
     final svc = NotificationService.instance;
     await svc.cancel(NotificationService.idWeeklyRecap);
+    // The night-check is decided fresh on every call (armedTonight is always a
+    // real answer, unlike checkInDoneToday) — cancel unconditionally, then
+    // re-arm below exactly like the weekly recap just above.
+    await svc.cancel(NotificationService.idAlarmNightCheck);
     // Wind-down follows the standing rule — cancel what this call cannot put
     // back, and only that. A null slot (switch off, or no LEARNED bedtime yet)
     // cancels; a real slot is armed below.
@@ -290,11 +302,14 @@ class NotificationCenter {
             doneToday: checkInDoneToday, nowMin: now.hour * 60 + now.minute);
     final meds =
         medPromptSlots(prefs, medDefs ?? const [], medDosesToday, now: now);
+    final nightCheck = alarmNightCheckSlot(prefs,
+        armedTonight: armedTonight, nowMin: now.hour * 60 + now.minute);
     if (water.isEmpty &&
         !wantWeekly &&
         windDownMin == null &&
         checkIn == null &&
-        meds.isEmpty) {
+        meds.isEmpty &&
+        nightCheck == null) {
       return;
     }
     // Re-resolve the zone first: this runs on every foreground resume, and the
@@ -306,6 +321,43 @@ class NotificationCenter {
     if (windDownMin != null) await _armWindDown(svc, windDownMin);
     if (checkIn != null) await _armCheckIn(svc, checkIn);
     await _armMedSlots(svc, meds);
+    if (nightCheck != null) await _armAlarmNightCheck(svc, nightCheck);
+  }
+
+  /// The hour the 7pm no-alarm-tonight check-in fires at, when armed.
+  static const int alarmNightCheckHour = 19;
+
+  /// The check-in's wall-clock minute, or null when it must not be armed: the
+  /// toggle is off, an alarm IS armed for tonight (the honest gate — the whole
+  /// point is to catch the GAP, not to nag someone who already has one set),
+  /// or 19:00 has already passed today (a one-shot rolled to tomorrow would
+  /// warn about TONIGHT a day late). No quiet-hours cap like windDown/checkIn:
+  /// 19:00 is fixed and outside the default quiet window, and moving it to
+  /// dodge a user-configured quiet window would just make the warning late.
+  static int? alarmNightCheckSlot(
+    NotificationPrefs prefs, {
+    required bool armedTonight,
+    required int nowMin,
+  }) {
+    if (!prefs.alarmNightCheckEnabled || armedTonight) return null;
+    final t = alarmNightCheckHour * 60;
+    if (nowMin >= t) return null;
+    return t;
+  }
+
+  /// The 7pm one-shot itself. ONE-SHOT, not a daily repeat, for the same
+  /// reason the check-in and med slots are: "armed for tonight" is a fact
+  /// about today specifically, and a repeat would go on warning about a night
+  /// that, by the next evening, may well have a real alarm set.
+  Future<void> _armAlarmNightCheck(NotificationService svc, int minuteOfDay) async {
+    await svc.scheduleOnce(
+      id: NotificationService.idAlarmNightCheck,
+      category: NotifCategory.reminders,
+      title: 'No alarm set for tonight',
+      body: 'You have no wake alarm armed for tonight.',
+      at: svc.nextDailyInstant(minuteOfDay ~/ 60, minuteOfDay % 60),
+      route: kRouteAlarm,
+    );
   }
 
   /// One notification per dose still due — never one per day, never a summary.

--- a/lib/notify/notification_center.dart
+++ b/lib/notify/notification_center.dart
@@ -219,7 +219,30 @@ class NotificationCenter {
   /// `checkInDoneToday`/`medDefs`, it costs no extra read (AppState already
   /// holds the armed epoch), so there is no "caller doesn't know" case to
   /// preserve through.
+  /// Public entry point — serialized through [_synchronized] so two
+  /// overlapping callers (e.g. a foreground resume racing a sync-completion
+  /// callback) can't interleave their cancel/re-arm passes and have a stale
+  /// call clobber a newer one's result.
   Future<void> scheduleStandingReminders(
+    NotificationPrefs prefs, {
+    double? bedtimeMinOfDay,
+    String? weeklyFinding,
+    bool? checkInDoneToday,
+    List<MedDef>? medDefs,
+    Map<String, Map<int, Map<String, Object?>>> medDosesToday = const {},
+    bool armedTonight = false,
+  }) =>
+      _synchronized(() => _scheduleStandingReminders(
+            prefs,
+            bedtimeMinOfDay: bedtimeMinOfDay,
+            weeklyFinding: weeklyFinding,
+            checkInDoneToday: checkInDoneToday,
+            medDefs: medDefs,
+            medDosesToday: medDosesToday,
+            armedTonight: armedTonight,
+          ));
+
+  Future<void> _scheduleStandingReminders(
     NotificationPrefs prefs, {
     double? bedtimeMinOfDay,
     String? weeklyFinding,
@@ -321,7 +344,16 @@ class NotificationCenter {
     if (windDownMin != null) await _armWindDown(svc, windDownMin);
     if (checkIn != null) await _armCheckIn(svc, checkIn);
     await _armMedSlots(svc, meds);
-    if (nightCheck != null) await _armAlarmNightCheck(svc, nightCheck);
+    // Recomputed fresh right before arming, not reused from the `now` this
+    // call started with — the awaits above (zone resolve + every slot ahead
+    // of this one) are real wall-clock time, and this is the one slot whose
+    // hour boundary (19:00) a stale `nowMin` could cross mid-call.
+    final freshNow = DateTime.now();
+    final freshNightCheck = alarmNightCheckSlot(prefs,
+        armedTonight: armedTonight, nowMin: freshNow.hour * 60 + freshNow.minute);
+    if (freshNightCheck != null) {
+      await _armAlarmNightCheck(svc, freshNightCheck);
+    }
   }
 
   /// The hour the 7pm no-alarm-tonight check-in fires at, when armed.

--- a/lib/notify/notification_prefs.dart
+++ b/lib/notify/notification_prefs.dart
@@ -111,6 +111,19 @@ class NotificationPrefs {
   /// bedtime has actually been learned — see NotificationCenter.windDownSlot.
   final bool windDownEnabled;
 
+  /// The alarm safety notifications (weekly-schedule feature). Both default
+  /// ON, unlike every other reminder above: they exist to catch a wake alarm
+  /// that silently isn't going to fire, which is the one failure mode where
+  /// starting silent defeats the point.
+  ///
+  /// Latch-failure: the strap never confirmed (event 56) an arm this app
+  /// wrote, after the retry AlarmConfirmation's grace window already allows.
+  final bool alarmLatchFailedEnabled;
+
+  /// The 7pm "no alarm set for tonight" check-in: silent whenever an alarm IS
+  /// armed for tonight, so it only ever speaks up about an actual gap.
+  final bool alarmNightCheckEnabled;
+
   /// Allowed bounds for [batteryAlertPct]. Below 5% a band is dying, not low;
   /// above 40% the alert would fire constantly and be muted forever.
   static const int batteryPctMin = 5;
@@ -138,6 +151,8 @@ class NotificationPrefs {
     this.batteryAlertPct = batteryPctDefault,
     this.stepGoalEnabled = true,
     this.windDownEnabled = false,
+    this.alarmLatchFailedEnabled = true,
+    this.alarmNightCheckEnabled = true,
   });
 
   static const _kHealth = 'notif_health';
@@ -163,6 +178,8 @@ class NotificationPrefs {
   static const _kBatteryPct = batteryPctPrefKey;
   static const _kStepGoal = 'notif_stepgoal';
   static const _kWindDown = 'notif_winddown';
+  static const _kAlarmLatchFailed = 'notif_alarm_latch_failed';
+  static const _kAlarmNightCheck = 'notif_alarm_night_check';
 
   static Future<NotificationPrefs> load() async {
     final p = await SharedPreferences.getInstance();
@@ -186,6 +203,8 @@ class NotificationPrefs {
           .toInt(),
       stepGoalEnabled: p.getBool(_kStepGoal) ?? true,
       windDownEnabled: p.getBool(_kWindDown) ?? false,
+      alarmLatchFailedEnabled: p.getBool(_kAlarmLatchFailed) ?? true,
+      alarmNightCheckEnabled: p.getBool(_kAlarmNightCheck) ?? true,
     );
   }
 
@@ -209,6 +228,8 @@ class NotificationPrefs {
         _kBatteryPct, batteryAlertPct.clamp(batteryPctMin, batteryPctMax).toInt());
     await p.setBool(_kStepGoal, stepGoalEnabled);
     await p.setBool(_kWindDown, windDownEnabled);
+    await p.setBool(_kAlarmLatchFailed, alarmLatchFailedEnabled);
+    await p.setBool(_kAlarmNightCheck, alarmNightCheckEnabled);
   }
 
   NotificationPrefs copyWith({
@@ -229,6 +250,8 @@ class NotificationPrefs {
     int? batteryAlertPct,
     bool? stepGoalEnabled,
     bool? windDownEnabled,
+    bool? alarmLatchFailedEnabled,
+    bool? alarmNightCheckEnabled,
   }) =>
       NotificationPrefs(
         healthEnabled: healthEnabled ?? this.healthEnabled,
@@ -249,6 +272,10 @@ class NotificationPrefs {
         batteryAlertPct: batteryAlertPct ?? this.batteryAlertPct,
         stepGoalEnabled: stepGoalEnabled ?? this.stepGoalEnabled,
         windDownEnabled: windDownEnabled ?? this.windDownEnabled,
+        alarmLatchFailedEnabled:
+            alarmLatchFailedEnabled ?? this.alarmLatchFailedEnabled,
+        alarmNightCheckEnabled:
+            alarmNightCheckEnabled ?? this.alarmNightCheckEnabled,
       );
 
   bool categoryEnabled(NotifCategory c) => switch (c) {

--- a/lib/notify/notification_service.dart
+++ b/lib/notify/notification_service.dart
@@ -125,6 +125,8 @@ class NotificationService {
   static const int idJournalLog = 2004; // scheduled daily ("log your day")
   static const int idMorningBrief = 2005; // scheduled daily (AI morning briefing)
   static const int idEveningBrief = 2006; // scheduled daily (AI evening recap)
+  static const int idAlarmLatchFailed = 2007; // immediate ("alarm not confirmed")
+  static const int idAlarmNightCheck = 2008; // scheduled daily, one-shot 19:00
   static const int idStillness = 2200; // provisional one-shot ("time to move", issue #123)
   static const int idCheckIn = 2201; // daily ("how was today?" → the journal)
 
@@ -196,6 +198,7 @@ class NotificationService {
     idWindDown,
     idStillness,
     idCheckIn,
+    idAlarmNightCheck,
   };
 
   /// Whether [id] is one of the hydration slots. A band rather than a set

--- a/lib/notify/tap_router.dart
+++ b/lib/notify/tap_router.dart
@@ -103,6 +103,11 @@ const String kRouteProfile = '/profile';
 /// `domainForRoute` claimed otherwise.
 const String kRouteRecap = '/recap';
 
+/// Emitted by the two alarm safety notifications (latch-failure, the 7pm
+/// no-alarm-tonight check-in). Lands on the Alarm screen itself, the one place
+/// either can actually be fixed — see `screenForRoute` in app.dart.
+const String kRouteAlarm = '/alarm';
+
 class TapTarget {
   /// Shell tab index to land on (always valid; unknown → 0 = Today).
   final int tab;
@@ -150,6 +155,7 @@ const Map<String, int> _screenRoutes = {
   kRouteWorkoutSuggestion: 4,
   kRouteProfile: 0,
   kRouteRecap: 1, // 1|2|3 all fold into Health — see domainForTab
+  kRouteAlarm: 0,
 };
 
 TapTarget resolveTapRoute(String route) {

--- a/lib/state/alarm_schedule.dart
+++ b/lib/state/alarm_schedule.dart
@@ -153,6 +153,30 @@ AlarmScheduleEntry seedEntryFromLegacyEpoch(int epoch) {
   );
 }
 
+/// Whether the alarm armed for [armedEpochSec] fires during tonight's
+/// upcoming overnight sleep, as measured from [now]. TRUE iff the epoch is
+/// non-null, strictly after [now], AND strictly before noon of the day after
+/// [now]'s calendar date — the window covering the whole overnight sleep
+/// ahead, whether the arm lands later tonight or in the small hours of
+/// tomorrow morning. An epoch already past, or one two-or-more nights out, is
+/// not "tonight". Calendar-date comparison of the two DateTimes is
+/// deliberately not used: a wake alarm armed for tomorrow morning is tonight's
+/// alarm even though its date differs from today's.
+///
+/// Pure — no AppState/DB/engine deps — so the 7pm "no alarm tonight" check can
+/// be unit-tested without a clock or a strap.
+///
+/// CALENDAR arithmetic for the window boundary (`DateTime(y, m, d + 1, 12, 0)`),
+/// not a `Duration` of hours — the same DST reasoning as [nextAlarmOccurrence]
+/// above: noon tomorrow is a wall-clock instant, not 36 elapsed hours.
+bool alarmArmsTonight(int? armedEpochSec, DateTime now) {
+  if (armedEpochSec == null) return false;
+  final at = DateTime.fromMillisecondsSinceEpoch(armedEpochSec * 1000);
+  if (!at.isAfter(now)) return false;
+  final endOfTonight = DateTime(now.year, now.month, now.day + 1, 12, 0);
+  return at.isBefore(endOfTonight);
+}
+
 /// Whether the latch-failure safety notification should fire for [epoch]: the
 /// toggle is on, [epoch] is STILL the confirmation machine's current target (a
 /// newer arm, or a cancel, superseded it), and the strap never confirmed it.

--- a/lib/state/alarm_schedule.dart
+++ b/lib/state/alarm_schedule.dart
@@ -113,28 +113,42 @@ DateTime? nextAlarmOccurrence(List<AlarmScheduleEntry> schedule, DateTime now) {
   return best;
 }
 
+/// Result of [armNextScheduledOccurrence]. [epoch] is the newly-armed unix
+/// instant, or null when nothing changed on the strap (no enabled day and
+/// already unarmed, the target already matches what's armed, or the write
+/// was refused/failed). [disabled] is true only when this call actively sent
+/// DISABLE_ALARM because the schedule now has nothing enabled but the strap
+/// still held a live arm — the case a caller must clear its own
+/// persisted/optimistic epoch for.
+typedef AlarmArmResult = ({int? epoch, bool disabled});
+
 /// Arms [engine] with the next scheduled occurrence, if one exists and it
 /// differs from [currentArmedEpoch] (unix seconds) — the "don't hammer the
-/// strap on every sync" rule. Returns the newly-armed epoch on a confirmed
-/// write, or null when nothing needed arming (no enabled day, or the target
-/// is already what's armed) or the write itself was refused/failed.
+/// strap on every sync" rule. See [AlarmArmResult] for what's returned.
 ///
 /// Pure I/O orchestration only: the occurrence math is [nextAlarmOccurrence],
 /// tested independently with no engine, and the wire form is whatever
 /// `engine.setAlarm` already sends (rev1 gen4 / gen5 rich — unchanged here).
-Future<int?> armNextScheduledOccurrence({
+Future<AlarmArmResult> armNextScheduledOccurrence({
   required BleEngine engine,
   required List<AlarmScheduleEntry> schedule,
   required int? currentArmedEpoch,
   DateTime? now,
 }) async {
   final next = nextAlarmOccurrence(schedule, now ?? DateTime.now());
-  if (next == null) return null;
+  if (next == null) {
+    // Nothing enabled. Toggling every weekday off individually (rather than
+    // an explicit cancel-all) must not leave the strap holding its last arm
+    // forever — nothing else in this flow ever tells the band to give it up.
+    if (currentArmedEpoch == null) return (epoch: null, disabled: false);
+    await engine.disableAlarm();
+    return (epoch: null, disabled: true);
+  }
   final epoch = next.millisecondsSinceEpoch ~/ 1000;
-  if (epoch == currentArmedEpoch) return null;
+  if (epoch == currentArmedEpoch) return (epoch: null, disabled: false);
   final armed = await engine.setAlarm(next);
-  if (armed == null) return null;
-  return armed.millisecondsSinceEpoch ~/ 1000;
+  if (armed == null) return (epoch: null, disabled: false);
+  return (epoch: armed.millisecondsSinceEpoch ~/ 1000, disabled: false);
 }
 
 /// The weekday/hour/minute a legacy single-alarm epoch maps onto, for the

--- a/lib/state/alarm_schedule.dart
+++ b/lib/state/alarm_schedule.dart
@@ -1,0 +1,162 @@
+// The weekly alarm schedule — pure occurrence math plus the thin engine
+// orchestration that arms it, shared between AppState (foreground connect/
+// sync) and background_sync.dart's headless drain, which has no AppState.
+//
+// [AlarmScheduleEntry.weekday] is 0=Mon..6=Sun — the same 0-indexed convention
+// `workout_screen.dart` already uses for weekday array positions. This is a
+// storage/UI indexing choice, not a replacement for `DateTime.weekday`
+// (1=Mon..7=Sun), which every conversion below still goes through explicitly.
+
+import '../ble/ble_engine.dart';
+import '../ble/ble_state.dart' show AlarmConfirmation;
+
+/// One weekday's slot in the schedule. Immutable — callers build a new one to
+/// change a field.
+class AlarmScheduleEntry {
+  final int weekday; // 0=Mon..6=Sun
+  final int hour;
+  final int minute;
+  final bool enabled;
+
+  const AlarmScheduleEntry({
+    required this.weekday,
+    required this.hour,
+    required this.minute,
+    this.enabled = true,
+  });
+
+  AlarmScheduleEntry copyWith({int? hour, int? minute, bool? enabled}) =>
+      AlarmScheduleEntry(
+        weekday: weekday,
+        hour: hour ?? this.hour,
+        minute: minute ?? this.minute,
+        enabled: enabled ?? this.enabled,
+      );
+
+  factory AlarmScheduleEntry.fromRow(Map<String, Object?> row) =>
+      AlarmScheduleEntry(
+        weekday: row['weekday'] as int,
+        hour: row['hour'] as int,
+        minute: row['minute'] as int,
+        enabled: (row['enabled'] as int) != 0,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      other is AlarmScheduleEntry &&
+      other.weekday == weekday &&
+      other.hour == hour &&
+      other.minute == minute &&
+      other.enabled == enabled;
+
+  @override
+  int get hashCode => Object.hash(weekday, hour, minute, enabled);
+
+  @override
+  String toString() =>
+      'AlarmScheduleEntry(weekday: $weekday, hour: $hour, minute: $minute, '
+      'enabled: $enabled)';
+}
+
+/// The default slot for a weekday nobody has configured yet: 07:00, off. A
+/// made-up ON default would arm a wake alarm nobody asked for; the honest
+/// default is silence with a sensible time already dialled in.
+const int defaultAlarmHour = 7;
+const int defaultAlarmMinute = 0;
+
+/// Exactly 7 entries, one per weekday, in weekday order (index == weekday). A
+/// weekday absent from [stored] gets [defaultAlarmHour]:[defaultAlarmMinute],
+/// disabled. This is the ONE place "unconfigured" and "configured but off"
+/// are made to look the same to every caller (the UI always renders 7 rows;
+/// [nextAlarmOccurrence] only ever sees a fully-populated list).
+List<AlarmScheduleEntry> fillDefaultAlarmSchedule(
+  List<AlarmScheduleEntry> stored,
+) {
+  final byWeekday = {for (final e in stored) e.weekday: e};
+  return [
+    for (var w = 0; w < 7; w++)
+      byWeekday[w] ??
+          AlarmScheduleEntry(
+            weekday: w,
+            hour: defaultAlarmHour,
+            minute: defaultAlarmMinute,
+            enabled: false,
+          ),
+  ];
+}
+
+/// The next enabled occurrence strictly after [now], or null when every
+/// weekday is disabled (or [schedule] is empty). Wraps to next week when this
+/// week's occurrence for a weekday has already passed.
+///
+/// CALENDAR arithmetic throughout (`DateTime(y, m, d + n, h, min)`), not
+/// `Duration` multiples of a day — the same reasoning as
+/// `AlarmScreenView.nextAt`: a `Duration(days: 7)` add is 168 ELAPSED hours,
+/// which is a different wall-clock time across a DST change.
+DateTime? nextAlarmOccurrence(List<AlarmScheduleEntry> schedule, DateTime now) {
+  DateTime? best;
+  for (final e in schedule) {
+    if (!e.enabled) continue;
+    final entryDow = e.weekday + 1; // DateTime.monday(1)..sunday(7)
+    var daysAhead = (entryDow - now.weekday) % 7;
+    if (daysAhead < 0) daysAhead += 7; // Dart's % can return negative
+    var candidate =
+        DateTime(now.year, now.month, now.day + daysAhead, e.hour, e.minute);
+    // Strictly after `now` — the same instant is treated as past, so an
+    // alarm never arms for "right now" (mirrors AlarmScreenView.nextAt).
+    if (!candidate.isAfter(now)) {
+      candidate =
+          DateTime(now.year, now.month, now.day + daysAhead + 7, e.hour, e.minute);
+    }
+    if (best == null || candidate.isBefore(best)) best = candidate;
+  }
+  return best;
+}
+
+/// Arms [engine] with the next scheduled occurrence, if one exists and it
+/// differs from [currentArmedEpoch] (unix seconds) — the "don't hammer the
+/// strap on every sync" rule. Returns the newly-armed epoch on a confirmed
+/// write, or null when nothing needed arming (no enabled day, or the target
+/// is already what's armed) or the write itself was refused/failed.
+///
+/// Pure I/O orchestration only: the occurrence math is [nextAlarmOccurrence],
+/// tested independently with no engine, and the wire form is whatever
+/// `engine.setAlarm` already sends (rev1 gen4 / gen5 rich — unchanged here).
+Future<int?> armNextScheduledOccurrence({
+  required BleEngine engine,
+  required List<AlarmScheduleEntry> schedule,
+  required int? currentArmedEpoch,
+  DateTime? now,
+}) async {
+  final next = nextAlarmOccurrence(schedule, now ?? DateTime.now());
+  if (next == null) return null;
+  final epoch = next.millisecondsSinceEpoch ~/ 1000;
+  if (epoch == currentArmedEpoch) return null;
+  final armed = await engine.setAlarm(next);
+  if (armed == null) return null;
+  return armed.millisecondsSinceEpoch ~/ 1000;
+}
+
+/// The weekday/hour/minute a legacy single-alarm epoch maps onto, for the
+/// one-time 49→50 seed (see AppState._seedAlarmScheduleFromLegacyEpoch).
+/// [epoch] is unix seconds, LOCAL wall-clock time is what the user saw when
+/// they set it, so this reads `DateTime.fromMillisecondsSinceEpoch` in local
+/// time (not UTC) and maps `DateTime.weekday` (1=Mon..7=Sun) to the 0-indexed
+/// column via `- 1`.
+AlarmScheduleEntry seedEntryFromLegacyEpoch(int epoch) {
+  final at = DateTime.fromMillisecondsSinceEpoch(epoch * 1000);
+  return AlarmScheduleEntry(
+    weekday: at.weekday - 1,
+    hour: at.hour,
+    minute: at.minute,
+    enabled: true,
+  );
+}
+
+/// Whether the latch-failure safety notification should fire for [epoch]: the
+/// toggle is on, [epoch] is STILL the confirmation machine's current target (a
+/// newer arm, or a cancel, superseded it), and the strap never confirmed it.
+/// Pure — no notification plumbing, no clock reads — so the decision itself is
+/// unit-testable without a fake OS notification sink.
+bool alarmLatchFailed(AlarmConfirmation a, int epoch, {required bool enabled}) =>
+    enabled && a.targetEpoch == epoch && !a.confirmed;

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -4022,17 +4022,15 @@ class AppState extends ChangeNotifier {
   }
 
   /// Whether the currently-armed alarm — from either source, the schedule
-  /// engine or a still-live manual arm — falls on TODAY's calendar date. Feeds
-  /// the 7pm "no alarm set for tonight" check (Feature 2.2): the honest, real
-  /// armed state, not merely that today's schedule row happens to be enabled
-  /// — a slot that never latched is not something this may claim is armed.
-  bool get _alarmArmedTonight {
-    final epoch = alarmEpoch;
-    if (epoch == null) return false;
-    final at = DateTime.fromMillisecondsSinceEpoch(epoch * 1000);
-    final now = DateTime.now();
-    return at.year == now.year && at.month == now.month && at.day == now.day;
-  }
+  /// engine or a still-live manual arm — fires during tonight's upcoming
+  /// overnight sleep. Feeds the 7pm "no alarm set for tonight" check
+  /// (Feature 2.2): the honest, real armed state, not merely that today's
+  /// schedule row happens to be enabled — a slot that never latched is not
+  /// something this may claim is armed. Delegates to the pure
+  /// [alarmArmsTonight], whose window is "after now, before noon tomorrow" —
+  /// a wake alarm armed tonight for tomorrow morning still counts, unlike a
+  /// same-calendar-date check would (see PR #329).
+  bool get _alarmArmedTonight => alarmArmsTonight(alarmEpoch, DateTime.now());
 
   // ── alarm confirmation state machine ────────────────────────────────────────
   // The strap CONFIRMS an alarm actually latched via event 56 (ALARM_SET) and

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -54,6 +54,7 @@ import '../stress/breath_phases.dart';
 // `runBackupIfDue` is also the name of the AppState method below, so the pure
 // scheduler is imported under an alias rather than shadowed by it.
 import '../data/auto_backup.dart' as backup show runBackupIfDue;
+import 'alarm_schedule.dart';
 import 'prefs.dart';
 import '../data/db.dart';
 import '../data/live_coverage_policy.dart';
@@ -2162,6 +2163,8 @@ class AppState extends ChangeNotifier {
         await LocalDb.getCursorInt('rec_ts_hw') ?? lastSynced?.tsEpoch;
     await LocalDb.refreshComputeFreshness();
     _savedAlarm = (await SharedPreferences.getInstance()).getInt('alarm_epoch');
+    await _loadAlarmSchedule();
+    await _seedAlarmScheduleFromLegacyIfNeeded();
     // Band-gesture mapping: load the saved action + query native capabilities so the
     // settings UI knows what this platform supports. Best-effort, non-blocking.
     unawaited(gestureSettings.bootstrap());
@@ -2320,6 +2323,7 @@ class AppState extends ChangeNotifier {
         checkInDoneToday: await _checkInDoneToday(),
         medDefs: meds.defs,
         medDosesToday: meds.doses,
+        armedTonight: _alarmArmedTonight,
       );
       // The strap-buzz half of the medication reminder, off the SAME schedule
       // read the OS dose slots above were armed from — one read feeds both
@@ -3923,6 +3927,113 @@ class AppState extends ChangeNotifier {
   }
   int? _savedAlarm;
 
+  // ── weekly alarm schedule (replaces a single next-occurrence value) ────────
+  // The 7-day schedule lives in `alarm_schedule` (lib/data/db.dart); this cache
+  // is always exactly 7 entries (see fillDefaultAlarmSchedule) so the UI can
+  // render every weekday row unconditionally, and [_armNextAlarmOccurrence]
+  // never has to special-case a weekday nobody has touched.
+  List<AlarmScheduleEntry> _schedule = fillDefaultAlarmSchedule(const []);
+  List<AlarmScheduleEntry> get alarmSchedule => _schedule;
+
+  Future<void> _loadAlarmSchedule() async {
+    try {
+      final rows = await LocalDb.alarmScheduleRows();
+      _schedule = fillDefaultAlarmSchedule(
+          [for (final r in rows) AlarmScheduleEntry.fromRow(r)]);
+    } catch (e) {
+      _log('[alarm] schedule load failed: $e');
+    }
+  }
+
+  /// One-time 49→50 seed: a legacy single-alarm value with nothing yet in
+  /// `alarm_schedule` becomes that weekday's slot. Safe to call on every
+  /// launch — it is a no-op the moment ANY row exists, including a schedule
+  /// the user has since cleared via Cancel-all, which must stay cleared
+  /// rather than resurrect the old value.
+  Future<void> _seedAlarmScheduleFromLegacyIfNeeded() async {
+    try {
+      if (_savedAlarm == null) return;
+      final rows = await LocalDb.alarmScheduleRows();
+      if (rows.isNotEmpty) return;
+      final seed = seedEntryFromLegacyEpoch(_savedAlarm!);
+      await LocalDb.setAlarmScheduleDay(
+        weekday: seed.weekday,
+        hour: seed.hour,
+        minute: seed.minute,
+        enabled: seed.enabled,
+      );
+      await _loadAlarmSchedule();
+    } catch (e) {
+      _log('[alarm] legacy schedule seed failed: $e');
+    }
+  }
+
+  /// Change one weekday's slot and re-arm immediately when connected —
+  /// waiting for the next connect/sync would leave the band holding the OLD
+  /// schedule while the screen already claims the new one.
+  Future<void> setScheduleDay({
+    required int weekday,
+    int? hour,
+    int? minute,
+    bool? enabled,
+  }) async {
+    final current = _schedule.firstWhere(
+      (e) => e.weekday == weekday,
+      orElse: () => AlarmScheduleEntry(
+          weekday: weekday,
+          hour: defaultAlarmHour,
+          minute: defaultAlarmMinute,
+          enabled: false),
+    );
+    final next =
+        current.copyWith(hour: hour, minute: minute, enabled: enabled);
+    await LocalDb.setAlarmScheduleDay(
+      weekday: next.weekday,
+      hour: next.hour,
+      minute: next.minute,
+      enabled: next.enabled,
+    );
+    await _loadAlarmSchedule();
+    notifyListeners();
+    if (isConnected) await _armNextAlarmOccurrence();
+  }
+
+  /// Compute + arm the next scheduled occurrence, skipping the write when it
+  /// already matches what's armed (don't hammer the strap on every sync).
+  /// Called after every successful connect and after each sync completes —
+  /// see the `_armNextAlarmOccurrence()` call sites in openSession,
+  /// _reconnect, and their `_kickSyncBurst` completion callbacks — so an
+  /// edited schedule or a just-fired alarm re-arms with no manual step, and a
+  /// fired one-shot (which clears `_savedAlarm`) picks up its next occurrence
+  /// on the very next connect.
+  Future<void> _armNextAlarmOccurrence() async {
+    if (!isConnected) return;
+    try {
+      final epoch = await armNextScheduledOccurrence(
+        engine: engine,
+        schedule: _schedule,
+        currentArmedEpoch: _savedAlarm ?? device.alarmEpoch,
+      );
+      if (epoch == null) return;
+      await _onArmed(DateTime.fromMillisecondsSinceEpoch(epoch * 1000), epoch);
+    } catch (e) {
+      _log('[alarm] weekly-schedule arm failed: $e');
+    }
+  }
+
+  /// Whether the currently-armed alarm — from either source, the schedule
+  /// engine or a still-live manual arm — falls on TODAY's calendar date. Feeds
+  /// the 7pm "no alarm set for tonight" check (Feature 2.2): the honest, real
+  /// armed state, not merely that today's schedule row happens to be enabled
+  /// — a slot that never latched is not something this may claim is armed.
+  bool get _alarmArmedTonight {
+    final epoch = alarmEpoch;
+    if (epoch == null) return false;
+    final at = DateTime.fromMillisecondsSinceEpoch(epoch * 1000);
+    final now = DateTime.now();
+    return at.year == now.year && at.month == now.month && at.day == now.day;
+  }
+
   // ── alarm confirmation state machine ────────────────────────────────────────
   // The strap CONFIRMS an alarm actually latched via event 56 (ALARM_SET) and
   // reports firing via 57/58 (+60). This replaces the parked GET_ALARM readback
@@ -3966,11 +4077,19 @@ class AppState extends ChangeNotifier {
       // phone and an explicit refusal — the engine log says which.
       throw Exception('Alarm not set');
     }
-    final epoch = armed.millisecondsSinceEpoch ~/ 1000;
+    await _onArmed(armed, armed.millisecondsSinceEpoch ~/ 1000);
+  }
+
+  /// Shared bookkeeping for anything that just armed the band: optimistic
+  /// display, the confirmation machine, the persisted epoch, and the grace
+  /// timer. [setAlarm] (an explicit write) and [_armNextAlarmOccurrence] (the
+  /// schedule engine) both funnel through here so the two can never drift
+  /// apart on what "armed" means.
+  Future<void> _onArmed(DateTime when, int epoch) async {
     _savedAlarm = epoch;
     device.alarmEpoch = epoch; // optimistic display
     _alarm.set(epoch, DateTime.now().millisecondsSinceEpoch); // await event 56
-    _alarmAutoRetried = false; // fresh user-initiated set gets its one retry
+    _alarmAutoRetried = false; // a fresh arm gets its one retry
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt('alarm_epoch', epoch);
     // Nudge the UI once the grace window elapses so an unconfirmed alarm flips to
@@ -4001,6 +4120,7 @@ class AppState extends ChangeNotifier {
     if (_savedAlarm != epoch) return;
     if (_alarmAutoRetried || !isConnected) {
       notifyListeners();
+      unawaited(_notifyAlarmLatchFailed(epoch));
       return;
     }
     _alarmAutoRetried = true;
@@ -4027,6 +4147,36 @@ class AppState extends ChangeNotifier {
       return;
     }
     notifyListeners();
+    unawaited(_notifyAlarmLatchFailed(epoch));
+  }
+
+  /// The "alarm not confirmed" safety notification (Feature 2.1): fires once
+  /// per armed epoch, only once every retry this grace window can offer is
+  /// exhausted and the strap still never confirmed. Respects its own toggle
+  /// (default ON). Category device + critical priority rides the same
+  /// quiet-hours exemption as the band's other own-failure alerts (flat
+  /// battery, gone quiet) — a wake alarm that silently didn't latch is
+  /// exactly the kind of thing quiet hours must not swallow.
+  Future<void> _notifyAlarmLatchFailed(int epoch) async {
+    try {
+      final prefs = await NotificationPrefs.load();
+      if (!alarmLatchFailed(_alarm, epoch,
+          enabled: prefs.alarmLatchFailedEnabled)) {
+        return;
+      }
+      await NotificationCenter.instance.emit(NotificationEvent(
+        dedupeKey: 'alarm_latch_failed:$epoch',
+        category: NotifCategory.device,
+        priority: NotifPriority.critical,
+        title: 'Alarm not confirmed',
+        body: 'The band did not confirm this alarm — check the strap.',
+        date: todayLabel(),
+        route: kRouteAlarm,
+        osId: NotificationService.idAlarmLatchFailed,
+      ));
+    } catch (e) {
+      _log('[alarm] latch-failure notification skipped: $e');
+    }
   }
 
   /// Fire the strap's alarm haptics immediately — a "test buzz" so the user can
@@ -4053,6 +4203,9 @@ class AppState extends ChangeNotifier {
     }
   }
 
+  /// The UI's "Cancel-all": DISABLE_ALARM on the band, and clear the whole
+  /// weekly schedule — not just the currently-armed instant — so nothing left
+  /// in `alarm_schedule` can silently re-arm this on the next connect/sync.
   Future<void> disableAlarm() async {
     if (!isConnected) throw Exception('Connect to your strap first');
     await engine.disableAlarm();
@@ -4062,6 +4215,8 @@ class AppState extends ChangeNotifier {
     _alarmGraceTimer?.cancel();
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('alarm_epoch');
+    await LocalDb.clearAlarmSchedule();
+    _schedule = fillDefaultAlarmSchedule(const []);
     notifyListeners();
   }
 
@@ -4264,6 +4419,9 @@ class AppState extends ChangeNotifier {
       // Arm the strap's high-frequency sync window when a wake alarm is near
       // (denser flushes → fresher overnight data ahead of the alarm).
       await _refreshHighFreqWakeWindow();
+      // Compute + arm the next weekly-schedule occurrence on every successful
+      // connect (Feature 1's arming engine) — see _armNextAlarmOccurrence.
+      await _armNextAlarmOccurrence();
       _log('Listening — live streams on, historical burst runs concurrently.');
       // Enable live streams PROMPTLY, then let the historical burst run
       // CONCURRENTLY (unawaited, single-flight via _kickSyncBurst). History and
@@ -4289,6 +4447,9 @@ class AppState extends ChangeNotifier {
           );
           // Re-evaluate the high-frequency wake window now the backlog landed.
           await _refreshHighFreqWakeWindow();
+          // Re-arm the weekly schedule now the sync completed (Feature 1: "on
+          // every successful connect AND after each sync").
+          await _armNextAlarmOccurrence();
           // The whole backlog landed → heavy foreground finalize (full sleep
           // staging + 24-h spectra over every stale day).
           _deriveScheduler.requestHeavy();
@@ -4398,6 +4559,9 @@ class AppState extends ChangeNotifier {
           // Arm the strap's high-frequency sync window when a wake alarm is
           // near (denser flushes ahead of the alarm).
           await _refreshHighFreqWakeWindow();
+          // Compute + arm the next weekly-schedule occurrence on every
+          // successful (re)connect — see _armNextAlarmOccurrence.
+          await _armNextAlarmOccurrence();
           // Live streams come up promptly; the FULL drain (no short timeout —
           // the ENTIRE offline backlog the band flashed while out of range)
           // runs concurrently, single-flight, exactly as in openSession.
@@ -4425,6 +4589,9 @@ class AppState extends ChangeNotifier {
               // Re-evaluate the high-frequency wake window now the backlog
               // landed.
               await _refreshHighFreqWakeWindow();
+              // Re-arm the weekly schedule now the sync completed (Feature 1:
+              // "on every successful connect AND after each sync").
+              await _armNextAlarmOccurrence();
               // Backlog (often an overnight gap) just landed → derive it.
               // Backgrounded, a flappy link (routine arm-swing dropouts)
               // reconnects many times an hour; each heavy pass spawns an

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2162,7 +2162,21 @@ class AppState extends ChangeNotifier {
     _lastRecTs =
         await LocalDb.getCursorInt('rec_ts_hw') ?? lastSynced?.tsEpoch;
     await LocalDb.refreshComputeFreshness();
-    _savedAlarm = (await SharedPreferences.getInstance()).getInt('alarm_epoch');
+    final alarmPrefs = await SharedPreferences.getInstance();
+    _savedAlarm = alarmPrefs.getInt('alarm_epoch');
+    // Seed the confirmation machine from what the last session (foreground OR
+    // headless — background_sync.dart writes the same two keys) actually
+    // learned, so a relaunch doesn't forget a confirmed headless arm and
+    // wrongly read it as unconfirmed, nor trust an arm that never confirmed.
+    // `setAtMs` is stamped as "now" rather than the true original arm time —
+    // ponytail: harmless imprecision (worst case a few extra seconds of
+    // "pending" after launch before an unconfirmed arm shows its warning),
+    // add real persistence of setAtMs if that grace window ever needs to be
+    // exact across relaunches.
+    if (_savedAlarm != null) {
+      _alarm.set(_savedAlarm!, DateTime.now().millisecondsSinceEpoch);
+      _alarm.confirmed = alarmPrefs.getBool('alarm_epoch_confirmed') ?? false;
+    }
     await _loadAlarmSchedule();
     await _seedAlarmScheduleFromLegacyIfNeeded();
     // Band-gesture mapping: load the saved action + query native capabilities so the
@@ -4009,11 +4023,35 @@ class AppState extends ChangeNotifier {
   Future<void> _armNextAlarmOccurrence() async {
     if (!isConnected) return;
     try {
-      final epoch = await armNextScheduledOccurrence(
+      // A headless re-arm (background_sync.dart) can have rewritten
+      // `alarm_epoch`/`alarm_epoch_confirmed` under this same live process
+      // since init() last read them — refresh from the shared store before
+      // comparing, or a stale in-memory `_savedAlarm` makes this issue a
+      // needless duplicate setAlarm write on every connect.
+      final prefs = await SharedPreferences.getInstance();
+      final onDisk = prefs.getInt('alarm_epoch');
+      if (onDisk != _savedAlarm) {
+        _savedAlarm = onDisk;
+        if (onDisk != null) {
+          _alarm.set(onDisk, DateTime.now().millisecondsSinceEpoch);
+          _alarm.confirmed = prefs.getBool('alarm_epoch_confirmed') ?? false;
+        } else {
+          _alarm.disable();
+        }
+      }
+      final result = await armNextScheduledOccurrence(
         engine: engine,
         schedule: _schedule,
         currentArmedEpoch: _savedAlarm ?? device.alarmEpoch,
       );
+      if (result.disabled) {
+        // Every weekday got disabled since the last arm — the strap doesn't
+        // give up its old alarm on its own (PR #329 review).
+        _clearArmedAlarmState();
+        notifyListeners();
+        return;
+      }
+      final epoch = result.epoch;
       if (epoch == null) return;
       await _onArmed(DateTime.fromMillisecondsSinceEpoch(epoch * 1000), epoch);
     } catch (e) {
@@ -4030,7 +4068,18 @@ class AppState extends ChangeNotifier {
   /// [alarmArmsTonight], whose window is "after now, before noon tomorrow" —
   /// a wake alarm armed tonight for tomorrow morning still counts, unlike a
   /// same-calendar-date check would (see PR #329).
-  bool get _alarmArmedTonight => alarmArmsTonight(alarmEpoch, DateTime.now());
+  bool get _alarmArmedTonight {
+    final epoch = alarmEpoch;
+    if (!alarmArmsTonight(epoch, DateTime.now())) return false;
+    // The window match alone isn't enough — an epoch that was WRITTEN but
+    // never actually latched (headless failure, or the write is still inside
+    // its grace window with no confirmation yet) must not suppress the 7pm
+    // check; that gap is exactly what this check exists to catch (CodeRabbit
+    // review, PR #329).
+    if (_alarm.targetEpoch != epoch) return false;
+    return _alarm.confirmed ||
+        _alarm.isPending(DateTime.now().millisecondsSinceEpoch);
+  }
 
   // ── alarm confirmation state machine ────────────────────────────────────────
   // The strap CONFIRMS an alarm actually latched via event 56 (ALARM_SET) and
@@ -4090,6 +4139,8 @@ class AppState extends ChangeNotifier {
     _alarmAutoRetried = false; // a fresh arm gets its one retry
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt('alarm_epoch', epoch);
+    // Not confirmed yet — event 56 (below, in _handleAlarmEvent) flips this.
+    await prefs.setBool('alarm_epoch_confirmed', false);
     // Nudge the UI once the grace window elapses so an unconfirmed alarm flips to
     // its soft warning even if no event ever arrives.
     _armAlarmGraceTimer(when);
@@ -4213,6 +4264,7 @@ class AppState extends ChangeNotifier {
     _alarmGraceTimer?.cancel();
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('alarm_epoch');
+    await prefs.remove('alarm_epoch_confirmed');
     await LocalDb.clearAlarmSchedule();
     _schedule = fillDefaultAlarmSchedule(const []);
     notifyListeners();
@@ -4235,6 +4287,14 @@ class AppState extends ChangeNotifier {
         // Diagnostic: ALARM_SET (event 56) means the arm LATCHED on the band.
         // Its absence after a SET is the tell that the write never took.
         _log('[alarm] strap CONFIRMED arm — ALARM_SET (event $id) received.');
+        unawaited(() async {
+          try {
+            final prefs = await SharedPreferences.getInstance();
+            await prefs.setBool('alarm_epoch_confirmed', true);
+          } catch (e) {
+            _log('[alarm] persisting confirmation failed: $e');
+          }
+        }());
         break;
       case AlarmEffect.fired:
         _log('[alarm] strap FIRED — EXECUTED (event $id) received.');
@@ -4269,6 +4329,7 @@ class AppState extends ChangeNotifier {
       try {
         final prefs = await SharedPreferences.getInstance();
         await prefs.remove('alarm_epoch');
+        await prefs.remove('alarm_epoch_confirmed');
       } catch (e) {
         _log('[alarm] clearing the persisted epoch failed: $e');
       }

--- a/lib/sync/background_sync.dart
+++ b/lib/sync/background_sync.dart
@@ -139,12 +139,32 @@ Future<bool> runHeadlessSync({BandLease? lease}) async {
             AlarmScheduleEntry.fromRow(r),
         ]);
         final prefs = await SharedPreferences.getInstance();
-        final epoch = await armNextScheduledOccurrence(
+        final result = await armNextScheduledOccurrence(
           engine: engine,
           schedule: schedule,
           currentArmedEpoch: prefs.getInt('alarm_epoch'),
         );
-        if (epoch != null) await prefs.setInt('alarm_epoch', epoch);
+        if (result.disabled) {
+          await prefs.remove('alarm_epoch');
+          await prefs.remove('alarm_epoch_confirmed');
+        } else if (result.epoch != null) {
+          final epoch = result.epoch!;
+          // No live AppState here to catch a late ALARM_SET (event 56) the way
+          // the foreground grace timer does, so wait for it inline — same
+          // grace window as AlarmConfirmation's default (6s) — before this
+          // headless connection closes. Not confirmed within that window still
+          // persists the epoch (optimistic, matching the foreground write) but
+          // as unconfirmed, so the 7pm safety check (AppState._alarmArmedTonight)
+          // won't wrongly treat an un-latched headless arm as covering tonight.
+          final armedAtMs = DateTime.now().millisecondsSinceEpoch;
+          var confirmed = false;
+          for (var i = 0; i < 6 && !confirmed; i++) {
+            await Future.delayed(const Duration(milliseconds: 1000));
+            confirmed = await LocalDb.alarmSetConfirmedSince(armedAtMs);
+          }
+          await prefs.setInt('alarm_epoch', epoch);
+          await prefs.setBool('alarm_epoch_confirmed', confirmed);
+        }
       } catch (e) {
         debugPrint('[bgsync] alarm re-arm skipped: $e');
       }

--- a/lib/sync/background_sync.dart
+++ b/lib/sync/background_sync.dart
@@ -24,6 +24,7 @@ import '../compute/profile.dart';
 import '../data/db.dart';
 import '../notify/notification_center.dart';
 import '../notify/notification_event.dart';
+import '../state/alarm_schedule.dart';
 import 'band_ownership.dart';
 import 'high_freq_wake_window.dart';
 import 'paired_device.dart';
@@ -127,6 +128,26 @@ Future<bool> runHeadlessSync({BandLease? lease}) async {
       // and the next wake resumes from the (now-advanced) cursor. No live streams
       // (battery): connect → listen → store → ACK → derive → disconnect.
       await engine.runSync();
+      // Feature 1's arming engine, headless half: "on every successful
+      // connect AND after each headless sync". No AppState here, so the
+      // schedule read and the `alarm_epoch` persistence go straight through
+      // LocalDb/SharedPreferences — the same store the foreground path uses,
+      // so whichever side runs next sees a consistent value.
+      try {
+        final schedule = fillDefaultAlarmSchedule([
+          for (final r in await LocalDb.alarmScheduleRows())
+            AlarmScheduleEntry.fromRow(r),
+        ]);
+        final prefs = await SharedPreferences.getInstance();
+        final epoch = await armNextScheduledOccurrence(
+          engine: engine,
+          schedule: schedule,
+          currentArmedEpoch: prefs.getInt('alarm_epoch'),
+        );
+        if (epoch != null) await prefs.setInt('alarm_epoch', epoch);
+      } catch (e) {
+        debugPrint('[bgsync] alarm re-arm skipped: $e');
+      }
     } finally {
       await engine.disconnect();
     }

--- a/lib/ui2/profile/alarm.dart
+++ b/lib/ui2/profile/alarm.dart
@@ -14,14 +14,23 @@
 // confirmation at all — only the epoch we wrote down. Three different states,
 // and the screen says which one it is rather than drawing a confident green
 // tick over all three.
+//
+// A single next-occurrence time picker used to live here. It is gone: the
+// weekly schedule below is now the ONLY thing that arms the band (AppState
+// computes the next enabled occurrence on every connect/sync), so a second,
+// independent "set one alarm" affordance would just be a second source of
+// truth that the schedule engine silently overwrites on the next sync.
 
 import 'package:flutter/material.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
 
 import '../../l10n/app_localizations.dart';
+import '../../state/alarm_schedule.dart';
 import '../../state/app_state.dart';
+import '../screens/home_screen.dart' show weekdayShortName;
 import '../ui2.dart';
+import 'profile.dart' show SetRow, settingsGroup;
 
 /// What we actually know about the armed alarm.
 enum AlarmArmState {
@@ -61,7 +70,11 @@ class AlarmScreen extends StatelessWidget {
                   ? AlarmArmState.pending
                   : AlarmArmState.unknown,
       connected: app.isConnected,
-      onSet: (when) => app.setAlarm(when),
+      schedule: app.alarmSchedule,
+      onToggleDay: (weekday, enabled) =>
+          app.setScheduleDay(weekday: weekday, enabled: enabled),
+      onSetDayTime: (weekday, hour, minute) =>
+          app.setScheduleDay(weekday: weekday, hour: hour, minute: minute),
       onTest: app.testAlarmBuzz,
       onCancel: app.disableAlarm,
     );
@@ -77,9 +90,17 @@ class AlarmScreenView extends StatelessWidget {
   /// this screen is otherwise a function of when the suite happens to run.
   final DateTime? now;
 
-  /// All three talk to the band and all three throw when it is not connected —
-  /// the screen reports the failure rather than pretending it worked.
-  final Future<void> Function(DateTime when)? onSet;
+  /// Always exactly 7 entries in weekday order — see
+  /// `fillDefaultAlarmSchedule` in state/alarm_schedule.dart, which is what
+  /// [AppState.alarmSchedule] guarantees.
+  final List<AlarmScheduleEntry> schedule;
+
+  /// All four talk to the band or its schedule and all throw when it is not
+  /// connected — the screen reports the failure rather than pretending it
+  /// worked.
+  final Future<void> Function(int weekday, bool enabled)? onToggleDay;
+  final Future<void> Function(int weekday, int hour, int minute)?
+      onSetDayTime;
   final Future<void> Function()? onTest, onCancel;
 
   const AlarmScreenView({
@@ -88,7 +109,9 @@ class AlarmScreenView extends StatelessWidget {
     this.state = AlarmArmState.none,
     this.connected = false,
     this.now,
-    this.onSet,
+    this.schedule = const [],
+    this.onToggleDay,
+    this.onSetDayTime,
     this.onTest,
     this.onCancel,
   });
@@ -98,6 +121,7 @@ class AlarmScreenView extends StatelessWidget {
     final p = P.of(c);
     final l = AppLocalizations.of(c);
     final at = armedAt;
+    final anyDayEnabled = schedule.any((d) => d.enabled);
     return Scaffold(
       backgroundColor: p.bg,
       body: SafeArea(
@@ -116,10 +140,10 @@ class AlarmScreenView extends StatelessWidget {
                     child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text(l?.alarmArmedFor ?? 'ARMED FOR',
+                          Text(l?.alarmNextLabel ?? 'NEXT',
                               style: F.over.copyWith(color: p.ink3)),
                           const SizedBox(height: S.x1),
-                          Text(_hhmm(at),
+                          Text(_dayAndTime(c, at),
                               style: F.n48.copyWith(color: p.ink)),
                           Text(_whichDay(c, at, now ?? DateTime.now()),
                               style: F.cap.copyWith(color: p.ink2)),
@@ -133,24 +157,39 @@ class AlarmScreenView extends StatelessWidget {
                     StatusCard(_stateHeadline(c, state), detail,
                         icon: _stateIcon(state)),
                   ],
+                  const SizedBox(height: S.x4),
                 ],
-                const SizedBox(height: S.x4),
                 if (!connected)
                   StatusCard(
                     l?.alarmNotConnectedTitle ?? 'The band is not connected',
                     l?.alarmNotConnectedBody ??
-                        'Setting, testing and cancelling all write to the band, so '
-                            'they need a live connection. An alarm that is already '
-                            'armed is unaffected — it lives on the band.',
+                        'Changing the schedule, testing and cancelling all '
+                            'write to the band, so they need a live '
+                            'connection. An alarm that is already armed is '
+                            'unaffected — it lives on the band.',
                     icon: LucideIcons.bluetoothOff,
                   )
                 else ...[
-                  BigButton(
-                      at == null
-                          ? (l?.alarmSetAnAlarm ?? 'Set an alarm')
-                          : (l?.alarmChangeTheTime ?? 'Change the time'),
-                      icon: LucideIcons.clock,
-                      onTap: () => _pick(c, at)),
+                  settingsGroup(c, l?.alarmScheduleGroup ?? 'Weekly schedule', [
+                    for (final day in schedule) ...[
+                      SetRow(
+                          LucideIcons.calendarDays,
+                          C.orange,
+                          _weekdayLabel(c, day.weekday),
+                          value: day.enabled
+                              ? (l?.stateOn ?? 'On')
+                              : (l?.stateOff ?? 'Off'),
+                          chevron: false,
+                          onTap: () =>
+                              onToggleDay?.call(day.weekday, !day.enabled)),
+                      if (day.enabled)
+                        SetRow(LucideIcons.clock, C.blue,
+                            l?.alarmWakeTimeRowTitle ?? 'Wake time',
+                            value: _hhmmOf(day.hour, day.minute),
+                            chevron: false,
+                            onTap: () => _pickDayTime(c, day)),
+                    ],
+                  ]),
                   const SizedBox(height: S.x3),
                   if (at != null) ...[
                     BigButton(l?.alarmTestTheBuzz ?? 'Test the buzz',
@@ -160,13 +199,14 @@ class AlarmScreenView extends StatelessWidget {
                         onTap: () => _run(
                             c, onTest, l?.alarmBuzzingTheBand ?? 'Buzzing the band')),
                     const SizedBox(height: S.x3),
+                  ],
+                  if (at != null || anyDayEnabled)
                     BigButton(l?.alarmCancelTheAlarm ?? 'Cancel the alarm',
                         icon: LucideIcons.bellOff,
                         color: C.red,
                         soft: true,
                         onTap: () => _run(
                             c, onCancel, l?.alarmCancelled ?? 'Alarm cancelled')),
-                  ],
                 ],
               ],
             ),
@@ -176,31 +216,20 @@ class AlarmScreenView extends StatelessWidget {
     );
   }
 
-  Future<void> _pick(BuildContext c, DateTime? current) async {
-    final wall = DateTime.now();
+  Future<void> _pickDayTime(BuildContext c, AlarmScheduleEntry day) async {
     final picked = await showTimePicker(
       context: c,
-      initialTime: TimeOfDay.fromDateTime(current ?? wall),
+      initialTime: TimeOfDay(hour: day.hour, minute: day.minute),
     );
     if (picked == null || !c.mounted) return;
-    await _run(c, () => onSet!(nextAt(picked.hour, picked.minute, wall)),
+    await _run(
+        c,
+        () => onSetDayTime!(day.weekday, picked.hour, picked.minute),
         AppLocalizations.of(c)?.alarmSentToBand ?? 'Alarm sent to the band');
   }
 
-  /// The next wall-clock instant at [hour]:[minute], today if it is still
-  /// ahead, otherwise tomorrow. CALENDAR arithmetic — `add(Duration(days: 1))`
-  /// is 24 elapsed hours, which is a different wall-clock time across a DST
-  /// change and would arm the alarm an hour out.
-  @visibleForTesting
-  static DateTime nextAt(int hour, int minute, DateTime now) {
-    final today = DateTime(now.year, now.month, now.day, hour, minute);
-    return today.isAfter(now)
-        ? today
-        : DateTime(now.year, now.month, now.day + 1, hour, minute);
-  }
-
-  /// Run a band write and report what happened. Every one of these throws when
-  /// the band is not connected, and silence would read as success.
+  /// Run a band/schedule write and report what happened. Every one of these
+  /// throws when the band is not connected, and silence would read as success.
   static Future<void> _run(
       BuildContext c, Future<void> Function()? action, String ok) async {
     if (action == null) return;
@@ -215,8 +244,22 @@ class AlarmScreenView extends StatelessWidget {
   static void _say(BuildContext c, String msg) =>
       ScaffoldMessenger.of(c).showSnackBar(SnackBar(content: Text(msg)));
 
-  static String _hhmm(DateTime d) =>
-      '${d.hour.toString().padLeft(2, '0')}:${d.minute.toString().padLeft(2, '0')}';
+  static String _hhmm(DateTime d) => _hhmmOf(d.hour, d.minute);
+
+  static String _hhmmOf(int hour, int minute) =>
+      '${hour.toString().padLeft(2, '0')}:${minute.toString().padLeft(2, '0')}';
+
+  /// "Tue 07:30" — the weekday plus the time, both from the ARMED instant
+  /// (not merely from the schedule row), so this never claims a day the band
+  /// hasn't actually latched yet.
+  static String _dayAndTime(BuildContext c, DateTime at) =>
+      '${weekdayShortName(at.weekday, AppLocalizations.of(c))} ${_hhmm(at)}';
+
+  /// Short weekday label for a schedule row. [weekday] is the 0=Mon..6=Sun
+  /// convention `AlarmScheduleEntry` uses; `weekdayShortName` wants
+  /// `DateTime.weekday` (1=Mon..7=Sun), hence the `+ 1`.
+  static String _weekdayLabel(BuildContext c, int weekday) =>
+      weekdayShortName(weekday + 1, AppLocalizations.of(c));
 
   static String _whichDay(BuildContext c, DateTime d, DateTime now) {
     final l = AppLocalizations.of(c);

--- a/lib/ui2/profile/settings.dart
+++ b/lib/ui2/profile/settings.dart
@@ -948,6 +948,34 @@ class NotificationSettingsView extends StatelessWidget {
                         chevron: false,
                         onTap: () => set(prefs.copyWith(
                             deviceEnabled: !prefs.deviceEnabled))),
+                    // On by default, unlike the reminders below: this exists to
+                    // catch a wake alarm that silently isn't going to fire, and
+                    // starting silent would defeat the point.
+                    SetRow(LucideIcons.alarmClock, C.red,
+                        l?.settingsAlarmLatchFailedRowTitle ??
+                            'Alarm not confirmed',
+                        sub: l?.settingsAlarmLatchFailedRowSub ??
+                            'Warn when the band never confirms an alarm this '
+                                'app just armed',
+                        value: prefs.alarmLatchFailedEnabled ? on : off,
+                        chevron: false,
+                        onTap: () => set(prefs.copyWith(
+                            alarmLatchFailedEnabled:
+                                !prefs.alarmLatchFailedEnabled))),
+                    // Also on by default, same reasoning: silent whenever an
+                    // alarm IS armed for tonight, so it only ever speaks up
+                    // about a real gap.
+                    SetRow(LucideIcons.moon, C.red,
+                        l?.settingsAlarmNightCheckRowTitle ??
+                            'No-alarm check-in',
+                        sub: l?.settingsAlarmNightCheckRowSub ??
+                            'A 7pm heads-up on any night with no wake alarm '
+                                'armed — silent otherwise',
+                        value: prefs.alarmNightCheckEnabled ? on : off,
+                        chevron: false,
+                        onTap: () => set(prefs.copyWith(
+                            alarmNightCheckEnabled:
+                                !prefs.alarmNightCheckEnabled))),
                     // The low-battery threshold, only while band alerts are
                     // on — an interval for a muted alert is furniture, same
                     // rule as the water row below.

--- a/test/alarm_schedule_test.dart
+++ b/test/alarm_schedule_test.dart
@@ -1,0 +1,124 @@
+// The weekly alarm schedule's pure occurrence math:
+//   - fillDefaultAlarmSchedule always produces exactly 7 entries,
+//   - nextAlarmOccurrence (week wrap, disabled days, same-time-skip), and
+//   - seedEntryFromLegacyEpoch's weekday mapping for the 49→50 migration seed.
+// No radio, no DB — everything here is deterministic.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:openstrap_edge/state/alarm_schedule.dart';
+
+void main() {
+  group('fillDefaultAlarmSchedule', () {
+    test('an empty stored list becomes 7 disabled default-time entries', () {
+      final schedule = fillDefaultAlarmSchedule(const []);
+      expect(schedule.length, 7);
+      for (var w = 0; w < 7; w++) {
+        expect(schedule[w].weekday, w);
+        expect(schedule[w].hour, defaultAlarmHour);
+        expect(schedule[w].minute, defaultAlarmMinute);
+        expect(schedule[w].enabled, isFalse);
+      }
+    });
+
+    test('a configured weekday is kept, everything else still defaults', () {
+      final schedule = fillDefaultAlarmSchedule(const [
+        AlarmScheduleEntry(weekday: 2, hour: 6, minute: 45, enabled: true),
+      ]);
+      expect(schedule.length, 7);
+      expect(schedule[2], const AlarmScheduleEntry(
+          weekday: 2, hour: 6, minute: 45, enabled: true));
+      expect(schedule[0].enabled, isFalse);
+      expect(schedule[6].enabled, isFalse);
+    });
+  });
+
+  group('nextAlarmOccurrence', () {
+    // Wednesday 2026-08-19.
+    final wed = DateTime(2026, 8, 19, 8, 0);
+
+    test('empty schedule → null', () {
+      expect(nextAlarmOccurrence(const [], wed), isNull);
+    });
+
+    test('every day disabled → null', () {
+      final schedule = fillDefaultAlarmSchedule(const []);
+      expect(nextAlarmOccurrence(schedule, wed), isNull);
+    });
+
+    test('disabled days are skipped — only the enabled one is considered', () {
+      // Monday (0) enabled at 07:00; every other day left disabled.
+      final schedule = fillDefaultAlarmSchedule(const [
+        AlarmScheduleEntry(weekday: 0, hour: 7, minute: 0, enabled: true),
+      ]);
+      // From Wednesday, the next Monday is 5 days ahead.
+      final next = nextAlarmOccurrence(schedule, wed);
+      expect(next, DateTime(2026, 8, 24, 7, 0));
+      expect(next!.weekday, DateTime.monday);
+    });
+
+    test('a time later today is today, not next week', () {
+      // Wednesday (2) enabled at 20:00 — still ahead of the 08:00 "now".
+      final schedule = fillDefaultAlarmSchedule(const [
+        AlarmScheduleEntry(weekday: 2, hour: 20, minute: 0, enabled: true),
+      ]);
+      expect(nextAlarmOccurrence(schedule, wed), DateTime(2026, 8, 19, 20, 0));
+    });
+
+    test('a time already past today wraps to NEXT week, not tomorrow', () {
+      // Wednesday (2) enabled at 06:00 — already past the 08:00 "now", and
+      // Wednesday is the only enabled day, so the next one is 7 days out.
+      final schedule = fillDefaultAlarmSchedule(const [
+        AlarmScheduleEntry(weekday: 2, hour: 6, minute: 0, enabled: true),
+      ]);
+      expect(nextAlarmOccurrence(schedule, wed), DateTime(2026, 8, 26, 6, 0));
+    });
+
+    test('the exact same minute as "now" is treated as past (same-time-skip)',
+        () {
+      // Wednesday (2) enabled at exactly 08:00 == "now" — must not arm for
+      // right now; the next occurrence is a full week out.
+      final schedule = fillDefaultAlarmSchedule(const [
+        AlarmScheduleEntry(weekday: 2, hour: 8, minute: 0, enabled: true),
+      ]);
+      expect(nextAlarmOccurrence(schedule, wed), DateTime(2026, 8, 26, 8, 0));
+    });
+
+    test('picks the SOONEST occurrence across multiple enabled days', () {
+      final schedule = fillDefaultAlarmSchedule(const [
+        AlarmScheduleEntry(weekday: 0, hour: 7, minute: 0, enabled: true), // Mon
+        AlarmScheduleEntry(weekday: 4, hour: 6, minute: 30, enabled: true), // Fri
+      ]);
+      // From Wednesday 08:00, Friday 06:30 (2 days out) beats Monday (5 days).
+      expect(
+          nextAlarmOccurrence(schedule, wed), DateTime(2026, 8, 21, 6, 30));
+    });
+
+    test('week wrap preserves the wall-clock time across a DST boundary', () {
+      // 8 March 2026 is a US spring-forward Sunday. A Sunday-only schedule
+      // from the Sunday before must land on 06:30 local the following Sunday,
+      // not 05:30/07:30 from a naive 7×24h elapsed-hours add.
+      final schedule = fillDefaultAlarmSchedule(const [
+        AlarmScheduleEntry(weekday: 6, hour: 6, minute: 30, enabled: true), // Sun
+      ]);
+      final now = DateTime(2026, 3, 1, 23, 0); // Sunday 2026-03-01
+      final next = nextAlarmOccurrence(schedule, now);
+      expect(next, DateTime(2026, 3, 8, 6, 30));
+      expect(next!.hour, 6);
+      expect(next.minute, 30);
+    });
+  });
+
+  group('seedEntryFromLegacyEpoch', () {
+    test('maps a legacy epoch onto its local weekday/hour/minute, enabled', () {
+      // 2026-08-19 06:30 LOCAL is a Wednesday → DateTime.weekday 3 → column 2.
+      final at = DateTime(2026, 8, 19, 6, 30);
+      final epoch = at.millisecondsSinceEpoch ~/ 1000;
+      final seed = seedEntryFromLegacyEpoch(epoch);
+      expect(seed.weekday, at.weekday - 1);
+      expect(seed.hour, 6);
+      expect(seed.minute, 30);
+      expect(seed.enabled, isTrue);
+    });
+  });
+}

--- a/test/alarm_schedule_test.dart
+++ b/test/alarm_schedule_test.dart
@@ -109,6 +109,42 @@ void main() {
     });
   });
 
+  group('alarmArmsTonight', () {
+    // Wednesday 2026-08-19, 19:00 — the 7pm check-in instant.
+    final now = DateTime(2026, 8, 19, 19, 0);
+    int epochOf(DateTime at) => at.millisecondsSinceEpoch ~/ 1000;
+
+    test('arm for tomorrow 07:00 is TRUE — the overnight wake alarm (bug case)',
+        () {
+      expect(alarmArmsTonight(epochOf(DateTime(2026, 8, 20, 7, 0)), now),
+          isTrue);
+    });
+
+    test('arm for later today (23:00) is TRUE', () {
+      expect(alarmArmsTonight(epochOf(DateTime(2026, 8, 19, 23, 0)), now),
+          isTrue);
+    });
+
+    test('arm for day-after-tomorrow 07:00 is FALSE — not tonight', () {
+      expect(alarmArmsTonight(epochOf(DateTime(2026, 8, 21, 7, 0)), now),
+          isFalse);
+    });
+
+    test('an arm epoch already in the past is FALSE', () {
+      expect(alarmArmsTonight(epochOf(DateTime(2026, 8, 19, 6, 0)), now),
+          isFalse);
+    });
+
+    test('a null epoch is FALSE', () {
+      expect(alarmArmsTonight(null, now), isFalse);
+    });
+
+    test('boundary: an arm exactly at noon tomorrow is FALSE (exclusive)', () {
+      expect(alarmArmsTonight(epochOf(DateTime(2026, 8, 20, 12, 0)), now),
+          isFalse);
+    });
+  });
+
   group('seedEntryFromLegacyEpoch', () {
     test('maps a legacy epoch onto its local weekday/hour/minute, enabled', () {
       // 2026-08-19 06:30 LOCAL is a Wednesday → DateTime.weekday 3 → column 2.

--- a/test/alarm_test.dart
+++ b/test/alarm_test.dart
@@ -15,6 +15,7 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openstrap_edge/ble/ble_engine.dart';
 import 'package:openstrap_edge/ble/ble_state.dart';
+import 'package:openstrap_edge/state/alarm_schedule.dart' show alarmLatchFailed;
 import 'package:openstrap_edge/sync/sync_policy.dart' show ClockRef;
 import 'package:openstrap_protocol/openstrap_protocol.dart' as proto;
 
@@ -324,6 +325,46 @@ void main() {
       expect(a.onEvent(proto.EventId.wristOn, 5), isNull);
       expect(a.confirmed, isFalse);
       expect(a.targetEpoch, 1750000000);
+    });
+  });
+
+  // The pure decision behind AppState._notifyAlarmLatchFailed (Feature 2.1):
+  // whether the "alarm not confirmed" safety notification should fire for a
+  // given epoch, given the toggle and the CURRENT confirmation state. No
+  // notification plumbing here — the OS-facing side is exercised separately.
+  group('alarmLatchFailed (safety notification gate)', () {
+    test('fires when the toggle is on, the epoch is still the target, and it '
+        'never confirmed', () {
+      final a = AlarmConfirmation()..set(1750000000, 0);
+      expect(alarmLatchFailed(a, 1750000000, enabled: true), isTrue);
+    });
+
+    test('the toggle off overrides everything else', () {
+      final a = AlarmConfirmation()..set(1750000000, 0);
+      expect(alarmLatchFailed(a, 1750000000, enabled: false), isFalse);
+    });
+
+    test('a confirmed alarm never fires it, even with the toggle on', () {
+      final a = AlarmConfirmation()..set(1750000000, 0);
+      a.onEvent(AlarmConfirmation.kEvtSet, 10);
+      expect(alarmLatchFailed(a, 1750000000, enabled: true), isFalse);
+    });
+
+    test('a superseded epoch (a newer arm, or a cancel) does not fire the '
+        'STALE one\'s notification', () {
+      final a = AlarmConfirmation()..set(1750000000, 0);
+      a.set(1750003600, 100); // a fresh arm replaced the pending one
+      expect(alarmLatchFailed(a, 1750000000, enabled: true), isFalse,
+          reason: 'that epoch is no longer what this machine is tracking');
+      // The NEW target, still unconfirmed, is what should fire instead.
+      expect(alarmLatchFailed(a, 1750003600, enabled: true), isTrue);
+    });
+
+    test('a disabled/cleared alarm (targetEpoch null) never fires it', () {
+      final a = AlarmConfirmation()
+        ..set(1750000000, 0)
+        ..disable();
+      expect(alarmLatchFailed(a, 1750000000, enabled: true), isFalse);
     });
   });
 

--- a/test/db_alarm_schedule_migration_test.dart
+++ b/test/db_alarm_schedule_migration_test.dart
@@ -1,0 +1,128 @@
+// Migration 49→50: the `alarm_schedule` table. CREATE TABLE IF NOT EXISTS,
+// no backfill, no rewrite — see db.dart's v50 rung doc for why that additive
+// shape is what keeps a throw here from bricking the whole upgrade ladder
+// (invariant 11). Run against REAL sqflite_ffi, same idiom as
+// db_migration_ladder_test.dart.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:openstrap_edge/data/db.dart';
+
+Future<String> _dbPath(String name) async =>
+    p.join(await databaseFactory.getDatabasesPath(), name);
+
+/// A v49 database with no tables at all — `_repairOpenSchema`'s self-heal
+/// (every `_create*` is CREATE TABLE IF NOT EXISTS) backfills everything else
+/// this ladder needs, so an empty seed is enough to isolate the v50 rung.
+Future<void> _seedEmptyV49Db(String name) async {
+  final path = await _dbPath(name);
+  await databaseFactory.deleteDatabase(path);
+  final db = await databaseFactory.openDatabase(
+    path,
+    options: OpenDatabaseOptions(version: 49, onCreate: (db, _) async {}),
+  );
+  await db.close();
+}
+
+/// Open [name] through LocalDb (running the real ladder) and hand back the
+/// resulting `PRAGMA user_version`.
+Future<int> _openThroughLocalDb(String name) async {
+  await LocalDb.close();
+  LocalDb.lastRebuild = null;
+  LocalDb.dbName = name;
+  final db = await LocalDb.instance;
+  // THE LADDER, not the quarantine-and-rebuild safety net — see
+  // db_migration_ladder_test.dart's identical guard for why this matters.
+  expect(LocalDb.lastRebuild, isNull,
+      reason: 'the upgrade bricked and fell back to quarantine-and-rebuild: '
+          '${LocalDb.lastRebuild?.cause}');
+  final rows = await db.rawQuery('PRAGMA user_version');
+  return (rows.first.values.first as num?)?.toInt() ?? -1;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final created = <String>[];
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  tearDownAll(() async {
+    await LocalDb.close();
+    for (final name in created) {
+      await databaseFactory.deleteDatabase(await _dbPath(name));
+    }
+  });
+
+  test(
+      'upgrade from v49 reaches schemaVersion 50 and creates alarm_schedule '
+      'keyed on weekday', () async {
+    const name = 'openstrap_alarm_schedule_migration_test.db';
+    created.add(name);
+    await _seedEmptyV49Db(name);
+    final version = await _openThroughLocalDb(name);
+    expect(LocalDb.schemaVersion, 50);
+    expect(version, LocalDb.schemaVersion);
+
+    final db = await LocalDb.instance;
+    final cols = await db.rawQuery('PRAGMA table_info(alarm_schedule)');
+    final names = cols.map((c) => c['name'] as String).toSet();
+    expect(names, {'weekday', 'hour', 'minute', 'enabled'});
+    final weekdayCol = cols.firstWhere((c) => c['name'] == 'weekday');
+    expect((weekdayCol['pk'] as num).toInt(), 1,
+        reason: 'weekday must be the PRIMARY KEY');
+
+    final health = await LocalDb.schemaHealth();
+    expect(health['ok'], isTrue, reason: '$health');
+  });
+
+  test('a fresh install (onCreate) also has alarm_schedule', () async {
+    const name = 'openstrap_alarm_schedule_fresh_test.db';
+    created.add(name);
+    await databaseFactory.deleteDatabase(await _dbPath(name));
+    await LocalDb.close();
+    LocalDb.lastRebuild = null;
+    LocalDb.dbName = name;
+    final db = await LocalDb.instance;
+    final cols = await db.rawQuery('PRAGMA table_info(alarm_schedule)');
+    expect(cols, isNotEmpty);
+  });
+
+  test(
+      'setAlarmScheduleDay / alarmScheduleRows / clearAlarmSchedule round-trip '
+      'through the real table, upserting rather than duplicating a weekday',
+      () async {
+    const name = 'openstrap_alarm_schedule_crud_test.db';
+    created.add(name);
+    await databaseFactory.deleteDatabase(await _dbPath(name));
+    await LocalDb.close();
+    LocalDb.lastRebuild = null;
+    LocalDb.dbName = name;
+    await LocalDb.instance;
+
+    await LocalDb.setAlarmScheduleDay(
+        weekday: 0, hour: 7, minute: 30, enabled: true);
+    await LocalDb.setAlarmScheduleDay(
+        weekday: 3, hour: 6, minute: 0, enabled: false);
+    var rows = await LocalDb.alarmScheduleRows();
+    expect(rows.length, 2);
+
+    // Re-setting weekday 0 upserts (PRIMARY KEY (weekday)) — it must not
+    // leave a stale second row behind.
+    await LocalDb.setAlarmScheduleDay(
+        weekday: 0, hour: 8, minute: 0, enabled: true);
+    rows = await LocalDb.alarmScheduleRows();
+    expect(rows.length, 2);
+    final mon = rows.firstWhere((r) => r['weekday'] == 0);
+    expect(mon['hour'], 8);
+    expect(mon['minute'], 0);
+    expect(mon['enabled'], 1);
+
+    await LocalDb.clearAlarmSchedule();
+    expect(await LocalDb.alarmScheduleRows(), isEmpty);
+  });
+}

--- a/test/notification_wiring_test.dart
+++ b/test/notification_wiring_test.dart
@@ -149,6 +149,46 @@ void main() {
     });
   });
 
+  group('alarmNightCheckSlot', () {
+    test('off switch wins even with nothing armed for tonight', () {
+      expect(
+          NotificationCenter.alarmNightCheckSlot(
+              const NotificationPrefs(alarmNightCheckEnabled: false),
+              armedTonight: false,
+              nowMin: 12 * 60),
+          isNull);
+    });
+
+    test('an alarm armed for tonight silences it — the whole point is the gap',
+        () {
+      expect(
+          NotificationCenter.alarmNightCheckSlot(
+              const NotificationPrefs(alarmNightCheckEnabled: true),
+              armedTonight: true,
+              nowMin: 12 * 60),
+          isNull);
+    });
+
+    test('nothing armed for tonight, before 19:00 → the 19:00 slot', () {
+      expect(
+          NotificationCenter.alarmNightCheckSlot(
+              const NotificationPrefs(alarmNightCheckEnabled: true),
+              armedTonight: false,
+              nowMin: 12 * 60),
+          NotificationCenter.alarmNightCheckHour * 60);
+    });
+
+    test('after 19:00 today, nothing is armed — a one-shot would land a day '
+        'late', () {
+      expect(
+          NotificationCenter.alarmNightCheckSlot(
+              const NotificationPrefs(alarmNightCheckEnabled: true),
+              armedTonight: false,
+              nowMin: 20 * 60),
+          isNull);
+    });
+  });
+
   group('weeklyLookbackFinding', () {
     test('an empty week says nothing', () {
       expect(NotificationCenter.weeklyLookbackFinding(const []), isNull);

--- a/test/ui2_alarm_test.dart
+++ b/test/ui2_alarm_test.dart
@@ -1,49 +1,18 @@
-// The band alarm's two pieces of real logic.
+// The band alarm screen's one piece of real logic left in the screen itself:
+// the mapping that decides what it is allowed to claim about confirmation.
+// (The single next-occurrence picker — and its `nextAt` arithmetic — is gone;
+// the weekly schedule in state/alarm_schedule.dart is now the only thing that
+// arms the band, and its occurrence math is tested there, with no widget tree
+// needed.)
 //
-// The screen is otherwise a rendering of AppState, and its layout is covered by
-// the profile goldens. What is worth a test is the arithmetic that decides WHEN
-// the alarm is armed for, and the mapping that decides what the screen is
-// allowed to claim about it.
+// The screen is otherwise a rendering of AppState, and its layout is covered
+// by the profile goldens.
 
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:openstrap_edge/ui2/profile/alarm.dart';
 
 void main() {
-  group('nextAt', () {
-    test('a time still ahead is today', () {
-      final now = DateTime(2026, 8, 21, 5, 0);
-      expect(AlarmScreenView.nextAt(6, 30, now), DateTime(2026, 8, 21, 6, 30));
-    });
-
-    test('a time already past rolls to tomorrow', () {
-      final now = DateTime(2026, 8, 21, 22, 40);
-      expect(AlarmScreenView.nextAt(6, 30, now), DateTime(2026, 8, 22, 6, 30));
-    });
-
-    test('the same minute is treated as past — never arm for right now', () {
-      final now = DateTime(2026, 8, 21, 6, 30);
-      expect(AlarmScreenView.nextAt(6, 30, now), DateTime(2026, 8, 22, 6, 30));
-    });
-
-    test('month and year rollover is calendar arithmetic', () {
-      expect(AlarmScreenView.nextAt(6, 30, DateTime(2026, 8, 31, 23, 0)),
-          DateTime(2026, 9, 1, 6, 30));
-      expect(AlarmScreenView.nextAt(6, 30, DateTime(2026, 12, 31, 23, 0)),
-          DateTime(2027, 1, 1, 6, 30));
-    });
-
-    test('the wall-clock time is preserved across a DST boundary', () {
-      // 8 March 2026 is a US spring-forward. `add(Duration(days: 1))` from the
-      // 7th is 24 ELAPSED hours, which is 07:30 local on the 8th, not 06:30 —
-      // an alarm an hour late on the one morning nobody wants one.
-      final armed = AlarmScreenView.nextAt(6, 30, DateTime(2026, 3, 7, 23, 0));
-      expect(armed.day, 8);
-      expect(armed.hour, 6);
-      expect(armed.minute, 30);
-    });
-  });
-
   group('what the screen may claim', () {
     test('an unconfirmed alarm never says it will fire', () {
       // The band confirms separately (event 56) and might never do so; after a

--- a/test/ui2_onboarding_profile_golden_test.dart
+++ b/test/ui2_onboarding_profile_golden_test.dart
@@ -22,6 +22,7 @@ import 'package:provider/provider.dart';
 
 import 'package:openstrap_edge/notify/notification_prefs.dart';
 import 'package:openstrap_edge/platform/app_icon.dart';
+import 'package:openstrap_edge/state/alarm_schedule.dart';
 import 'package:openstrap_edge/state/locale_controller.dart';
 import 'package:openstrap_edge/ui2/onboarding/pairing.dart';
 import 'package:openstrap_edge/ui2/onboarding/profile_setup.dart';
@@ -39,7 +40,15 @@ final _synced = DateTime(2026, 8, 22, 7, 12);
 /// The alarm screen renders a relative day ("Tomorrow"), so both ends of that
 /// comparison are pinned or the golden is a function of when the suite runs.
 final _alarmNow = DateTime(2026, 8, 21, 22, 40);
-final _alarmAt = DateTime(2026, 8, 22, 6, 30);
+final _alarmAt = DateTime(2026, 8, 22, 6, 30); // Saturday → weekday index 5.
+
+/// A representative weekly schedule: Saturday matches [_alarmAt] above (so
+/// the armed-instant card and the schedule row agree, like a real one would),
+/// Wednesday is a second enabled day, everything else is off.
+final _alarmSchedule = fillDefaultAlarmSchedule(const [
+  AlarmScheduleEntry(weekday: 5, hour: 6, minute: 30, enabled: true),
+  AlarmScheduleEntry(weekday: 2, hour: 7, minute: 0, enabled: true),
+]);
 
 final _band = HealthSource(
   name: 'WHOOP 4.0',
@@ -105,13 +114,14 @@ Map<String, Widget> _cases() => {
       // The alarm's three confirmation states are the point of the screen: it
       // must not draw a confident tick over an alarm the band never
       // acknowledged.
-      'alarm_none': const AlarmScreenView(connected: true),
+      'alarm_none':
+          AlarmScreenView(connected: true, schedule: _alarmSchedule),
       'alarm_confirmed': AlarmScreenView(
           armedAt: _alarmAt,
           now: _alarmNow,
           state: AlarmArmState.confirmed,
           connected: true,
-          onSet: (_) async {},
+          schedule: _alarmSchedule,
           onTest: () async {},
           onCancel: () async {}),
       'alarm_unconfirmed': AlarmScreenView(
@@ -119,11 +129,14 @@ Map<String, Widget> _cases() => {
           now: _alarmNow,
           state: AlarmArmState.unknown,
           connected: true,
-          onSet: (_) async {},
+          schedule: _alarmSchedule,
           onTest: () async {},
           onCancel: () async {}),
       'alarm_disconnected': AlarmScreenView(
-          armedAt: _alarmAt, now: _alarmNow, state: AlarmArmState.unknown),
+          armedAt: _alarmAt,
+          now: _alarmNow,
+          state: AlarmArmState.unknown,
+          schedule: _alarmSchedule),
       'notification_settings': const NotificationSettingsView(),
       'notification_settings_blocked': const NotificationSettingsView(
           granted: false,


### PR DESCRIPTION
Implements #328.

## What
- **Weekly schedule** replaces the single next-occurrence picker: Mon–Sun rows, each with enable toggle + time, persisted in a new `alarm_schedule` table (laddered 49→50 migration; legacy single alarm seeds its weekday slot).
- **Arming engine** (`lib/state/alarm_schedule.dart`): computes the next occurrence (week wrap, disabled-day skip, same-target skip) and arms on every successful connect + headless sync via the existing `AlarmPayloads`/confirmation path. Re-arm skipped when the armed target already matches — no strap hammering.
- **Latch-failure notification**: if an arm gets no event 56 within the confirmation grace, a local notification fires (toggle in notification settings, default ON).
- **7pm check-in**: scheduled local notification — fires only when nothing is armed for tonight (toggle, default ON).
- UI: alarm screen shows the weekday list + live 'Next: … — Confirmed/Waiting/Not confirmed' from real strap events; settings gained the two notification toggles.

## Honesty invariants
Arm state reflects only real strap confirmation (event 56/57/58/59); an unanswered arm is logged as unconfirmed, never shown as armed. A failed write is the only silent null.

## Tests
70 tests across 5 files (migration seed, occurrence engine, confirmation transitions, notification wiring, UI). Analyzer clean on all touched files.

## Notes for review
- Validated on local Flutter 3.47.2; CI pins 3.41.6 (phosphor_flutter/IconData). Local full-suite baseline has 14 pre-existing failures in 8 unrelated files — none in the touched set.
- The 6s confirmation grace is unchanged (delayed-confirmation observation tracked separately as a bug-report follow-up).
- V2 snooze-confirmation backup deliberately out of scope (documented in the issue).

Claude Code implemented per brief; Hermes independently re-ran the test gates.

## Summary by Sourcery

Introduce a confirmation-aware weekly alarm schedule with automatic re-arming and safety notifications for alarms that are missing or fail to latch.

New Features:
- Replace the single alarm picker with a persisted weekly schedule covering all seven weekdays.
- Automatically arm the next enabled schedule occurrence after foreground and headless synchronization while avoiding redundant strap writes.
- Add configurable safety notifications for unconfirmed alarm latches and missing alarms at 7pm.

Bug Fixes:
- Ensure alarm state and notifications reflect strap confirmation rather than optimistic writes, including headless arms and relaunches.
- Prevent disabled schedules and cancelled alarms from retaining or silently restoring stale strap alarms.

Enhancements:
- Update the alarm interface to show weekday schedules and live confirmation status.
- Route alarm safety notifications directly to the alarm schedule screen.
- Preserve legacy single-alarm settings by seeding their weekday slot during schedule initialization.

Tests:
- Add coverage for schedule occurrence calculation, migration and persistence, confirmation gating, notification scheduling, and updated alarm UI behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added weekly alarm scheduling with per-day wake times and enable/disable controls.
  - Alarms automatically re-arm for the next scheduled occurrence after syncing or connecting.
  - Added safety alerts for unconfirmed alarms and reminders when no alarm is set for the evening.
  - Added notification settings to control both alarm alerts.
  - Alarm notifications now open directly to the alarm schedule.
- **Bug Fixes**
  - Improved alarm retry and failure handling when confirmation is missed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->