### PR TITLE
Live HR/IMU stream ownership reconciler (#287)

### DIFF
--- a/lib/ble/ble_engine.dart
+++ b/lib/ble/ble_engine.dart
@@ -513,9 +513,20 @@ class _SessionGapSummary {
 /// All per-connection resources. A fresh one is built on every connect and torn
 /// down (every subscription + timer cancelled, characteristics nulled) on every
 /// disconnect — so nothing bleeds across reconnects.
+/// How one live-stream transition ended on the wire.
+enum _LiveWrite { ok, failed, stale }
+
 class _Session {
   final BluetoothDevice device;
   BluetoothCharacteristic? cmdTo;
+
+  /// Set synchronously at the top of `_teardownSession`, before any await.
+  /// The generation bump happens there too, but `_session` is nulled only
+  /// after the subscription cancels have been awaited — so for that window
+  /// the dying session is still the current one and still `connected`, and a
+  /// live-stream pass that just discarded a stale completion would otherwise
+  /// capture the NEW generation and write to the link being closed.
+  bool closing = false;
 
   /// Which registered band this link speaks. Defaults to gen4 (WHOOP 4) and is
   /// pinned once during service discovery via [applyBand] — everything that
@@ -835,6 +846,12 @@ class BleEngine {
   final LiveFrameSink? onLiveFrame;
   final OffloadStateSink? onOffloadState;
 
+  /// The current live-stream owner set (#287). Read INSIDE the reconcile loop,
+  /// never cached, so a nudge that was missed is healed by the next keep-alive
+  /// tick rather than persisting until the next owner change. Null means no
+  /// owners (a headless drainer).
+  final LiveStreamOwners Function()? liveOwners;
+
   /// If provided, sync chunks are persisted via this ATOMIC commit (raw + samples
   /// + continuation cursor in one transaction) before the HISTORY_END ACK. This is
   /// what makes the offload resumable across restarts (durable cursor).
@@ -872,6 +889,7 @@ class BleEngine {
     this.onDataStored,
     this.onLiveFrame,
     this.onOffloadState,
+    this.liveOwners,
     this.onCommitBatch,
     this.onArchiveRecord,
     this.cursorReader,
@@ -1207,18 +1225,64 @@ class BleEngine {
   // (we keep ACKing HISTORY_END markers as they arrive, even after the first
   // HISTORY_COMPLETE — a later strap-triggered offload reuses it).
   DrainController? _drain;
-  bool _liveEnabled = false;
-  // Background live downgrade: only the compact realtime-HR stream is armed
-  // (no high-rate R10/R11 + IMU + optical flood). Set by [enableHrOnlyLive].
-  bool _liveHrOnly = false;
 
-  /// Whether any live stream is currently armed (full or HR-only). Lets a live
-  /// consumer (spot check / step calibration) know if it must arm streams itself
-  /// — and therefore whether IT owns turning them back off.
-  bool get liveEnabled => _liveEnabled;
+  // ── live HR / IMU ownership (#287) ──────────────────────────────────────────
+  // Desired state comes from the app's owner set through [liveOwners] and is
+  // recomputed inside the reconcile loop; applied state is what this LINK has
+  // been told and acknowledged. They are deliberately separate: the old flags
+  // flipped before the writes went out and doubled as both, which is how a
+  // stale OFF could defeat a new owner. See `desiredLiveStreams` /
+  // `nextLiveStreamStep` in ble_state.dart for the policy.
+  LiveStreamIntent _liveApplied = LiveStreamIntent.off;
 
-  /// True while live is in the background HR-only downgrade.
-  bool get liveHrOnly => _liveEnabled && _liveHrOnly;
+  /// The strap's high-rate bundle state is unknown on a fresh link. Consulted
+  /// on gen4 only (R10/R11 OFF persists across reconnects there); reset by
+  /// teardown.
+  bool _imuFresh = true;
+
+  /// A write for that bit failed or went stale, so the strap may be in either
+  /// state; the policy replays the newest desired direction before it declares
+  /// convergence. Reset by teardown.
+  bool _imuDirty = false;
+  bool _hrDirty = false;
+
+  /// The in-flight reconcile pass. Shared so that `await reconcileLiveStreams()`
+  /// is a real barrier for a caller that coalesced behind a running pass —
+  /// `disconnect()` relies on that to know its OFF intent has been processed.
+  Completer<void>? _liveRun;
+
+  /// Owners changed (or a disconnect arrived) while a pass was in flight:
+  /// recompute once more before the pass ends.
+  bool _liveRestale = false;
+
+  /// The keep-alive asked for the applied streams to be re-asserted on the
+  /// next converged pass (the band's live toggles can silently die).
+  bool _liveReassert = false;
+
+  /// The link has finished its INIT sequence and may carry live toggles.
+  /// `listening` is set BEFORE `_startInitDrain` sends the INIT packets (with
+  /// delays, possibly behind a history-lifecycle wait), so the phase alone
+  /// would let an owner nudge slip a live toggle in between them. Set at the
+  /// end of `_finishConnect`; cleared on a new session and at teardown.
+  bool _liveReady = false;
+
+  /// `disconnect()` in progress: desired is forced to OFF for the whole of the
+  /// shutdown reconcile AND the teardown, so nothing can re-arm the closing
+  /// link. Cleared in a `finally`.
+  bool _liveShutdown = false;
+
+  /// Whether any live stream is currently applied on this link. Read by the
+  /// resume-time staleness bar, the keep-alive's liveness poll and the
+  /// marginal-radio detector.
+  bool get liveEnabled => _liveApplied.any;
+
+  /// What this link has been told and acknowledged. Tests only.
+  @visibleForTesting
+  LiveStreamIntent get debugLiveApplied => _liveApplied;
+
+  /// What the current owners call for on this link. Tests only.
+  @visibleForTesting
+  LiveStreamIntent get debugLiveDesired => _desiredLive();
 
   // ── link power (issue #200) ─────────────────────────────────────────────────
   // Android's connection priority was requested ONCE at connect setup and never
@@ -1254,7 +1318,7 @@ class BleEngine {
   LinkPriority linkPriorityForCurrentState() => desiredLinkPriority(
         offloadActive: _offloadActive || _connectSetup,
         background: _backgrounded,
-        hasLiveConsumer: _liveEnabled && !_liveHrOnly,
+        hasLiveConsumer: _liveApplied.imu || _desiredLive().imu,
       );
 
   /// The last hop: the policy's [LinkPriority] as the radio's own enum.
@@ -1306,11 +1370,18 @@ class BleEngine {
   /// non-trimmable, so the commit-before-ACK ordering and the result-write
   /// failure paths are unreachable.
   @visibleForTesting
+  ///
+  /// [listening] marks the link READY (the post-bootstrap `listening` phase);
+  /// [liveReady] (defaults to [listening]) marks its INIT sequence finished,
+  /// which is what the live-stream reconciler requires before it writes. The
+  /// defaults leave both alone so bootstrap tests can drive them themselves.
   void debugInstallFakeLink({
     required Future<bool> Function(Uint8List frame) onWrite,
     BandProfile band = BandProfile.gen4,
     ArchiveSink? onArchive,
     CommitSyncBatchSink? onCommit,
+    bool listening = false,
+    bool? liveReady,
   }) {
     final session = _Session(
       BluetoothDevice(remoteId: const DeviceIdentifier('AA:BB:CC:DD:EE:FF')),
@@ -1319,6 +1390,8 @@ class BleEngine {
     session.sawConnected = true;
     session.applyBand(bandEntryFor(band));
     _session = session;
+    if (listening) _phase = BleConnState.listening;
+    _liveReady = liveReady ?? listening;
     debugWriteHook = onWrite;
     _drain = DrainController(
       onRecord: _storeRecord,
@@ -1509,7 +1582,9 @@ class BleEngine {
         final want = desiredLinkPriority(
           offloadActive: _offloadActive || _connectSetup,
           background: _backgrounded,
-          hasLiveConsumer: _liveEnabled && !_liveHrOnly,
+          // Desired OR applied: the fast interval is requested before the
+          // flood starts and held until the OFF has landed.
+          hasLiveConsumer: _liveApplied.imu || _desiredLive().imu,
         );
         if (want == _appliedPriority) continue;
         final generation = _linkGeneration;
@@ -2335,6 +2410,7 @@ class BleEngine {
     _setPhase(BleConnState.connecting);
     final session = _Session(device);
     _session = session;
+    _liveReady = false;
     _seq.reset();
 
     // SOURCE OF TRUTH: listen to the OS connection-state stream FIRST so we never
@@ -2637,7 +2713,11 @@ class BleEngine {
       // The INIT drain claim rides the same task-lifecycle rules as every
       // other history task ([_startInitDrain]) — quiescence barrier, task
       // generation, staleness re-checks, arm/rollback.
-      return await _startInitDrain(session);
+      final ok = await _startInitDrain(session);
+      // Live toggles only AFTER the INIT sequence: the caller reconciles the
+      // owners' intent once this returns (see `_liveReady`).
+      if (ok && identical(_session, session)) _liveReady = true;
+      return ok;
     } catch (e) {
       _log('connect setup failed: $e');
       await _failConnect();
@@ -3479,35 +3559,18 @@ class BleEngine {
       _log('[SYNC] Periodic RTC re-verify (long-lived connection).');
       unawaited(getClock());
     }
-    if (_liveEnabled) {
-      // Re-arm ONLY what the current live mode wants: re-sending the high-rate
-      // R10/R11 toggle while in HR-only mode (background downgrade) or under the
-      // marginal-radio fallback would silently undo the downgrade every 30 s.
-      // A band with no SEND_R10_R11 opcode (WHOOP 5: Unknown/Unhandled) carries
-      // its high-rate live stream on the IMU toggle, so that is what re-arms.
-      final r10 = (_session?.entry ?? kWhoopGen4).commands.r10R11Realtime;
-      if (!_liveHrOnly && !state.standardHrFallback) {
-        if (r10 == null) {
-          _sendToggleImu(true);
-        } else {
-          _send(r10, const [0x01]);
-        }
-      }
-      // Evidence-gated: the HR re-arm exists to recover a stream that silently
-      // died, so send it only when the stream is demonstrably NOT delivering
-      // (no valid reading for >60 s — off-wrist stamps nothing, which
-      // correctly degrades to the old blind re-arm there). Blindly re-sending
-      // every 30 s was ~2,880 write-with-response round trips/day whose
-      // payload was a no-op. The IMU re-arm above stays unconditional: it runs
-      // only in foreground full-live (bounded by screen-on time), and a
-      // flowing HR stream is no proof the IMU stream is alive.
-      final hrAtMs = state.liveHrAt;
-      final hrDelivering = hrAtMs != null &&
-          DateTime.now().millisecondsSinceEpoch - hrAtMs < 60 * 1000;
-      if (!hrDelivering) {
-        _send(Cmd.toggleRealtimeHr, const [0x01]);
-      }
-    }
+    // Re-arm what is APPLIED (the band's live toggles can silently die) and,
+    // as a side effect, retry any transition that failed earlier — a no-op
+    // when applied already equals desired. Serialised through the same pass as
+    // every other live write; see [_reassertLive] for what is re-sent.
+    // Only START a pass; never restale one in flight. A coalesced call marks
+    // the running pass restale, and a failed transition retries while that
+    // flag is set — a gen4 OFF bundle whose four writes each time out (8 s)
+    // outlasts this 30 s tick, so a tick that restaled it would retry it
+    // forever. The reassert flag alone is picked up by the next converged
+    // pass, whoever starts it.
+    _liveReassert = true;
+    if (_liveRun == null) unawaited(_reconcileLive());
     // Battery is a DISPLAY value that moves over hours. Polling it on every
     // 30 s keep-alive tick was 2,880 radio round-trips a day for a handful of
     // real changes (issue #200).
@@ -3528,7 +3591,7 @@ class BleEngine {
         // bar (~every other 30 s tick ⇒ sinceLastRx stays ≤ ~65 s). With a
         // stream armed, the original fuse/2 threshold stands.
         force: sinceLastRx.inSeconds >
-            (_liveEnabled
+            (liveEnabled
                 ? kLivenessFuseSeconds ~/ 2
                 : kNoStreamPollSilenceSeconds),
       ),
@@ -3886,6 +3949,10 @@ class BleEngine {
               '($_crcFailuresThisSession CRC failures this session) — '
               'standard-HR fallback enabled.',
             );
+            // The fallback is an input to the desired live state: drop an
+            // applied IMU bundle now rather than on a keep-alive tick that
+            // returns early for the whole of an offload.
+            unawaited(_reconcileLive());
           }
         }
       }),
@@ -4001,7 +4068,7 @@ class BleEngine {
         ? null
         : now.difference(_bondTime!).inMilliseconds / 1000.0;
     if (_marginalRadio.connectionEnded(
-      wasArmed: _liveEnabled,
+      wasArmed: liveEnabled,
       secondsSinceArm: sinceArm,
       timedOut: timedOut,
     )) {
@@ -4122,7 +4189,7 @@ class BleEngine {
         // so a hooked write rejects a stale-session ACK exactly like the real
         // one. A seam that skips the guards it is meant to be standing in for
         // makes every test that relies on it prove the wrong thing.
-        if (session == null || !session.connected) {
+        if (session == null || !session.connected || session.closing) {
           _log('write skipped: link not ready.');
           return false;
         }
@@ -4288,9 +4355,14 @@ class BleEngine {
   /// byte where gen4 sends a bare on/off byte; protocol's `cmdToggleImu` owns
   /// that split. Sent the gen4 body, a gen5 strap reads the state from past the
   /// end of the body, the stream never arms, and step calibration stays at 0.
-  Future<bool> _sendToggleImu(bool on) => _write(
+  ///
+  /// [owner] pins the write to one session exactly as [_send] does: the live
+  /// reconciler issues this from a multi-write bundle that can straddle a
+  /// teardown, and the gen4 tail must not land on a replacement gen5 link.
+  Future<bool> _sendToggleImu(bool on, {_Session? owner}) => _write(
         cmdToggleImu(_seq.nextLive(), on,
-            profile: _session?.band ?? BandProfile.gen4),
+            profile: (owner ?? _session)?.band ?? BandProfile.gen4),
+        owner: owner,
       );
 
   Future<bool> _sendGetDataRange({_Session? owner}) =>
@@ -7281,60 +7353,23 @@ class BleEngine {
     return _send(Cmd.runHapticsPattern, [pattern, 0, 0, 0, 0]);
   }
 
-  /// Enable live foreground streams (makes the band emit live R10/R11 + optical).
-  /// Optical stays WRIST-GATED (0x6B only). This sends the toggle commands but
-  /// DOES NOT change the displayed state — we stay in the single `listening` phase;
-  /// live records simply start arriving on the same subscription history uses.
-  Future<void> enableLiveStreams() async {
-    _liveEnabled = true;
-    _liveHrOnly = false;
-    unawaited(_applyLinkPriority()); // a live consumer earns the fast interval
-    _armTime =
-        DateTime.now(); // marginal-radio detector measures arm→drop latency
-    final c = (_session?.entry ?? kWhoopGen4).commands;
-    await _send(Cmd.toggleRealtimeHr, const [0x01]);
-    // MARGINAL-RADIO FALLBACK: a weak radio can't sustain the high-rate R10/R11 +
-    // IMU + optical flood, so once the detector trips we arm HR only.
-    if (state.standardHrFallback) {
-      _log('Live streams: standard-HR only (marginal-radio fallback).');
-      return;
-    }
-    await Future.delayed(const Duration(milliseconds: 100));
-    // A band with no SEND_R10_R11 opcode (gen5 console: 0x3F is
-    // Unknown/Unhandled) skips it. Live steps ride toggleImuMode there
-    // (gen5: 0x2B rec 0x15; gen4: 0x33).
-    final r10 = c.r10R11Realtime;
-    if (r10 != null) {
-      await _send(r10, const [0x01]);
-      await Future.delayed(const Duration(milliseconds: 100));
-    }
-    await _sendToggleImu(true);
-    await Future.delayed(const Duration(milliseconds: 100));
-    // Only where ENABLE_OPTICAL_DATA is the LIVE toggle. On gen5 it is the
-    // SAVE-to-history toggle — the realtime one is the next opcode up — so
-    // arming it here would write a save enable on every live-stream start, next
-    // door to the persistent-optical footgun that leaves the LEDs on and drains
-    // the battery. gen5's own 1 Hz stream already carries per-second HR, so
-    // there is nothing to gain until the roles are confirmed on hardware. The
-    // OFF writes in disableLiveStreams stay unconditional.
-    if (c.opticalDataIsLiveToggle) {
-      await _send(Cmd.enableOpticalData, const [revision1, 0x01]);
-    }
-    _log(
-      'Live streams enabled ('
-      '${c.opticalDataIsLiveToggle ? "optical: wrist-gated" : "gen5 IMU rev1; optical skipped"}).',
-    );
-  }
+  // ── live HR / IMU ownership reconciler (#287) ───────────────────────────────
 
-  /// Clear the sticky standard-HR fallback and give the full live set another
-  /// chance. The fallback protects a struggling radio from the high-rate
-  /// flood, but it never resets and [enableLiveStreams] honours it silently —
-  /// so once tripped, every later step calibration / workout counted 0 steps
-  /// for the rest of the process lifetime (the IMU toggles were never sent).
-  /// Call this from EXPLICIT foreground user actions whose feature needs the
-  /// 100 Hz stream: there the flood is the point, and if the radio genuinely
-  /// can't sustain it the detectors re-trip (and re-downgrade) within seconds.
-  Future<void> retryFullLiveStreams() async {
+  /// Recompute the owners' intent and walk this link's applied streams towards
+  /// it. Safe to call at any time from any state transition; a no-op when not
+  /// connected. The returned future completes when the pass that will observe
+  /// the caller's change has finished (a caller that coalesces behind a
+  /// running pass awaits that pass — it re-reads the owners before it ends).
+  Future<void> reconcileLiveStreams() => _reconcileLive();
+
+  /// An explicit foreground user action whose feature needs the 100 Hz stream
+  /// (a workout start): clear the sticky marginal-radio fallback and reconcile.
+  /// The fallback protects a struggling radio from the high-rate flood but
+  /// never resets on its own, so once tripped every later workout counted 0
+  /// steps for the rest of the process lifetime. Here the flood is the point,
+  /// and if the radio genuinely cannot sustain it the detectors re-trip (and
+  /// re-downgrade) within seconds.
+  Future<void> clearRadioFallbackAndReconcile() {
     if (state.standardHrFallback) {
       _log('Radio fallback: cleared by explicit user action — retrying the '
           'full live set.');
@@ -7343,71 +7378,298 @@ class BleEngine {
       _frameCorruption.reset();
       onState(state);
     }
-    await enableLiveStreams();
+    return _reconcileLive();
   }
 
-  /// Background live downgrade: keep ONLY the compact realtime-HR stream (0x28)
-  /// armed and turn the high-rate R10/R11 + IMU + optical flood OFF. Used while
-  /// backgrounded with no live consumer, so the radio isn't saturated by a raw
-  /// flood nobody is reading — which can starve the periodic R24 offloads.
-  /// [enableLiveStreams] restores the full set on foreground return. Idempotent.
-  Future<void> enableHrOnlyLive() async {
-    if (_session?.connected != true) return;
-    _liveEnabled = true;
-    _liveHrOnly = true;
-    final r10 = (_session?.entry ?? kWhoopGen4).commands.r10R11Realtime;
-    unawaited(_applyLinkPriority()); // downgraded to HR-only ⇒ step the link down
-    await _send(Cmd.toggleRealtimeHr, const [0x01]);
-    final offOps = <Future<bool> Function()>[
-      () => _send(Cmd.toggleOpticalMode, const [revision1, 0x00]),
-      () => _send(Cmd.enableOpticalData, const [revision1, 0x00]),
-      if (r10 != null) () => _send(r10, const [0x00]),
-      () => _sendToggleImu(false),
-    ];
-    for (final op in offOps) {
-      await op();
-      await Future.delayed(const Duration(milliseconds: 60));
+  /// Tests only: the keep-alive's re-arm request, without the rest of the
+  /// tick (its liveness fuse would bounce a fake link with no inbound traffic).
+  @visibleForTesting
+  Future<void> debugReassertLiveStreams() {
+    _liveReassert = true;
+    return _liveRun?.future ?? _reconcileLive();
+  }
+
+  /// Tests only: an OS-style link drop — the non-intentional teardown plus
+  /// the `idle` phase [_onLinkDown] surfaces afterwards.
+  @visibleForTesting
+  Future<void> debugDropLink() async {
+    await _teardownSession(intentional: false);
+    _setPhase(BleConnState.idle);
+  }
+
+  LiveStreamIntent _desiredLive() {
+    if (_liveShutdown) return LiveStreamIntent.off;
+    return desiredLiveStreams(
+      liveOwners?.call() ?? LiveStreamOwners.none,
+      gen5: _session?.band.isGen5 ?? false,
+      standardHrFallback: state.standardHrFallback,
+    );
+  }
+
+  /// True once [session] is no longer the link we started a write on.
+  bool _liveStale(_Session session, int generation) =>
+      generation != _linkGeneration ||
+      !identical(_session, session) ||
+      !session.connected ||
+      session.closing;
+
+  /// The ONLY writer of the realtime-HR toggle (opcode 3) and the high-rate
+  /// bundle (gen5: IMU opcode 106; gen4: R10/R11 + IMU + optical).
+  ///
+  /// SERIALIZED and COALESCING, same shape as [_applyLinkPriority]: desired is
+  /// recomputed inside the loop after every await, one transition is written
+  /// per iteration, applied moves only after that write succeeded and only if
+  /// the link it was written to is still the live one, and the loop runs until
+  /// applied equals the NEWEST desired. A failed write marks its bit dirty
+  /// (the strap may be in either state) and ends the pass — the keep-alive
+  /// tick retries; spinning here against a refusing radio would hammer it.
+  Future<void> _reconcileLive() {
+    final running = _liveRun;
+    if (running != null) {
+      _liveRestale = true;
+      return running.future;
     }
-    _log('Live streams: HR-only (background downgrade — raw flood off).');
+    final run = _liveRun = Completer<void>();
+    () async {
+      // gen4's OFF-tail head (`03(1)`) belongs to the old HR-only downgrade,
+      // i.e. to a bundle OFF on a link whose HR was ALREADY on; a pass that
+      // armed HR itself moments ago must not send it twice.
+      var hrArmedThisPass = false;
+      try {
+        do {
+          _liveRestale = false;
+          final session = _session;
+          // Physically connected is not enough: `connected` is true from the
+          // moment the link is up, before discovery, bonding, the subscribes
+          // and INIT. A stale pass that loops onto a replacement session — or
+          // an owner nudge landing mid-bootstrap — must not put live toggles
+          // into that sequence. Only a LISTENING (post-READY) link is written
+          // to; the app's post-connect reconcile applies the intent after.
+          if (session == null ||
+              !session.connected ||
+              session.closing ||
+              _phase != BleConnState.listening ||
+              !_liveReady) {
+            return;
+          }
+          final want = _desiredLive();
+          final gen5 = session.band.isGen5;
+          final step = nextLiveStreamStep(
+            applied: _liveApplied,
+            desired: want,
+            imuFresh: _imuFresh && !gen5,
+            imuDirty: _imuDirty,
+            hrDirty: _hrDirty,
+          );
+          final generation = _linkGeneration;
+          if (step == null) {
+            if (_liveReassert) {
+              _liveReassert = false;
+              await _reassertLive(session, generation);
+            }
+            continue;
+          }
+          // The fast interval is earned by the flood: ask BEFORE it starts.
+          if (step == LiveStreamStep.imuOn) unawaited(_applyLinkPriority());
+          final r = await _writeLiveStep(
+            step,
+            session,
+            generation,
+            hrHead: want.hr && !hrArmedThisPass,
+          );
+          if (r == _LiveWrite.stale || _liveStale(session, generation)) {
+            // Do not record it against the dead link (teardown already reset
+            // its state); loop once more so a replacement session, if there is
+            // one, gets its own pass.
+            _log('Live stream step ${step.name} completed after teardown — '
+                'discarded.');
+            _liveRestale = true;
+            continue;
+          }
+          if (r == _LiveWrite.failed) {
+            if (step.isImu) {
+              _imuDirty = true;
+            } else {
+              _hrDirty = true;
+            }
+            _log('Live stream step ${step.name} failed — will retry on the '
+                'next keep-alive tick.');
+            // A nudge that arrived during the failed write (a new owner, or
+            // disconnect()'s shutdown intent) is still honoured: recompute
+            // once more. Only a quiet failure exits. Bounded, because restale
+            // is only ever set by an external nudge, never by this loop.
+            if (!_liveRestale) break;
+            continue;
+          }
+          _liveApplied = applyLiveStreamStep(_liveApplied, step);
+          if (step == LiveStreamStep.hrOn) hrArmedThisPass = true;
+          if (step.isImu) {
+            _imuFresh = false;
+            _imuDirty = false;
+          } else {
+            _hrDirty = false;
+          }
+          if (step == LiveStreamStep.imuOff) _armTime = null;
+          if (step == LiveStreamStep.hrOff) {
+            state.liveHr = null;
+            onState(state);
+          }
+          _log('Live streams: ${step.name} applied → '
+              'hr=${_liveApplied.hr} imu=${_liveApplied.imu}.');
+          unawaited(_applyLinkPriority()); // the live consumer set changed
+          _liveRestale = true; // recompute until applied == newest desired
+        } while (_liveRestale);
+      } catch (e) {
+        // Never poison the shared future: nudges are fired unawaited from
+        // state transitions, so an error here would surface as an uncaught
+        // zone error in whoever happened to be awaiting. Log; the next nudge
+        // or keep-alive tick converges.
+        _log('Live stream reconcile failed: $e');
+      } finally {
+        _liveRun = null;
+        run.complete();
+      }
+    }();
+    return run.future;
   }
 
-  /// Turn everything off. Safe + idempotent. Clears flags back to wrist-gated.
-  Future<void> disableLiveStreams() async {
-    final r10 = (_session?.entry ?? kWhoopGen4).commands.r10R11Realtime;
-    final ops = <Future<bool> Function()>[
-      () => _send(Cmd.toggleOpticalMode, const [revision1, 0x00]),
-      () => _send(Cmd.enableOpticalData, const [revision1, 0x00]),
-      if (r10 != null) () => _send(r10, const [0x00]),
-      () => _sendToggleImu(false),
-      () => _send(Cmd.toggleRealtimeHr, const [0x00]),
-    ];
+  /// One transition on the wire. Every write is pinned to [session] and the
+  /// link is re-checked after every await (writes AND delays), so a gen4
+  /// bundle interrupted by a teardown can never continue onto a replacement
+  /// link. `ok` only when every sub-write succeeded.
+  ///
+  /// gen5 sequences: HR `03(1)` / `03(0)`; IMU `6A(rev1,1)` / `6A(rev1,0)`.
+  /// Optical opcodes 107/108 are never written on gen5 — 0x6B is the
+  /// SAVE-to-history toggle there and 0x6C's role is unconfirmed on hardware.
+  ///
+  /// gen4 sequences are byte-for-byte what the old enable / HR-only / disable
+  /// methods wrote, including the spacing, so nothing changes for gen4 users:
+  ///   ON   `03(1)` · 100 ms · `3F(1)` · 100 ms · `6A(1)` · 100 ms · `6B(rev1,1)`
+  ///   OFF  [`03(1)` when HR stays on and was not just armed by this pass —
+  ///        the old HR-only downgrade's head, see [hrHead]] ·
+  ///        `6C(rev1,0)` · 60 · `6B(rev1,0)` · 60 · `3F(0)` · 60 · `6A(0)` · 60
+  ///   then `03(0)` · 60 when HR goes off too.
+  /// R10/R11 OFF persists across reconnects on gen4, which is why a fresh
+  /// gen4 link replays the OFF tail defensively (see `nextLiveStreamStep`).
+  Future<_LiveWrite> _writeLiveStep(
+    LiveStreamStep step,
+    _Session session,
+    int generation, {
+    required bool hrHead,
+  }) async {
+    final c = session.entry.commands;
+    // A band with the R10/R11 opcode carries the legacy high-rate bundle
+    // (gen4); a band without it (gen5) rides the IMU toggle alone.
+    final r10 = c.r10R11Realtime;
+    Future<bool> gap(int ms) async {
+      await Future<void>.delayed(Duration(milliseconds: ms));
+      return true;
+    }
+
+    Future<bool> Function() send(int opcode, List<int> body) =>
+        () => _send(opcode, body, owner: session);
+    final ops = <Future<bool> Function()>[];
+    switch (step) {
+      case LiveStreamStep.hrOn:
+        ops.add(send(Cmd.toggleRealtimeHr, const [0x01]));
+      case LiveStreamStep.hrOff:
+        ops
+          ..add(send(Cmd.toggleRealtimeHr, const [0x00]))
+          ..add(() => gap(60));
+      case LiveStreamStep.imuOn:
+        // marginal-radio detector measures arm→drop latency of the flood
+        _armTime = DateTime.now();
+        ops.add(() => gap(100));
+        if (r10 != null) {
+          ops
+            ..add(send(r10, const [0x01]))
+            ..add(() => gap(100));
+        }
+        ops
+          ..add(() => _sendToggleImu(true, owner: session))
+          ..add(() => gap(100));
+        // Only where ENABLE_OPTICAL_DATA is the LIVE toggle (gen4). On gen5 it
+        // is the SAVE-to-history toggle, next door to the persistent-optical
+        // footgun that leaves the LEDs on and drains the battery.
+        if (c.opticalDataIsLiveToggle) {
+          ops.add(send(Cmd.enableOpticalData, const [revision1, 0x01]));
+        }
+      case LiveStreamStep.imuOff:
+        if (r10 != null) {
+          if (hrHead) ops.add(send(Cmd.toggleRealtimeHr, const [0x01]));
+          ops
+            ..add(send(Cmd.toggleOpticalMode, const [revision1, 0x00]))
+            ..add(() => gap(60))
+            ..add(send(Cmd.enableOpticalData, const [revision1, 0x00]))
+            ..add(() => gap(60))
+            ..add(send(r10, const [0x00]))
+            ..add(() => gap(60));
+        }
+        ops
+          ..add(() => _sendToggleImu(false, owner: session))
+          ..add(() => gap(60));
+    }
+    // ponytail: "ok" means the GATT write-with-response was delivered, as the
+    // old methods judged it; a toggle's own correlated reply is not awaited.
+    // Correlating 0x03/0x6A replies (`_sendAwaited`) is the upgrade once the
+    // strap's reply behaviour for these toggles is confirmed on hardware.
+    var ok = true;
     for (final op in ops) {
-      await op();
-      await Future.delayed(const Duration(milliseconds: 60));
+      if (!await op()) ok = false;
+      if (_liveStale(session, generation)) return _LiveWrite.stale;
     }
-    _liveEnabled = false;
-    _liveHrOnly = false;
-    unawaited(_applyLinkPriority()); // no live consumer left
-    _armTime = null;
-    state.liveHr = null;
-    // No phase change — we stay `listening`; only the live R10/R11/optical streams
-    // stop. Historical records + the heartbeat keep flowing on the same link.
-    onState(state);
+    return ok ? _LiveWrite.ok : _LiveWrite.failed;
+  }
+
+  /// The keep-alive's re-arm, run only from a CONVERGED pass: the band's live
+  /// toggles can silently die, so what is applied is re-sent. The high-rate
+  /// re-arm is unconditional (a flowing HR stream is no proof the IMU stream
+  /// is alive; it runs only while something owns the flood); the HR re-arm is
+  /// evidence-gated — sent only when no valid reading has arrived for 60 s,
+  /// because blindly re-sending it every 30 s was ~2,880 write-with-response
+  /// round trips a day whose payload was a no-op. Results are ignored: this is
+  /// a re-assert, not a transition, so applied and dirty are untouched.
+  Future<void> _reassertLive(_Session session, int generation) async {
+    if (_liveApplied.imu) {
+      final r10 = session.entry.commands.r10R11Realtime;
+      if (r10 == null) {
+        await _sendToggleImu(true, owner: session);
+      } else {
+        await _send(r10, const [0x01], owner: session);
+      }
+      if (_liveStale(session, generation)) return;
+    }
+    if (_liveApplied.hr) {
+      final hrAtMs = state.liveHrAt;
+      final hrDelivering = hrAtMs != null &&
+          DateTime.now().millisecondsSinceEpoch - hrAtMs < 60 * 1000;
+      if (!hrDelivering) {
+        await _send(Cmd.toggleRealtimeHr, const [0x01], owner: session);
+      }
+    }
   }
 
   /// Idempotent, intentional teardown. Safe to call repeatedly.
   Future<void> disconnect() => _locked(() async {
-    if (_liveEnabled && _session?.connected == true) {
-      try {
-        await disableLiveStreams();
-      } catch (_) {}
+    // Desired is forced to OFF for the shutdown reconcile AND the teardown, so
+    // an owner change cannot re-arm the closing link in either await window.
+    // Not gated on `liveEnabled`: an ON may be in flight with applied still
+    // off. Cleared in `finally` — a throwing subscription cancel must not
+    // leave the latch stuck and every later connection silent.
+    _liveShutdown = true;
+    try {
+      if (_session?.connected == true) {
+        await _reconcileLive(); // a real barrier: awaits the in-flight pass
+      }
+      if (_session?.connected == true && _highFreqModeRequested) {
+        try {
+          await _disableHighFreqSync(reason: 'intentional_disconnect');
+        } catch (_) {}
+      }
+      await _teardownSession(intentional: true);
+    } finally {
+      _liveShutdown = false;
     }
-    if (_session?.connected == true && _highFreqModeRequested) {
-      try {
-        await _disableHighFreqSync(reason: 'intentional_disconnect');
-      } catch (_) {}
-    }
-    await _teardownSession(intentional: true);
     // Release the single-owner claim ONLY on an intentional disconnect (not on a
     // link-down we intend to reconnect from) so the band is free for a background
     // drain once we've genuinely let go. If we were already preempted by another
@@ -7424,6 +7686,17 @@ class BleEngine {
     final session = _session;
     if (session == null) return;
     session.intentionalClose = intentional;
+    // SYNCHRONOUSLY, before any await: see `_Session.closing`.
+    session.closing = true;
+    // Live arming is per-connection: applied clears now, the owners' intent
+    // survives and is re-applied on the next link's first reconcile. A fresh
+    // link's high-rate bundle is unknown again (gen4's R10/R11 OFF persists on
+    // the strap), and nothing is dirty on a link that no longer exists.
+    _liveApplied = LiveStreamIntent.off;
+    _liveReady = false;
+    _imuFresh = true;
+    _imuDirty = false;
+    _hrDirty = false;
     // Per-link state: Android resets the connection interval on every new GATT
     // connection, so a remembered priority would make the next link skip its
     // request. The battery stamp resets too — a fresh session should read the
@@ -7461,13 +7734,10 @@ class BleEngine {
     _offloadFrames.clear();
     _drainingOffloadFrames = false;
     _setOffloadActive(false);
-    // Live arming is per-connection. `_armTime` used to survive teardown, and
-    // enableHrOnlyLive sets `_liveEnabled` without touching it — so the
-    // marginal-radio detector measured the NEXT session's drop against the
-    // PREVIOUS session's arm and permanently downgraded live streams on the
-    // evidence of a session that never armed the raw flood.
-    _liveEnabled = false;
-    _liveHrOnly = false;
+    // `_armTime` used to survive teardown, so the marginal-radio detector
+    // measured the NEXT session's drop against the PREVIOUS session's arm and
+    // permanently downgraded live streams on the evidence of a session that
+    // never armed the raw flood.
     _armTime = null;
     // ALWAYS drop the radio link, not just on an intentional disconnect. Every
     // self-initiated bounce (liveness fuse, ACK-exhausted, commit-failed) tears

--- a/lib/ble/ble_state.dart
+++ b/lib/ble/ble_state.dart
@@ -1843,3 +1843,201 @@ class WriteChain {
     return completer.future;
   }
 }
+
+// ── live HR / IMU stream ownership (discussion #287) ─────────────────────────
+//
+// A foreground connection used to be an implicit request for BOTH the
+// realtime-HR stream (opcode 3) and the 100 Hz IMU stream (gen5 opcode 106),
+// and the enable / HR-only / disable methods each flipped the engine's live
+// flags BEFORE their writes went out, with no serialisation between them. Two
+// races followed from that: a breathing close started an OFF sequence
+// unawaited, a workout starting inside that window saw "already enabled" and
+// skipped its ON, and the older OFF then finished and left the workout without
+// a stream; and a feature that started while another already had streams on
+// recorded no ownership, so when both left nothing recomputed the remaining
+// owner set and the keep-alive kept re-arming a flood nobody read.
+//
+// The fix is a desired-vs-applied reconciler: every consumer is an explicit
+// owner ([LiveStreamOwners]), the policy below turns the owner set into two
+// independent desired bits ([desiredLiveStreams]), and the engine walks the
+// applied state towards the desired one a single transition at a time
+// ([nextLiveStreamStep]). The engine is the only writer of these opcodes; the
+// app never calls enable/disable, it only changes owners and nudges.
+
+/// Which live streams are wanted or applied. OFF, HR-only, IMU-only and
+/// HR+IMU are all representable — a three-state off / HR-only / full model
+/// cannot express movement sampling without HR, and would arm the IMU flood
+/// for breathing and non-gait workouts that only read beats.
+class LiveStreamIntent {
+  final bool hr;
+  final bool imu;
+  const LiveStreamIntent({required this.hr, required this.imu});
+
+  static const off = LiveStreamIntent(hr: false, imu: false);
+
+  bool get any => hr || imu;
+
+  @override
+  bool operator ==(Object other) =>
+      other is LiveStreamIntent && other.hr == hr && other.imu == imu;
+
+  @override
+  int get hashCode => Object.hash(hr, imu);
+
+  @override
+  String toString() => 'LiveStreamIntent(hr: $hr, imu: $imu)';
+}
+
+/// Who wants what, as explicit consumers. None of these is "the app is
+/// connected" — except [foreground], which only the gen4 legacy row of
+/// [desiredLiveStreams] reads.
+class LiveStreamOwners {
+  /// A screen showing the live BPM is mounted (HR).
+  final bool visibleLiveHrView;
+
+  /// A workout is running, any type, foreground or background (HR: zones,
+  /// peak HR, strain and calories all ride the beat stream).
+  final bool activeWorkout;
+
+  /// A gait workout (see `kGaitStepTypeKeys`) is running in the FOREGROUND
+  /// (IMU: live steps and cadence). Background IMU is not promised until the
+  /// background link is measured to sustain the pedometer's sample-rate floor.
+  final bool foregroundGaitWorkout;
+
+  /// A guided-breathing session or its pre/post quiet window is open (HR:
+  /// R-R for coherence and RMSSD).
+  final bool breathing;
+
+  /// iOS, backgrounded: the inbound 1 Hz notification is what keeps the
+  /// suspended process schedulable, so HR stays on there with no other owner.
+  /// An Edge platform policy, not a measured guarantee.
+  final bool iosBackgroundKeepalive;
+
+  /// A bounded movement-reminder sampling window is open (IMU-only). There is
+  /// no scheduler yet: enabling the reminder preference must NOT hold IMU, and
+  /// sampling only inside windows cannot prove stillness between them.
+  final bool movementSampling;
+
+  /// Passive strap-step collection opt-in (IMU). Off by default on gen5: the
+  /// on-chip daily counter is the fallback, and the phone can supply windowed
+  /// steps. A future opt-in requests IMU through this same owner.
+  final bool passiveStrapSteps;
+
+  /// The app is in the foreground. Read ONLY for gen4, where a foreground
+  /// connection keeps today's behaviour: HR plus the R10/R11 + IMU + optical
+  /// bundle, so gen4 users keep passive strap steps and live HR exactly as
+  /// before. gen4 has no on-chip daily step fallback, and the "default off"
+  /// decision in #287 was taken in gen5 terms.
+  final bool foreground;
+
+  const LiveStreamOwners({
+    this.visibleLiveHrView = false,
+    this.activeWorkout = false,
+    this.foregroundGaitWorkout = false,
+    this.breathing = false,
+    this.iosBackgroundKeepalive = false,
+    this.movementSampling = false,
+    this.passiveStrapSteps = false,
+    this.foreground = false,
+  });
+
+  static const none = LiveStreamOwners();
+
+  @override
+  String toString() => 'LiveStreamOwners('
+      'hrView: $visibleLiveHrView, workout: $activeWorkout, '
+      'fgGait: $foregroundGaitWorkout, breathing: $breathing, '
+      'iosBg: $iosBackgroundKeepalive, movement: $movementSampling, '
+      'passiveSteps: $passiveStrapSteps, foreground: $foreground)';
+}
+
+/// The streams the current owners call for.
+///
+///   wantHr  = visibleLiveHrView || activeWorkout || breathing
+///           || iosBackgroundKeepalive
+///   wantImu = foregroundGaitWorkout || movementSampling || passiveStrapSteps
+///
+/// plus, on gen4 only, `foreground` as an owner of both (see
+/// [LiveStreamOwners.foreground]). History sync is never an owner — it reads
+/// flash, not live frames — which is why it has no field here.
+///
+/// [standardHrFallback] is the sticky marginal-radio latch: a radio that
+/// cannot sustain the high-rate flood keeps HR and drops IMU, exactly as the
+/// old enable path returned right after HR ON.
+LiveStreamIntent desiredLiveStreams(
+  LiveStreamOwners o, {
+  required bool gen5,
+  required bool standardHrFallback,
+}) {
+  final legacy = !gen5 && o.foreground;
+  final hr = o.visibleLiveHrView ||
+      o.activeWorkout ||
+      o.breathing ||
+      o.iosBackgroundKeepalive ||
+      legacy;
+  final imu = (o.foregroundGaitWorkout ||
+          o.movementSampling ||
+          o.passiveStrapSteps ||
+          legacy) &&
+      !standardHrFallback;
+  return LiveStreamIntent(hr: hr, imu: imu);
+}
+
+/// One transition of one stream. `imuOn`/`imuOff` are the high-rate bundle:
+/// opcode 106 alone on gen5, R10/R11 + IMU + optical on gen4.
+enum LiveStreamStep {
+  hrOn,
+  imuOn,
+  imuOff,
+  hrOff;
+
+  bool get isImu => this == imuOn || this == imuOff;
+}
+
+/// The next single transition that moves [applied] towards [desired], or null
+/// when they already agree. Order is today's wire order: ONs first (HR before
+/// the bundle), then OFFs (bundle before HR), so a full arm and a full disarm
+/// emit exactly the sequences the old enable/disable methods did.
+///
+/// Per-bit uncertainty the engine tracks per link:
+///
+/// [imuFresh] — the strap's bundle state is not known on a fresh link. gen4's
+/// R10/R11 OFF state PERSISTS across reconnects on the strap (protocol
+/// `cmdSendR10R11`: "the off state persists across reconnects"), so a fresh
+/// gen4 link cannot be modelled as known-off. While fresh, the first time the
+/// link is used at all (anything desired) the bundle is replayed in the
+/// desired direction; a link nothing wants stays silent, which is what an
+/// Android-background gen4 reconnect did before. gen5 passes false: its IMU
+/// bit is a single write and #287 forbids speculative writes there.
+///
+/// [imuDirty] / [hrDirty] — a write for that bit FAILED or went stale, so the
+/// strap may be in either state (a timed-out write can still have landed; a
+/// gen4 bundle can be half-applied). Dirty ALWAYS replays the newest desired
+/// direction before convergence, even when nothing is desired: a dirty OFF
+/// must be cleaned up, unlike a fresh one.
+LiveStreamStep? nextLiveStreamStep({
+  required LiveStreamIntent applied,
+  required LiveStreamIntent desired,
+  bool imuFresh = false,
+  bool imuDirty = false,
+  bool hrDirty = false,
+}) {
+  final replayImu = imuDirty || (imuFresh && desired.any);
+  if (desired.hr && (!applied.hr || hrDirty)) return LiveStreamStep.hrOn;
+  if (desired.imu && (!applied.imu || replayImu)) return LiveStreamStep.imuOn;
+  if (!desired.imu && (applied.imu || replayImu)) return LiveStreamStep.imuOff;
+  if (!desired.hr && (applied.hr || hrDirty)) return LiveStreamStep.hrOff;
+  return null;
+}
+
+/// [applied] after [step] succeeded.
+LiveStreamIntent applyLiveStreamStep(
+  LiveStreamIntent applied,
+  LiveStreamStep step,
+) =>
+    switch (step) {
+      LiveStreamStep.hrOn => LiveStreamIntent(hr: true, imu: applied.imu),
+      LiveStreamStep.hrOff => LiveStreamIntent(hr: false, imu: applied.imu),
+      LiveStreamStep.imuOn => LiveStreamIntent(hr: applied.hr, imu: true),
+      LiveStreamStep.imuOff => LiveStreamIntent(hr: applied.hr, imu: false),
+    };

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -36,7 +36,7 @@ import '../ble/hrs_link.dart';
 import '../ble/live_cadence.dart';
 import '../ble/live_step_runs.dart';
 import '../ble/ble_state.dart'
-    show AlarmConfirmation, AlarmEffect, SyncActivityWindow;
+    show AlarmConfirmation, AlarmEffect, LiveStreamOwners, SyncActivityWindow;
 import '../ble/ios_ble_restore.dart';
 import '../cloud/companion_client.dart';
 import '../compute/derivation_engine.dart';
@@ -1221,6 +1221,9 @@ class AppState extends ChangeNotifier {
       // LIVE high-rate frames (0x28/0x2B/0x33) are ephemeral — routed here for the
       // live UI / breathing session, never persisted.
       onLiveFrame: _onLiveFrame,
+      // Live HR/IMU ownership (#287): the engine reads the owner set inside
+      // its reconcile loop; this side only mutates owners and nudges.
+      liveOwners: _liveOwners,
       deriveDataStaleness: () {
         final ts = _lastRecTs;
         if (ts == null || ts <= 0) return const Duration(days: 3650);
@@ -1287,6 +1290,7 @@ class AppState extends ChangeNotifier {
           onState: _onEngineState,
           log: _log,
           onEvent: _onLiveEvent,
+          liveOwners: _liveOwners,
         );
   }
 
@@ -1363,10 +1367,9 @@ class AppState extends ChangeNotifier {
     _workoutTimer ??= Timer.periodic(const Duration(seconds: 1), (_) {});
   }
 
-  /// True while some foreground feature is holding the live streams open —
-  /// the gate [_maybeDowngradeLiveForBackground] consults. Tests only.
+  /// The live-stream owner set the engine reads right now. Tests only.
   @visibleForTesting
-  bool get debugHasLiveConsumer => _hasLiveConsumer;
+  LiveStreamOwners get debugLiveOwners => _liveOwners();
 
   /// Run start-up (guarded, exactly as the constructor fires it) so a test can
   /// drive the failure path. Tests only.
@@ -1547,7 +1550,7 @@ class AppState extends ChangeNotifier {
   /// — steady state has nothing left to reclaim on a second pass.
   Future<void> _maybeReclaimDiskSpace() async {
     if (_vacuumedThisLaunch || _disposed) return;
-    if (_background || busy || _hasLiveConsumer) return;
+    if (_background || busy || _liveSessionActive) return;
     _vacuumedThisLaunch = true;
     try {
       final freed = await LocalDb.vacuumIfBloated();
@@ -2222,21 +2225,11 @@ class AppState extends ChangeNotifier {
             // cold launch, so there is nothing to double-count.
             await _recoverOrphanedLiveSession();
             _resetLivePedometer();
-            // Settle any in-flight background downgrade FIRST — arming over
-            // a pending disable let its trailing OFF writes kill what we just
-            // armed.
-            await _settleBgLiveDowngrade();
-            if (Platform.isIOS && !engine.liveEnabled) {
-              // A background cold-launch connects with NO stream armed, and
-              // _maybeDowngradeLiveForBackground no-ops when live is already
-              // off — but on iOS zero inbound traffic can stall the suspended
-              // process's Dart timers (the 1 Hz notification is what keeps it
-              // schedulable; see the downgrade doc). Arm HR-only directly.
-              // Android correctly stays stream-less here.
-              unawaited(engine.enableHrOnlyLive());
-            } else {
-              _maybeDowngradeLiveForBackground();
-            }
+            // Apply the owners' intent to the fresh link: iOS backgrounded
+            // owns HR (the 1 Hz notification keeps the suspended process
+            // schedulable); Android backgrounded owns nothing and stays
+            // stream-less. See [_liveOwners].
+            await engine.reconcileLiveStreams();
             _startBackfillTimer();
           } else {
             // Connect attempt didn't succeed on this background cold-launch —
@@ -2562,11 +2555,10 @@ class AppState extends ChangeNotifier {
     // short background BLE wake gets the app killed (iOS CPU watchdog / jetsam).
     // Capture keeps running; queued derive jobs drain on foreground return.
     _deriveScheduler.setBackground(true);
-    // LIVE-FLOOD SUPPRESSION GUARD: with no foreground consumer of the live
-    // streams (no workout / breathing session), downgrade live to
-    // HR-only so the high-rate raw flood can't starve the periodic R24 offloads
-    // while backgrounded. Full live is restored on foreground reclaim.
-    _maybeDowngradeLiveForBackground();
+    // `_background` is an owner input (foreground gait IMU, the gen4 bundle,
+    // the iOS keepalive): let the engine step the streams to what the
+    // remaining owners call for. See [_liveOwners].
+    _nudgeLive();
     if (Platform.isAndroid) {
       // Android: ensure the Edge Tracking foreground service is up (idempotent) so the
       // process + live connection survive backgrounding. The service IS the keep-alive.
@@ -2589,69 +2581,95 @@ class AppState extends ChangeNotifier {
     }
   }
 
-  /// True while some foreground feature is actively consuming the live streams
-  /// (workout coach, breathing session).
-  bool get _hasLiveConsumer =>
+  // ── live HR / IMU ownership (#287) ──────────────────────────────────────────
+  //
+  // A foreground connection used to be an implicit request for both the
+  // realtime-HR stream and the 100 Hz IMU stream, and every feature that
+  // needed one re-armed the whole bundle and tried to remember whether it was
+  // the one that had turned it on. The engine now owns the streams through a
+  // serialized desired-vs-applied reconciler; this side only says WHO wants
+  // WHAT ([_liveOwners]) and nudges it whenever an owner changes.
+  //
+  // Policy (gen5; `desiredLiveStreams` in ble_state.dart):
+  //   HR  ← a mounted live-HR view, any workout, a breathing session or
+  //         window, or iOS backgrounded (the inbound 1 Hz notification is what
+  //         keeps the suspended process schedulable — with zero inbound
+  //         traffic the Dart timers may never run and continuous capture
+  //         stalls; the stream is load-bearing there, not waste).
+  //   IMU ← a gait workout in the FOREGROUND, a bounded movement-sampling
+  //         window, or the passive strap-step opt-in (off).
+  //   An ordinary foreground connection owns nothing on gen5: the on-chip daily
+  //   counter is the step fallback and the phone can supply windowed steps.
+  //   Android backgrounded with no owner is fully OFF — the EdgeTracking
+  //   foreground service keeps the process alive without any inbound stream,
+  //   and the 1 Hz stream with no consumer was ~86,400 wakes a day; liveness
+  //   is covered by the keep-alive's forced battery poll
+  //   (kNoStreamPollSilenceSeconds) and the resume paths judge freshness by
+  //   the no-stream bar. `state.wristOn`/`liveHr` simply stop updating while
+  //   nothing owns HR.
+  // gen4 keeps its previous behaviour: a foreground connection owns HR plus
+  // the R10/R11 + IMU + optical bundle (see `LiveStreamOwners.foreground`).
+
+  /// A feature session (workout, breathing) is running — the "nothing else in
+  /// flight" bar the one-off VACUUM waits for.
+  bool get _liveSessionActive =>
       activeWorkout != null || breathingActive || breathingWindowOpen;
 
-  /// Step live down when backgrounded with no live consumer. Platform-split:
-  ///
-  ///   • Android: live goes fully OFF. The EdgeTracking foreground service
-  ///     keeps the process alive without any inbound stream, so the 1 Hz
-  ///     HR-only stream bought nothing here — it was ~86,400 CPU/radio wakes
-  ///     per day (each one decode → state mutation → notifyListeners) with no
-  ///     consumer, the single largest steady drain on the phone. Liveness is
-  ///     covered by the keep-alive's forced battery poll (see
-  ///     kNoStreamPollSilenceSeconds) — a swap, not a removal: ~86,400
-  ///     notifications/day become ~1,440 get-battery round-trips/day, still
-  ///     the largest net win here. The resume paths judge freshness by the
-  ///     no-stream bar (isLinkStale liveStreamArmed: false), whose 90 s bar
-  ///     already tolerates one dropped poll reply. Records keep landing via
-  ///     the 15-min flash backfill. NOTE: `state.wristOn` is written from
-  ///     LIVE/hello paths only — it freezes for the backgrounded stretch
-  ///     (derived wear still comes from historical HR; nothing branches on
-  ///     the frozen flag). wristOn/liveHr simply stop updating in realtime.
-  ///
-  ///   • iOS: HR-only downgrade, as before. The inbound 1 Hz notification is
-  ///     what keeps the suspended process schedulable (bluetooth-central
-  ///     resumes us per notification) — with zero inbound traffic the Dart
-  ///     timers (keep-alive, backfill) may never run, stalling continuous
-  ///     background capture. The stream is load-bearing there, not waste.
-  ///
-  /// [openSession]'s fast reclaim (or a foreground reconnect) restores the
-  /// full set either way.
-  /// The in-flight background live downgrade, if any. `disableLiveStreams`
-  /// (Android) clears `liveEnabled`/`liveHrOnly` only AFTER its ~300 ms write
-  /// sequence, so a foreground reclaim landing inside that window must AWAIT
-  /// this before deciding whether to re-arm — otherwise it reads stale
-  /// full-live flags, skips `enableLiveStreams`, and the pending disable's OFF
-  /// writes then leave foreground live off. See [openSession].
-  Future<void>? _bgLiveDowngrade;
+  /// Screens showing the live BPM that are mounted right now.
+  int _liveHrViewers = 0;
 
-  void _maybeDowngradeLiveForBackground() {
-    if (!engine.isConnected || !engine.liveEnabled) return;
-    if (_hasLiveConsumer) return;
-    _bgLiveDowngrade = Platform.isAndroid
-        ? engine.disableLiveStreams()
-        : engine.enableHrOnlyLive();
-    unawaited(_bgLiveDowngrade!);
+  /// A screen that displays the live heart rate is on screen: own the HR
+  /// stream while it is. Pair with [releaseLiveHrView] in `dispose`.
+  void retainLiveHrView() {
+    _liveHrViewers++;
+    _nudgeLive();
   }
 
-  /// Await every in-flight background live downgrade before (re-)arming live
-  /// streams, so ON writes cannot interleave with a disable's trailing OFF
-  /// writes. Drains CHAINED downgrades too: a newer one started while an
-  /// older was awaited is awaited as well, never dropped.
-  Future<void> _settleBgLiveDowngrade() async {
-    while (_bgLiveDowngrade != null) {
-      final pending = _bgLiveDowngrade!;
-      try {
-        await pending;
-      } catch (_) {/* a failed downgrade still cleared its flags or didn't;
-                       either way the reclaim re-reads live state fresh */}
-      // Only clear when no NEWER downgrade replaced it while we awaited.
-      if (identical(_bgLiveDowngrade, pending)) _bgLiveDowngrade = null;
-    }
+  void releaseLiveHrView() {
+    if (_liveHrViewers > 0) _liveHrViewers--;
+    _nudgeLive();
   }
+
+  /// A bounded movement-reminder sampling window is open (IMU-only owner).
+  ///
+  /// There is NO scheduler yet, and enabling the movement-reminder preference
+  /// must not hold the IMU stream: sampling only inside bounded windows cannot
+  /// prove that movement did not happen between them, so a standing owner
+  /// would let the reminder claim an uninterrupted stillness it never
+  /// observed. A separately validated scheduler that can account for the gaps
+  /// is the only thing that should call this.
+  void setMovementSamplingWindow(bool active) {
+    if (_movementSampling == active) return;
+    _movementSampling = active;
+    _nudgeLive();
+  }
+
+  bool _movementSampling = false;
+
+  /// Passive strap-step collection: OFF by default on gen5 (#287 decision 1).
+  /// A future explicit opt-in requests IMU through this same owner.
+  static const bool _passiveStrapSteps = false;
+
+  LiveStreamOwners _liveOwners() {
+    final w = activeWorkout;
+    return LiveStreamOwners(
+      // A route is not disposed when the app backgrounds, so a mounted
+      // live-HR page must not keep the stream on behind a locked screen.
+      visibleLiveHrView: !_background && _liveHrViewers > 0,
+      activeWorkout: w != null,
+      foregroundGaitWorkout: w != null && !_background && isGaitStepType(w.type),
+      breathing: breathingActive || breathingWindowOpen,
+      iosBackgroundKeepalive: _background && Platform.isIOS,
+      movementSampling: _movementSampling,
+      passiveStrapSteps: _passiveStrapSteps,
+      foreground: !_background,
+    );
+  }
+
+  /// An owner input changed: let the engine converge. Fire-and-forget; the
+  /// engine reads [_liveOwners] inside its own loop, and its keep-alive tick
+  /// heals a nudge that was missed.
+  void _nudgeLive() => unawaited(engine.reconcileLiveStreams());
 
   /// iOS recovery: release the band to the native restore central's no-timeout pending
   /// connect so the OS relaunches us when the band is reachable again.
@@ -3906,8 +3924,8 @@ class AppState extends ChangeNotifier {
   /// The band's heart rate RIGHT NOW, or null when there isn't one.
   ///
   /// `DeviceState.liveHr` on its own is only "the last value the engine saw":
-  /// nothing clears it on an unintentional drop (the teardown path never calls
-  /// `disableLiveStreams`), so it keeps reading like a measurement long after
+  /// nothing clears it on an unintentional drop (only an applied HR OFF does),
+  /// so it keeps reading like a measurement long after
   /// the band is gone. Freshness rather than connection alone is the test,
   /// because it also covers the connected-but-stalled stream, which no
   /// disconnect hook can see. Every live consumer must read THIS.
@@ -4378,11 +4396,6 @@ class AppState extends ChangeNotifier {
     // Back in the foreground with an OS CPU/memory budget again — let the
     // scheduler drain any derive jobs that queued (durably) while backgrounded.
     _deriveScheduler.setBackground(false);
-    // A background live downgrade may still be writing (its flags clear only on
-    // completion). Let it finish before any reclaim path below re-arms live, so
-    // the re-arm sees settled flags and its ON writes can't interleave with the
-    // disable's trailing OFF writes.
-    await _settleBgLiveDowngrade();
     if (wasBackground && engine.isConnected) {
       IosBleRestore.foregroundActive = true;
       await IosBleRestore.setOwnsBand(true);
@@ -4408,12 +4421,9 @@ class AppState extends ChangeNotifier {
             await engine.getStrapName();
           } catch (_) {}
         }());
-        // Backgrounding downgraded live to HR-only (iOS) or fully OFF
-        // (Android) — restore the full live set now that the foreground UI is
-        // consuming it again.
-        if (!engine.liveEnabled || engine.liveHrOnly) {
-          unawaited(engine.enableLiveStreams());
-        }
+        // `_background` flipped: the foreground owners (gen4 bundle, a gait
+        // workout's IMU) apply again.
+        _nudgeLive();
         // FOREGROUND CATCH-UP: R24 drains on a ~15-min timer while backgrounded,
         // so "last data" can lag up to 15 min behind a healthy link. The user
         // just opened the app — pull the flash backlog now. Floored at 90 s
@@ -4481,7 +4491,7 @@ class AppState extends ChangeNotifier {
       // Compute + arm the next weekly-schedule occurrence on every successful
       // connect (Feature 1's arming engine) — see _armNextAlarmOccurrence.
       await _armNextAlarmOccurrence();
-      _log('Listening — live streams on, historical burst runs concurrently.');
+      _log('Listening — live streams per owners, historical burst runs concurrently.');
       // Enable live streams PROMPTLY, then let the historical burst run
       // CONCURRENTLY (unawaited, single-flight via _kickSyncBurst). History and
       // live records already share the one data subscription, so there is no
@@ -4492,12 +4502,12 @@ class AppState extends ChangeNotifier {
       // untouched: commit-before-ACK and the HISTORY_COMPLETE bookkeeping all
       // live inside the engine regardless of who awaits the report.
       // Recover any steps orphaned by a killed process, and zero the counters
-      // for this session, BEFORE live delivery starts. Doing it after
-      // enableLiveStreams() left a window where frames ingested during the
+      // for this session, BEFORE live delivery starts. Arming live first
+      // left a window where frames ingested during the
       // (awaited, I/O-bound) recovery were then wiped by _resetLivePedometer.
       await _recoverOrphanedLiveSession();
       _resetLivePedometer(); // fresh live step count for this connected session
-      await engine.enableLiveStreams();
+      await engine.reconcileLiveStreams(); // the owners' intent, not full live
       unawaited(
         _kickSyncBurst(kickFirst: false).then((report) async {
           _log(
@@ -4621,22 +4631,15 @@ class AppState extends ChangeNotifier {
           // Compute + arm the next weekly-schedule occurrence on every
           // successful (re)connect — see _armNextAlarmOccurrence.
           await _armNextAlarmOccurrence();
-          // Live streams come up promptly; the FULL drain (no short timeout —
-          // the ENTIRE offline backlog the band flashed while out of range)
-          // runs concurrently, single-flight, exactly as in openSession.
-          // Background reconnect with no live consumer: Android leaves live
-          // fully OFF (the FGS keeps the process alive; the 1 Hz stream has no
-          // consumer — see _maybeDowngradeLiveForBackground); iOS arms HR-only
-          // (the inbound notification keeps the suspended process schedulable).
-          await _settleBgLiveDowngrade();
-          if (_background && !_hasLiveConsumer) {
-            if (!Platform.isAndroid) {
-              await engine.enableHrOnlyLive();
-            }
-          } else {
-            await engine.enableLiveStreams();
-          }
+          // Live streams come up per the current owners (see _liveOwners:
+          // backgrounded with no owner is OFF on Android and HR-only on iOS);
+          // the FULL drain (no short timeout — the ENTIRE offline backlog the
+          // band flashed while out of range) runs concurrently, single-flight,
+          // exactly as in openSession.
+          // Reset BEFORE arming: an IMU ON step waits after the toggle, so
+          // frames can land inside the await and would then be wiped.
           _resetLivePedometer();
+          await engine.reconcileLiveStreams();
           await engine.getBattery();
           await engine.getStrapName();
           // Alarm display comes from the locally-set/persisted value; the
@@ -4920,7 +4923,7 @@ class AppState extends ChangeNotifier {
   // The live HRV spot-check that used to live here is GONE. It was fully
   // implemented — 60 s of RR-bearing frames handed to the repository seam —
   // and no screen ever started one, so `spotActive` was a permanently-false
-  // term in [_hasLiveConsumer] and a dead branch on every live frame. The
+  // term in the old live-consumer gate and a dead branch on every live frame. The
   // LocalRepository seam (`spotCheck`) is still there for whoever builds the
   // screen; the half-wired state machine is not.
 
@@ -4963,7 +4966,6 @@ class AppState extends ChangeNotifier {
   String? breathingError;
   final List<String> _breathingFrames = [];
   Timer? _breathingRecomputeTimer;
-  bool _breathingEnabledStreams = false;
 
   // ── MIND-06 · the quiet windows either side of the paced block ─────────────
   //
@@ -4989,11 +4991,9 @@ class AppState extends ChangeNotifier {
   /// to and are dropped).
   int? _windowRowStartedAt;
 
-  /// Open the quiet window: live streams on, frames buffering, no pacing yet.
-  ///
-  /// Takes stream ownership itself so [startBreathingSession] finds live
-  /// already enabled and claims nothing — otherwise the paced block's stop
-  /// would turn off streams the post window is still reading.
+  /// Open the quiet window: HR stream on, frames buffering, no pacing yet.
+  /// The window is an HR owner in its own right (see [_liveOwners]), so the
+  /// paced block's stop cannot turn off a stream the post window still reads.
   Future<void> openBreathingWindow() async {
     if (breathingWindowOpen || breathingActive) return;
     if (!isConnected) {
@@ -5006,14 +5006,8 @@ class AppState extends ChangeNotifier {
     _windowRowStartedAt = null;
     _breathingFrames.clear();
     notifyListeners();
-    await _settleBgLiveDowngrade();
     try {
-      if (!engine.liveEnabled) {
-        await engine.enableLiveStreams();
-        _breathingEnabledStreams = true;
-      } else if (engine.liveHrOnly) {
-        await engine.enableLiveStreams();
-      }
+      await engine.reconcileLiveStreams();
     } catch (_) {
       /* best-effort; we still collect whatever arrives */
     }
@@ -5035,7 +5029,7 @@ class AppState extends ChangeNotifier {
     _preWindowFrames = null;
     _windowRowStartedAt = null;
     _breathingFrames.clear();
-    _stopBreathingStreams();
+    _nudgeLive(); // the window's HR ownership ends here
     notifyListeners();
     if (row == null || pre == null) return;
     final before = await _windowRmssd(pre);
@@ -5092,19 +5086,12 @@ class AppState extends ChangeNotifier {
     notifyListeners();
     unawaited(BreathingLiveActivity.start(startedAt: DateTime.now()));
     try {
-      // A background downgrade may be mid-write (band double-tap start right
-      // after backgrounding is exactly this case): settle it first so its
-      // trailing OFF writes cannot kill the streams we arm here.
-      await _settleBgLiveDowngrade();
-      // OWNERSHIP: only claim "we enabled it" when
-      // live was actually OFF, so ending the session can never turn off
-      // streams the open session still expects on.
-      if (!engine.liveEnabled) {
-        await engine.enableLiveStreams();
-        _breathingEnabledStreams = true;
-      } else if (engine.liveHrOnly) {
-        await engine.enableLiveStreams();
-      }
+      // The session is an HR owner (see [_liveOwners]); the engine's
+      // reconciler serialises this against any in-flight transition, e.g. a
+      // background downgrade still writing when a band double-tap starts the
+      // session — the exact race that used to leave the session without its
+      // stream.
+      await engine.reconcileLiveStreams();
     } catch (_) {
       /* best-effort; we still collect whatever arrives */
     }
@@ -5124,7 +5111,7 @@ class AppState extends ChangeNotifier {
     _breathingRecomputeTimer?.cancel();
     _breathingRecomputeTimer = null;
     breathingActive = false;
-    _stopBreathingStreams();
+    _nudgeLive(); // the session's HR ownership ends; an open window keeps it
     unawaited(BreathingLiveActivity.end());
 
     final started = _breathingStartedAt;
@@ -5227,17 +5214,6 @@ class AppState extends ChangeNotifier {
     } catch (_) {
       /* best-effort; keep the last good result on screen rather than erroring */
     }
-  }
-
-  void _stopBreathingStreams() {
-    // The post window is still reading them. [closeBreathingWindow] is the one
-    // caller that clears the flag first, so it is the only one that gets past
-    // here while a window exists.
-    if (breathingWindowOpen) return;
-    if (_breathingEnabledStreams && activeWorkout == null) {
-      unawaited(engine.disableLiveStreams());
-    }
-    _breathingEnabledStreams = false;
   }
 
   // GUIDED STEP CALIBRATION REMOVED (v56).
@@ -5362,26 +5338,6 @@ class AppState extends ChangeNotifier {
     if (activeWorkout != null) return;
     final start = DateTime.now();
     final id = workoutId ?? 'w${start.millisecondsSinceEpoch}';
-    // The workout screen's live step count rides the 100 Hz IMU stream, which
-    // the sticky standard-HR fallback silently suppresses (same starvation as
-    // the calibration walk) — and which may simply be off (a breathing
-    // session restores streams to OFF when they were off before) or still in the
-    // background HR-only downgrade. A deliberate workout start is an explicit
-    // user action — retry the full live set; detectors re-trip if it can't
-    // hold. No ownership flag: the background downgrade / session close
-    // manage the stream lifecycle exactly as for openSession's arming.
-    unawaited(() async {
-      // The band double-tap lands while backgrounded by definition — settle
-      // the background HR-only downgrade BEFORE retrying full live, or its
-      // trailing OFF writes (~300 ms of them) kill exactly what we arm.
-      await _settleBgLiveDowngrade();
-      if (isConnected &&
-          (!engine.liveEnabled ||
-              engine.liveHrOnly ||
-              device.standardHrFallback)) {
-        await engine.retryFullLiveStreams();
-      }
-    }());
     _workoutRawBase = _liveRaw;
     _workoutSawSamples = false;
     _workoutMinuteSteps.clear();
@@ -5428,6 +5384,16 @@ class AppState extends ChangeNotifier {
       ),
       restingHr: _liveRestingHr,
     );
+    // The workout is now an owner (HR; plus IMU for a foreground gait type —
+    // the live step count rides the 100 Hz stream). AFTER the assignment: the
+    // engine reads the owner set synchronously on entry. A deliberate workout
+    // start is an explicit user action, so it also clears the sticky
+    // marginal-radio fallback that silently suppressed the IMU flood for the
+    // rest of the process lifetime; the detectors re-trip if it can't hold.
+    // Unconditionally: a workout may be started offline, and a fallback left
+    // set would mask its IMU owner for the whole session once the band
+    // reconnects. The reconcile is a no-op with no link.
+    unawaited(engine.clearRadioFallbackAndReconcile());
     // Persist the live session (INSERT OR REPLACE — idempotent if repo already
     // inserted this id). Final stats are written on stop.
     unawaited(
@@ -5664,6 +5630,7 @@ class AppState extends ChangeNotifier {
           unawaited(HrsLink.instance.arm());
           _deriveScheduler.setWorkoutActive(true);
           ScreenWake.enable();
+          _nudgeLive(); // a resumed workout owns its streams too
         } else {
           // A stale live row has no end_ts (it was never stopped). We don't
           // know when the workout actually ended, so the honest stamp is
@@ -5797,12 +5764,10 @@ class AppState extends ChangeNotifier {
           : 'Live session ended. Burned $finalKcal kcal.',
     );
     LiveActivity.end();
-    // A workout stopped while backgrounded (band double-tap gesture) was the
-    // one path that left FULL live armed with no consumer — the keep-alive
-    // then faithfully re-armed the 100 Hz flood every 30 s until the next
-    // lifecycle transition. Re-run the background downgrade now the consumer
-    // is gone (no-op when foregrounded or already downgraded).
-    if (_background) _maybeDowngradeLiveForBackground();
+    // The workout's ownership ends: a workout stopped while backgrounded used
+    // to leave FULL live armed with no consumer, and the keep-alive then
+    // re-armed the 100 Hz flood every 30 s until the next lifecycle transition.
+    _nudgeLive();
     // A workout often rides the live feed; if the connection blipped during it, the
     // band may hold that window in flash. Pull it now over the live connection so the
     // just-finished session isn't left with a gap.
@@ -5834,6 +5799,7 @@ class AppState extends ChangeNotifier {
     ScreenWake.release();
     _deriveScheduler.setWorkoutActive(false);
     activeWorkout = null;
+    _nudgeLive(); // the workout's stream ownership ends with it
     _workoutRawBase = null;
     _workoutSawSamples = false;
     _workoutMinuteSteps.clear();

--- a/lib/ui2/live_hr.dart
+++ b/lib/ui2/live_hr.dart
@@ -1,9 +1,11 @@
 // The heart rate arriving RIGHT NOW.
 //
-// Live HR is not a workout-only quantity: `openSession()` calls
-// `enableLiveStreams()` whenever the app is foregrounded with the band
-// connected, so a beat is usually a second old while someone is looking at the
-// app. It was simply never surfaced outside the workout screen.
+// Live HR is not a workout-only quantity, but the stream is not free either:
+// the screen hosting this card owns the realtime-HR stream while it is mounted
+// (`AppState.retainLiveHrView` / `releaseLiveHrView`, discussion #287), so a
+// beat is a second old while someone is looking at it and the band goes quiet
+// again when they leave. It was simply never surfaced outside the workout
+// screen.
 //
 // THE RULES THIS FILE HOLDS:
 //

--- a/lib/ui2/profile/devices.dart
+++ b/lib/ui2/profile/devices.dart
@@ -843,14 +843,25 @@ class _DeviceDetailState extends State<DeviceDetail> {
   /// notification they may have dismissed.
   BatteryForecast? _forecast;
 
+  /// This page shows the band's live BPM, so it owns the HR stream while
+  /// mounted. Captured for `dispose`, which must not read `context`.
+  AppState? _liveHrOwner;
+
   @override
   void initState() {
     super.initState();
     if (!widget.s.isBand) return;
+    _liveHrOwner = context.read<AppState>()..retainLiveHrView();
     LocalDb.batteryHealth().then((h) {
       if (mounted) setState(() => _health = h);
     }).catchError((_) {});
     _loadForecast();
+  }
+
+  @override
+  void dispose() {
+    _liveHrOwner?.releaseLiveHrView();
+    super.dispose();
   }
 
   Future<void> _loadForecast() async {

--- a/lib/ui2/screens/metric_detail.dart
+++ b/lib/ui2/screens/metric_detail.dart
@@ -505,6 +505,12 @@ class _MetricDetailState extends State<MetricDetail> {
     ]);
   }
 
+  /// The AppState this screen told "a live-HR view is on screen", captured
+  /// here so `dispose` can release it without touching `context`. Only the
+  /// LIVE resting-HR screen (data == null) reads AppState at all — fixtures
+  /// and goldens render with no Provider above them.
+  AppState? _liveHrOwner;
+
   @override
   void initState() {
     super.initState();
@@ -513,7 +519,16 @@ class _MetricDetailState extends State<MetricDetail> {
       _loading = false;
       return;
     }
+    if (widget.metricKey == 'resting_hr') {
+      _liveHrOwner = context.read<AppState>()..retainLiveHrView();
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  @override
+  void dispose() {
+    _liveHrOwner?.releaseLiveHrView();
+    super.dispose();
   }
 
   Future<void> _load() async {

--- a/test/app_state_live_owners_test.dart
+++ b/test/app_state_live_owners_test.dart
@@ -1,0 +1,176 @@
+// The live-stream owner set AppState hands the engine (discussion #287): which
+// feature states own the realtime-HR and IMU streams, and that the owner set
+// is already updated at the moment the engine is nudged.
+
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:openstrap_edge/ble/ble_engine.dart';
+import 'package:openstrap_edge/data/db.dart';
+import 'package:openstrap_edge/state/app_state.dart';
+import 'package:openstrap_protocol/openstrap_protocol.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const name = 'app_state_live_owners_test.db';
+
+  setUpAll(() async {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+    await LocalDb.close();
+    LocalDb.dbName = name;
+    await databaseFactory.deleteDatabase(
+      p.join(await databaseFactory.getDatabasesPath(), name),
+    );
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    BleEngine.resetBandClaimForTest();
+  });
+  tearDown(BleEngine.resetBandClaimForTest);
+
+  tearDownAll(() async {
+    await LocalDb.close();
+    await databaseFactory.deleteDatabase(
+      p.join(await databaseFactory.getDatabasesPath(), name),
+    );
+  });
+
+  LiveWorkoutState workout(String type) => LiveWorkoutState(
+        startTime: DateTime.now(),
+        targetKcal: 0,
+        type: type,
+      );
+
+  test('a fresh foreground AppState owns nothing but "foreground"', () {
+    final app = AppState.forTesting();
+    addTearDown(app.dispose);
+    final o = app.debugLiveOwners;
+    expect(o.foreground, isTrue);
+    expect(o.visibleLiveHrView, isFalse);
+    expect(o.activeWorkout, isFalse);
+    expect(o.foregroundGaitWorkout, isFalse);
+    expect(o.breathing, isFalse);
+    expect(o.movementSampling, isFalse);
+    expect(o.passiveStrapSteps, isFalse, reason: 'off by default (#287)');
+  });
+
+  test('a gait workout owns IMU in the foreground; a non-gait one does not', () {
+    final app = AppState.forTesting();
+    addTearDown(app.dispose);
+    app.activeWorkout = workout('running');
+    expect(app.debugLiveOwners.activeWorkout, isTrue);
+    expect(app.debugLiveOwners.foregroundGaitWorkout, isTrue);
+    app.activeWorkout = workout('Strength');
+    expect(app.debugLiveOwners.activeWorkout, isTrue);
+    expect(app.debugLiveOwners.foregroundGaitWorkout, isFalse);
+    app.activeWorkout = workout('Trail Running'.toLowerCase().replaceAll(' ', '_'));
+    expect(app.debugLiveOwners.foregroundGaitWorkout, isTrue);
+  });
+
+  test('backgrounding keeps the workout\'s HR ownership and drops its IMU', () async {
+    final app = AppState.forTesting();
+    addTearDown(app.dispose);
+    app.activeWorkout = workout('walking');
+    await app.pauseForBackground();
+    final o = app.debugLiveOwners;
+    expect(o.foreground, isFalse);
+    expect(o.activeWorkout, isTrue);
+    expect(o.foregroundGaitWorkout, isFalse,
+        reason: 'background IMU is not promised until measured');
+  });
+
+  test('a breathing window or session owns HR; neither, nothing', () {
+    final app = AppState.forTesting();
+    addTearDown(app.dispose);
+    app.breathingWindowOpen = true;
+    expect(app.debugLiveOwners.breathing, isTrue);
+    app.breathingActive = true;
+    app.breathingWindowOpen = false;
+    expect(app.debugLiveOwners.breathing, isTrue);
+    app.breathingActive = false;
+    expect(app.debugLiveOwners.breathing, isFalse);
+  });
+
+  test('live-HR views are counted: the last one to leave releases HR', () {
+    final app = AppState.forTesting();
+    addTearDown(app.dispose);
+    app.retainLiveHrView();
+    app.retainLiveHrView();
+    app.releaseLiveHrView();
+    expect(app.debugLiveOwners.visibleLiveHrView, isTrue);
+    app.releaseLiveHrView();
+    expect(app.debugLiveOwners.visibleLiveHrView, isFalse);
+    app.releaseLiveHrView(); // an extra release cannot go negative
+    app.retainLiveHrView();
+    expect(app.debugLiveOwners.visibleLiveHrView, isTrue);
+  });
+
+  test('a mounted live-HR view does not own HR while backgrounded', () async {
+    final app = AppState.forTesting();
+    addTearDown(app.dispose);
+    app.retainLiveHrView();
+    await app.pauseForBackground();
+    expect(app.debugLiveOwners.visibleLiveHrView, isFalse,
+        reason: 'the route survives backgrounding; the stream must not');
+  });
+
+  test('starting a workout offline still clears the sticky radio fallback', () async {
+    final app = AppState.forTesting();
+    addTearDown(app.dispose);
+    app.engine.state.standardHrFallback = true;
+    app.startWorkout(type: 'running');
+    await app.engine.reconcileLiveStreams();
+    expect(app.engine.state.standardHrFallback, isFalse);
+    await app.stopWorkout();
+  });
+
+  test('a movement-sampling window is an owner only while open', () {
+    final app = AppState.forTesting();
+    addTearDown(app.dispose);
+    app.setMovementSamplingWindow(true);
+    expect(app.debugLiveOwners.movementSampling, isTrue);
+    app.setMovementSamplingWindow(false);
+    expect(app.debugLiveOwners.movementSampling, isFalse);
+  });
+
+  test('stopWorkout ends the workout\'s ownership', () async {
+    final app = AppState.forTesting();
+    addTearDown(app.dispose);
+    app.activeWorkout = workout('running');
+    await app.stopWorkout();
+    expect(app.debugLiveOwners.activeWorkout, isFalse);
+  });
+
+  test('startWorkout: the engine sees the workout on the very first pass', () async {
+    // The engine reads owners synchronously when nudged, so the nudge has to
+    // come AFTER `activeWorkout` is assigned — otherwise the first pass sees
+    // no workout, and nothing arms until a keep-alive tick.
+    final app = AppState.forTesting();
+    addTearDown(app.dispose);
+    final opcodes = <int>[];
+    app.engine.debugInstallFakeLink(
+      band: BandProfile.gen5,
+      listening: true,
+      onWrite: (Uint8List frame) async {
+        final op = parseFrame(frame, profile: BandProfile.gen5)!.inner[2];
+        // Only the live toggles: a READY link also carries stopWorkout's
+        // resync burst, which is not what this test is about.
+        if (op == Cmd.toggleRealtimeHr || op == Cmd.toggleImuMode) opcodes.add(op);
+        return true;
+      },
+    );
+    app.startWorkout(type: 'running');
+    await app.engine.reconcileLiveStreams(); // the barrier for the nudged pass
+    expect(opcodes, [Cmd.toggleRealtimeHr, Cmd.toggleImuMode]);
+    await app.stopWorkout();
+    await app.engine.reconcileLiveStreams();
+    expect(opcodes.sublist(2), [Cmd.toggleImuMode, Cmd.toggleRealtimeHr]);
+  });
+}

--- a/test/live_hr_view_owner_test.dart
+++ b/test/live_hr_view_owner_test.dart
@@ -1,0 +1,99 @@
+// The two screens that show the live BPM own the realtime-HR stream while
+// mounted and release it on dispose (discussion #287): the resting-HR detail
+// screen's live card host and the band's device page.
+//
+// No database is opened here on purpose: both screens tolerate a missing one
+// (the live resting-HR screen has no repo to load from under a test AppState;
+// the device page's battery reads are best-effort), and a real sqflite open
+// under the widget test's fake clock leaves the close hanging in teardown.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:openstrap_edge/ble/ble_engine.dart';
+import 'package:openstrap_edge/state/app_state.dart';
+import 'package:openstrap_edge/ui2/profile/devices.dart';
+import 'package:openstrap_edge/ui2/screens/metric_detail.dart';
+import 'package:openstrap_edge/ui2/ui2.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    BleEngine.resetBandClaimForTest();
+  });
+  tearDown(BleEngine.resetBandClaimForTest);
+
+  Widget host(AppState app, Widget child) => MaterialApp(
+        theme: buildTheme(Brightness.light),
+        home: ChangeNotifierProvider<AppState>.value(
+          value: app,
+          child: Scaffold(body: child),
+        ),
+      );
+
+  Future<void> pumpOut(WidgetTester t, AppState app) async {
+    await t.pumpWidget(host(app, const SizedBox()));
+    await t.pump();
+  }
+
+  testWidgets('the live resting-HR screen owns HR while mounted', (t) async {
+    t.view.physicalSize = const Size(390 * 3, 2400 * 3);
+    t.view.devicePixelRatio = 3;
+    addTearDown(t.view.reset);
+    final app = AppState.forTesting();
+    addTearDown(app.dispose);
+    await t.pumpWidget(host(app, const MetricDetail('resting_hr')));
+    await t.pump();
+    expect(app.debugLiveOwners.visibleLiveHrView, isTrue);
+    await pumpOut(t, app);
+    expect(app.debugLiveOwners.visibleLiveHrView, isFalse);
+  });
+
+  testWidgets('another metric\'s screen owns nothing', (t) async {
+    t.view.physicalSize = const Size(390 * 3, 2400 * 3);
+    t.view.devicePixelRatio = 3;
+    addTearDown(t.view.reset);
+    final app = AppState.forTesting();
+    addTearDown(app.dispose);
+    await t.pumpWidget(host(app, const MetricDetail('hrv')));
+    await t.pump();
+    expect(app.debugLiveOwners.visibleLiveHrView, isFalse);
+    await pumpOut(t, app);
+  });
+
+  testWidgets('the band device page owns HR while mounted; a sensor page does not',
+      (t) async {
+    t.view.physicalSize = const Size(390 * 3, 2400 * 3);
+    t.view.devicePixelRatio = 3;
+    addTearDown(t.view.reset);
+    final app = AppState.forTesting();
+    addTearDown(app.dispose);
+    const band = HealthSource(
+      name: 'WHOOP',
+      kind: 'band',
+      tier: null,
+      icon: Icons.watch,
+      isBand: true,
+    );
+    await t.pumpWidget(host(app, const DeviceDetail(band)));
+    await t.pump();
+    expect(app.debugLiveOwners.visibleLiveHrView, isTrue);
+    await pumpOut(t, app);
+    expect(app.debugLiveOwners.visibleLiveHrView, isFalse);
+
+    const sensor = HealthSource(
+      name: 'Chest strap',
+      kind: 'sensor',
+      tier: null,
+      icon: Icons.favorite,
+    );
+    await t.pumpWidget(host(app, const DeviceDetail(sensor)));
+    await t.pump();
+    expect(app.debugLiveOwners.visibleLiveHrView, isFalse);
+    await pumpOut(t, app);
+  });
+}

--- a/test/live_stream_ownership_test.dart
+++ b/test/live_stream_ownership_test.dart
@@ -1,0 +1,654 @@
+// Live HR / IMU ownership reconciler (discussion #287), driven end to end
+// through the engine's fake-link seam: which opcodes go out for which owner
+// set, in what order, and what happens when a write is slow, fails, or lands
+// after the link it was written to is gone.
+//
+// HR is opcode 3 on both generations. The high-rate bundle is IMU opcode 106
+// (0x6A) alone on gen5 and R10/R11 (0x3F) + IMU + optical (0x6B/0x6C) on
+// gen4, whose byte sequences must stay exactly what the old enable / HR-only /
+// disable methods wrote.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ble/ble_engine.dart';
+import 'package:openstrap_edge/ble/ble_state.dart';
+import 'package:openstrap_edge/sync/sync_policy.dart';
+import 'package:openstrap_protocol/openstrap_protocol.dart';
+
+typedef _Write = ({int opcode, List<int> body});
+
+const _hr = Cmd.toggleRealtimeHr; // 0x03
+const _imu = Cmd.toggleImuMode; // 0x6A
+const _r10 = Cmd.sendR10R11Realtime; // 0x3F
+const _optSave = Cmd.enableOpticalData; // 0x6B
+const _optMode = Cmd.toggleOpticalMode; // 0x6C
+
+const _fgGait = LiveStreamOwners(
+  activeWorkout: true,
+  foregroundGaitWorkout: true,
+  foreground: true,
+);
+const _hrView = LiveStreamOwners(visibleLiveHrView: true, foreground: true);
+
+/// A connected-looking link with no radio behind it.
+///
+/// The owner set is a mutable field the engine reads through its provider
+/// callback, exactly as AppState supplies it. Writes are recorded per link
+/// (a superseding link gets its own list) so a test can prove that a stale
+/// tail never reaches a replacement session.
+class _Rig {
+  final BandProfile band;
+  final logs = <String>[];
+  late final BleEngine engine;
+  LiveStreamOwners owners = LiveStreamOwners.none;
+
+  /// Every write, on every link, in order.
+  final all = <_Write>[];
+
+  /// Writes on the CURRENT link only (reset by [newLink]).
+  var link = <_Write>[];
+
+  /// Park the NEXT write of an opcode until the completer completes. The park
+  /// happens inside the write hook, i.e. inside the engine's write chain, so
+  /// everything queued behind it waits too — the same shape as a slow GATT
+  /// acknowledgement.
+  final _gates = <int, Completer<void>>{};
+
+  /// Opcodes whose writes report failure.
+  final failing = <int>{};
+
+  _Rig({this.band = BandProfile.gen5}) {
+    engine = BleEngine(
+      onRecord: (_, _) async {},
+      onState: (_) {},
+      log: logs.add,
+      liveOwners: () => owners,
+    );
+    newLink();
+  }
+
+  /// Install a fresh fake session (after a drop, or to supersede one).
+  /// [listening] = READY; a link still bootstrapping is not written to.
+  void newLink({BandProfile? band, bool listening = true, bool? liveReady}) {
+    link = <_Write>[];
+    final sink = link;
+    final profile = band ?? this.band;
+    engine.debugInstallFakeLink(
+      band: profile,
+      listening: listening,
+      liveReady: liveReady,
+      onWrite: (Uint8List frame) async {
+        final inner = parseFrame(frame, profile: profile)!.inner;
+        final opcode = inner[2];
+        final gate = _gates.remove(opcode);
+        if (gate != null) await gate.future;
+        final w = (opcode: opcode, body: inner.sublist(3));
+        sink.add(w);
+        all.add(w);
+        return !failing.contains(opcode);
+      },
+    );
+  }
+
+  Completer<void> park(int opcode) => _gates[opcode] = Completer<void>();
+
+  List<int> get opcodes => link.map((w) => w.opcode).toList();
+
+  /// `(opcode, on/off)` pairs. The inner payload is padded, so the on/off
+  /// byte is picked by opcode: `[rev1, on]` for the optical toggles and the
+  /// gen5 IMU toggle, a bare `[on]` for everything else.
+  List<(int, int)> get ops => [
+        for (final w in link)
+          (
+            w.opcode,
+            w.opcode == _optSave ||
+                    w.opcode == _optMode ||
+                    (w.opcode == _imu && band.isGen5)
+                ? w.body[1]
+                : w.body[0],
+          ),
+      ];
+
+  Future<void> reconcile() => engine.reconcileLiveStreams();
+
+  Future<void> setOwners(LiveStreamOwners o) {
+    owners = o;
+    return reconcile();
+  }
+
+  /// Let the engine start a pass and reach the write hook.
+  Future<void> settle() => Future<void>.delayed(const Duration(milliseconds: 20));
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(BleEngine.resetBandClaimForTest);
+  tearDown(BleEngine.resetBandClaimForTest);
+
+  group('gen5 — owner → opcode table', () {
+    test('ordinary READY with no owner writes nothing', () async {
+      final rig = _Rig();
+      await rig.reconcile();
+      expect(rig.opcodes, isEmpty);
+      expect(rig.engine.liveEnabled, isFalse);
+    });
+
+    test('ordinary foreground connection is not an owner on gen5', () async {
+      final rig = _Rig();
+      await rig.setOwners(const LiveStreamOwners(foreground: true));
+      expect(rig.opcodes, isEmpty);
+    });
+
+    test('visible live-HR view: HR only', () async {
+      final rig = _Rig();
+      await rig.setOwners(_hrView);
+      expect(rig.ops, [(_hr, 1)]);
+      expect(rig.engine.debugLiveApplied, const LiveStreamIntent(hr: true, imu: false));
+    });
+
+    test('breathing session/window: HR only', () async {
+      final rig = _Rig();
+      await rig.setOwners(const LiveStreamOwners(breathing: true, foreground: true));
+      expect(rig.ops, [(_hr, 1)]);
+    });
+
+    test('foreground gait workout: HR ON then IMU ON, rev-1 body, no optical', () async {
+      final rig = _Rig();
+      await rig.setOwners(_fgGait);
+      expect(rig.opcodes, [_hr, _imu]);
+      expect(rig.link[0].body.first, 0x01);
+      expect(rig.link[1].body.sublist(0, 2), [revision1, 0x01]);
+      expect(rig.opcodes, isNot(contains(_optSave)));
+      expect(rig.opcodes, isNot(contains(_optMode)));
+      expect(rig.engine.debugLiveApplied, const LiveStreamIntent(hr: true, imu: true));
+    });
+
+    test('non-gait workout (manual strength): HR only', () async {
+      final rig = _Rig();
+      await rig.setOwners(const LiveStreamOwners(activeWorkout: true, foreground: true));
+      expect(rig.ops, [(_hr, 1)]);
+    });
+
+    test('bounded movement-sampling window: IMU only; outside it, nothing', () async {
+      final rig = _Rig();
+      await rig.setOwners(const LiveStreamOwners(movementSampling: true, foreground: true));
+      expect(rig.ops, [(_imu, 1)]);
+      await rig.setOwners(const LiveStreamOwners(foreground: true));
+      expect(rig.ops, [(_imu, 1), (_imu, 0)]);
+      expect(rig.engine.liveEnabled, isFalse);
+    });
+
+    test('background gait workout: HR requested, IMU off', () async {
+      final rig = _Rig();
+      await rig.setOwners(const LiveStreamOwners(activeWorkout: true));
+      expect(rig.ops, [(_hr, 1)]);
+    });
+
+    test('iOS background with no other owner: HR only', () async {
+      final rig = _Rig();
+      await rig.setOwners(const LiveStreamOwners(iosBackgroundKeepalive: true));
+      expect(rig.ops, [(_hr, 1)]);
+    });
+
+    test('Android background with no owner: everything off, bundle before HR', () async {
+      final rig = _Rig();
+      await rig.setOwners(_fgGait);
+      await rig.setOwners(LiveStreamOwners.none);
+      expect(rig.ops, [(_hr, 1), (_imu, 1), (_imu, 0), (_hr, 0)]);
+      expect(rig.engine.liveEnabled, isFalse);
+      expect(rig.opcodes, isNot(contains(_optSave)));
+      expect(rig.opcodes, isNot(contains(_optMode)));
+    });
+
+    test('marginal-radio fallback drops an applied IMU on the next pass', () async {
+      final rig = _Rig();
+      await rig.setOwners(_fgGait);
+      rig.engine.state.standardHrFallback = true;
+      await rig.reconcile();
+      expect(rig.ops, [(_hr, 1), (_imu, 1), (_imu, 0)]);
+      // An explicit user action clears it and re-arms.
+      await rig.engine.clearRadioFallbackAndReconcile();
+      expect(rig.engine.state.standardHrFallback, isFalse);
+      expect(rig.ops.last, (_imu, 1));
+    });
+  });
+
+  group('overlapping owners', () {
+    test('two HR owners: HR goes off only after the last one leaves', () async {
+      final rig = _Rig();
+      await rig.setOwners(const LiveStreamOwners(activeWorkout: true, breathing: true));
+      expect(rig.ops, [(_hr, 1)]);
+      await rig.setOwners(const LiveStreamOwners(activeWorkout: true));
+      expect(rig.ops, [(_hr, 1)], reason: 'the workout still owns HR');
+      await rig.setOwners(LiveStreamOwners.none);
+      expect(rig.ops, [(_hr, 1), (_hr, 0)]);
+    });
+
+    test('two IMU owners: IMU goes off only after the last one leaves', () async {
+      final rig = _Rig();
+      await rig.setOwners(const LiveStreamOwners(
+        activeWorkout: true,
+        foregroundGaitWorkout: true,
+        movementSampling: true,
+        foreground: true,
+      ));
+      expect(rig.ops, [(_hr, 1), (_imu, 1)]);
+      await rig.setOwners(const LiveStreamOwners(movementSampling: true, foreground: true));
+      expect(rig.ops, [(_hr, 1), (_imu, 1), (_hr, 0)], reason: 'IMU still owned');
+      await rig.setOwners(const LiveStreamOwners(foreground: true));
+      expect(rig.ops.last, (_imu, 0));
+    });
+  });
+
+  group('transitions under delayed writes', () {
+    test('close/reopen during a delayed OFF converges on the new owner', () async {
+      final rig = _Rig();
+      await rig.setOwners(_hrView);
+      final gate = rig.park(_hr);
+      rig.owners = LiveStreamOwners.none;
+      final off = rig.reconcile(); // HR OFF parks in the hook
+      await rig.settle();
+      rig.owners = _hrView; // a new owner arrives while OFF is in flight
+      final on = rig.reconcile(); // coalesces behind the running pass
+      gate.complete();
+      await Future.wait([off, on]);
+      expect(rig.ops, [(_hr, 1), (_hr, 0), (_hr, 1)]);
+      expect(rig.engine.debugLiveApplied.hr, isTrue);
+    });
+
+    test('rapid owner flips during a delayed write converge to the newest', () async {
+      final rig = _Rig();
+      final gate = rig.park(_hr);
+      rig.owners = _hrView;
+      final first = rig.reconcile(); // HR ON parks
+      await rig.settle();
+      rig.owners = LiveStreamOwners.none;
+      unawaited(rig.reconcile());
+      rig.owners = _hrView;
+      unawaited(rig.reconcile());
+      rig.owners = LiveStreamOwners.none;
+      final last = rig.reconcile();
+      gate.complete();
+      await Future.wait([first, last]);
+      expect(rig.ops, [(_hr, 1), (_hr, 0)]);
+      expect(rig.engine.liveEnabled, isFalse);
+    });
+
+    test('a coalesced caller\'s await is a barrier for the pass that sees it', () async {
+      final rig = _Rig();
+      final gate = rig.park(_hr);
+      rig.owners = _hrView;
+      unawaited(rig.reconcile());
+      await rig.settle();
+      rig.owners = LiveStreamOwners.none;
+      final done = rig.reconcile();
+      var completed = false;
+      unawaited(done.then((_) => completed = true));
+      await rig.settle();
+      expect(completed, isFalse, reason: 'still parked');
+      gate.complete();
+      await done;
+      expect(rig.ops, [(_hr, 1), (_hr, 0)]);
+    });
+  });
+
+  group('failed writes', () {
+    test('failed ON: applied stays off, and a later pass retries', () async {
+      final rig = _Rig();
+      rig.failing.add(_hr);
+      await rig.setOwners(_hrView);
+      expect(rig.ops, [(_hr, 1)]);
+      expect(rig.engine.liveEnabled, isFalse, reason: 'never claimed applied');
+      rig.failing.clear();
+      await rig.reconcile();
+      expect(rig.ops, [(_hr, 1), (_hr, 1)]);
+      expect(rig.engine.debugLiveApplied.hr, isTrue);
+    });
+
+    test('failed HR ON then the owner leaves: HR OFF is still written', () async {
+      final rig = _Rig();
+      rig.failing.add(_hr);
+      await rig.setOwners(_hrView);
+      rig.failing.clear();
+      await rig.setOwners(LiveStreamOwners.none);
+      expect(rig.ops, [(_hr, 1), (_hr, 0)],
+          reason: 'a timed-out ON may have landed; the dirty bit replays OFF');
+    });
+
+    test('failed HR OFF then a new owner: HR ON is re-sent', () async {
+      final rig = _Rig();
+      await rig.setOwners(_hrView);
+      rig.failing.add(_hr);
+      await rig.setOwners(LiveStreamOwners.none);
+      rig.failing.clear();
+      await rig.setOwners(_hrView);
+      expect(rig.ops, [(_hr, 1), (_hr, 0), (_hr, 1)]);
+      expect(rig.engine.debugLiveApplied.hr, isTrue);
+    });
+
+    test('a nudge during a failed write is honoured in the same pass', () async {
+      final rig = _Rig();
+      rig.failing.add(_hr);
+      final gate = rig.park(_hr);
+      rig.owners = _hrView;
+      final first = rig.reconcile();
+      await rig.settle();
+      rig.owners = LiveStreamOwners.none; // arrives while the ON is failing
+      final second = rig.reconcile();
+      gate.complete();
+      await Future.wait([first, second]);
+      expect(rig.ops, [(_hr, 1), (_hr, 0)],
+          reason: 'the pass recomputed after the failure instead of exiting');
+    });
+  });
+
+  group('link replacement', () {
+    test('a step completing after teardown does not touch the new link', () async {
+      final rig = _Rig();
+      final gate = rig.park(_imu);
+      rig.owners = _fgGait;
+      final pass = rig.reconcile(); // HR ON lands, IMU ON parks
+      await rig.settle();
+      await Future<void>.delayed(const Duration(milliseconds: 150)); // past the 100 ms gap
+      final oldLink = rig.link;
+      await rig.engine.debugDropLink();
+      expect(rig.engine.liveEnabled, isFalse, reason: 'applied cleared by teardown');
+      rig.newLink();
+      gate.complete();
+      await pass;
+      expect(oldLink.map((w) => w.opcode), [_hr, _imu]);
+      expect(rig.logs, contains(contains('completed after teardown — discarded')),
+          reason: 'the stale IMU completion was not recorded as applied');
+      // The still-running pass then gives the replacement link its own clean
+      // pass from the current owners — HR first, from scratch — rather than
+      // inheriting the old link's half-applied state.
+      expect(rig.ops, [(_hr, 1), (_imu, 1)]);
+      expect(rig.engine.debugLiveApplied, const LiveStreamIntent(hr: true, imu: true));
+    });
+
+    test('a replacement link that has not reached READY is not written to', () async {
+      final rig = _Rig();
+      final gate = rig.park(_imu);
+      rig.owners = _fgGait;
+      final pass = rig.reconcile();
+      await rig.settle();
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      await rig.engine.debugDropLink();
+      rig.newLink(listening: false); // physically connected, mid-bootstrap
+      gate.complete();
+      await pass;
+      expect(rig.link, isEmpty,
+          reason: 'no live toggle may enter the bootstrap sequence');
+      await rig.reconcile(); // an owner nudge mid-bootstrap: same
+      expect(rig.link, isEmpty);
+      rig.newLink(); // READY
+      await rig.reconcile();
+      expect(rig.ops, [(_hr, 1), (_imu, 1)]);
+    });
+
+    test('a listening link whose INIT sequence is still going out is not '
+        'written to either', () async {
+      final rig = _Rig();
+      rig.newLink(listening: true, liveReady: false); // between INIT packets
+      await rig.setOwners(_fgGait);
+      expect(rig.link, isEmpty,
+          reason: 'no live toggle may interleave with the INIT packets');
+      rig.newLink(); // INIT done
+      await rig.reconcile();
+      expect(rig.ops, [(_hr, 1), (_imu, 1)]);
+    });
+
+    test('reconnect re-applies the current owners', () async {
+      final rig = _Rig();
+      await rig.setOwners(_fgGait);
+      await rig.engine.debugDropLink();
+      rig.newLink();
+      expect(rig.engine.liveEnabled, isFalse);
+      await rig.reconcile();
+      expect(rig.ops, [(_hr, 1), (_imu, 1)]);
+    });
+
+    test('a delayed gen4 bundle never continues onto a replacement gen5 link', () async {
+      final rig = _Rig(band: BandProfile.gen4);
+      final gate = rig.park(_r10); // park inside the ON bundle
+      rig.owners = const LiveStreamOwners(foreground: true);
+      final pass = rig.reconcile();
+      await rig.settle();
+      await Future<void>.delayed(const Duration(milliseconds: 150)); // reach R10
+      await rig.engine.debugDropLink();
+      rig.newLink(band: BandProfile.gen5);
+      gate.complete();
+      await pass;
+      expect(rig.link, isEmpty);
+      expect(rig.all.map((w) => w.opcode), [_hr, _r10],
+          reason: 'IMU/optical tail aborted at the first stale check');
+    });
+  });
+
+  group('disconnect()', () {
+    test('turns applied streams off before tearing down', () async {
+      final rig = _Rig();
+      await rig.setOwners(_fgGait);
+      await rig.engine.disconnect();
+      expect(rig.ops, [(_hr, 1), (_imu, 1), (_imu, 0), (_hr, 0)]);
+      expect(rig.engine.liveEnabled, isFalse);
+    });
+
+    test('during a delayed ON: converges to OFF, nothing re-arms, and the '
+        'shutdown latch is released for the next link', () async {
+      final rig = _Rig();
+      final gate = rig.park(_hr);
+      rig.owners = _hrView;
+      unawaited(rig.reconcile());
+      await rig.settle();
+      final closing = rig.engine.disconnect();
+      await rig.settle();
+      gate.complete();
+      await closing;
+      expect(rig.ops, [(_hr, 1), (_hr, 0)]);
+      expect(rig.engine.liveEnabled, isFalse);
+      // The owner is still there; a fresh link arms again.
+      rig.newLink();
+      await rig.reconcile();
+      expect(rig.ops, [(_hr, 1)]);
+    });
+
+    test('during a failed ON: the shutdown intent is processed in the same pass', () async {
+      final rig = _Rig();
+      rig.failing.add(_hr);
+      final gate = rig.park(_hr);
+      rig.owners = _hrView;
+      unawaited(rig.reconcile());
+      await rig.settle();
+      final closing = rig.engine.disconnect();
+      await rig.settle();
+      gate.complete();
+      await closing;
+      expect(rig.ops, [(_hr, 1), (_hr, 0)],
+          reason: 'OFF attempted for the dirty bit before teardown');
+    });
+
+    test('during a delayed OFF: waits for it, writes nothing more', () async {
+      final rig = _Rig();
+      await rig.setOwners(_hrView);
+      final gate = rig.park(_hr);
+      rig.owners = LiveStreamOwners.none;
+      unawaited(rig.reconcile());
+      await rig.settle();
+      final closing = rig.engine.disconnect();
+      await rig.settle();
+      gate.complete();
+      await closing;
+      expect(rig.ops, [(_hr, 1), (_hr, 0)]);
+    });
+  });
+
+  group('keep-alive reassert', () {
+    test('re-sends what is applied; HR only when no reading is flowing', () async {
+      final rig = _Rig();
+      await rig.setOwners(_fgGait);
+      await rig.engine.debugReassertLiveStreams();
+      expect(rig.ops, [(_hr, 1), (_imu, 1), (_imu, 1), (_hr, 1)]);
+      rig.engine.state.liveHrAt = DateTime.now().millisecondsSinceEpoch;
+      await rig.engine.debugReassertLiveStreams();
+      expect(rig.ops.last, (_imu, 1), reason: 'HR is delivering: not re-sent');
+    });
+
+    test('a keep-alive reassert during a failing pass does not restart it', () async {
+      final rig = _Rig();
+      rig.failing.add(_hr);
+      final gate = rig.park(_hr);
+      rig.owners = _hrView;
+      final pass = rig.reconcile();
+      await rig.settle();
+      final tick = rig.engine.debugReassertLiveStreams(); // the 30 s tick
+      gate.complete();
+      await Future.wait([pass, tick]);
+      expect(rig.ops, [(_hr, 1)],
+          reason: 'the failed ON is retried by a LATER tick, not re-run by '
+              'the tick that overlapped it');
+      expect(rig.engine.liveEnabled, isFalse);
+      rig.failing.clear();
+      rig.engine.state.liveHrAt = DateTime.now().millisecondsSinceEpoch;
+      await rig.engine.debugReassertLiveStreams();
+      expect(rig.ops, [(_hr, 1), (_hr, 1)], reason: 'the later tick retries');
+    });
+
+    test('nothing applied: nothing re-sent', () async {
+      final rig = _Rig();
+      await rig.engine.debugReassertLiveStreams();
+      expect(rig.opcodes, isEmpty);
+    });
+
+    test('a teardown between the two re-arms stops the HR write', () async {
+      final rig = _Rig();
+      await rig.setOwners(_fgGait);
+      final gate = rig.park(_imu);
+      final pass = rig.engine.debugReassertLiveStreams();
+      await rig.settle();
+      await rig.engine.debugDropLink();
+      rig.newLink();
+      gate.complete();
+      await pass;
+      expect(rig.link, isEmpty);
+      expect(rig.all.map((w) => w.opcode).where((o) => o == _hr).length, 1,
+          reason: 'only the original HR ON — the reassert HR write was aborted');
+    });
+  });
+
+  group('link priority follows desired IMU, not just applied', () {
+    test('high as soon as IMU is desired, until the OFF has landed', () async {
+      final rig = _Rig();
+      expect(rig.engine.linkPriorityForCurrentState(), LinkPriority.balanced);
+      final on = rig.park(_imu);
+      rig.owners = _fgGait;
+      final pass = rig.reconcile();
+      await rig.settle();
+      expect(rig.engine.linkPriorityForCurrentState(), LinkPriority.high,
+          reason: 'requested before the flood starts');
+      on.complete();
+      await pass;
+      final off = rig.park(_imu);
+      rig.owners = LiveStreamOwners.none;
+      final pass2 = rig.reconcile();
+      await rig.settle();
+      expect(rig.engine.linkPriorityForCurrentState(), LinkPriority.high,
+          reason: 'held until the OFF has landed');
+      off.complete();
+      await pass2;
+      expect(rig.engine.linkPriorityForCurrentState(), LinkPriority.balanced);
+    });
+  });
+
+  group('gen4 — byte sequences unchanged', () {
+    const fg = LiveStreamOwners(foreground: true);
+    const iosBg = LiveStreamOwners(iosBackgroundKeepalive: true);
+
+    test('foreground on a fresh link: HR, R10/R11, IMU, optical ON', () async {
+      final rig = _Rig(band: BandProfile.gen4);
+      await rig.setOwners(fg);
+      expect(rig.ops, [(_hr, 1), (_r10, 1), (_imu, 1), (_optSave, 1)]);
+      expect(rig.link[3].body.sublist(0, 2), [revision1, 0x01]);
+      expect(rig.link[2].body.first, 0x01, reason: 'gen4 IMU body is a bare byte');
+    });
+
+    test('full → off: optical mode, optical save, R10/R11, IMU, then HR', () async {
+      final rig = _Rig(band: BandProfile.gen4);
+      await rig.setOwners(fg);
+      await rig.setOwners(LiveStreamOwners.none);
+      expect(rig.ops.sublist(4), [(_optMode, 0), (_optSave, 0), (_r10, 0), (_imu, 0), (_hr, 0)]);
+      expect(rig.link[4].body.sublist(0, 2), [revision1, 0x00]);
+    });
+
+    test('full → HR-only (backgrounding on iOS): the old HR-only sequence', () async {
+      final rig = _Rig(band: BandProfile.gen4);
+      await rig.setOwners(fg);
+      await rig.setOwners(iosBg);
+      expect(rig.ops.sublist(4), [(_hr, 1), (_optMode, 0), (_optSave, 0), (_r10, 0), (_imu, 0)]);
+      expect(rig.engine.debugLiveApplied, const LiveStreamIntent(hr: true, imu: false));
+    });
+
+    test('fresh link, HR-only wanted (iOS background cold launch): HR ON then '
+        'the defensive OFF tail — R10/R11 OFF persists on the strap', () async {
+      final rig = _Rig(band: BandProfile.gen4);
+      await rig.setOwners(iosBg);
+      expect(rig.ops, [(_hr, 1), (_optMode, 0), (_optSave, 0), (_r10, 0), (_imu, 0)]);
+      // Once known, a second pass is silent.
+      await rig.reconcile();
+      expect(rig.ops.length, 5);
+    });
+
+    test('fresh link, nothing wanted (Android background): silent', () async {
+      final rig = _Rig(band: BandProfile.gen4);
+      await rig.setOwners(LiveStreamOwners.none);
+      expect(rig.opcodes, isEmpty);
+    });
+
+    test('background workout on a fresh link: HR on, defensive bundle off', () async {
+      final rig = _Rig(band: BandProfile.gen4);
+      await rig.setOwners(const LiveStreamOwners(activeWorkout: true));
+      expect(rig.ops, [(_hr, 1), (_optMode, 0), (_optSave, 0), (_r10, 0), (_imu, 0)]);
+      expect(rig.engine.debugLiveApplied.imu, isFalse);
+    });
+
+    test('partial ON failure then owners gone: the whole OFF bundle is replayed', () async {
+      final rig = _Rig(band: BandProfile.gen4);
+      rig.failing.add(_r10);
+      await rig.setOwners(fg);
+      expect(rig.ops, [(_hr, 1), (_r10, 1), (_imu, 1), (_optSave, 1)],
+          reason: 'the bundle runs to the end even when one write fails');
+      expect(rig.engine.debugLiveApplied.imu, isFalse, reason: 'never claimed');
+      rig.failing.clear();
+      await rig.setOwners(LiveStreamOwners.none);
+      expect(rig.ops.sublist(4), [(_optMode, 0), (_optSave, 0), (_r10, 0), (_imu, 0), (_hr, 0)],
+          reason: 'dirty replays OFF even though nothing is desired');
+    });
+
+    test('partial OFF failure then an owner returns: the ON bundle is replayed', () async {
+      final rig = _Rig(band: BandProfile.gen4);
+      await rig.setOwners(fg);
+      rig.failing.add(_optSave);
+      await rig.setOwners(LiveStreamOwners.none);
+      expect(rig.engine.debugLiveApplied.imu, isTrue, reason: 'OFF not confirmed');
+      // The failed OFF ended the pass before HR OFF was attempted (a failure
+      // exits; the keep-alive retries), so HR is still applied here.
+      expect(rig.engine.debugLiveApplied.hr, isTrue);
+      rig.failing.clear();
+      await rig.setOwners(fg);
+      expect(rig.ops.sublist(8), [(_r10, 1), (_imu, 1), (_optSave, 1)],
+          reason: 'dirty bundle replays ON in full; HR needs nothing');
+      expect(rig.engine.debugLiveApplied, const LiveStreamIntent(hr: true, imu: true));
+    });
+
+    test('keep-alive re-arms R10/R11 on gen4', () async {
+      final rig = _Rig(band: BandProfile.gen4);
+      await rig.setOwners(fg);
+      rig.engine.state.liveHrAt = DateTime.now().millisecondsSinceEpoch;
+      await rig.engine.debugReassertLiveStreams();
+      expect(rig.ops.last, (_r10, 1));
+      expect(rig.ops.length, 5);
+    });
+  });
+}

--- a/test/live_stream_policy_test.dart
+++ b/test/live_stream_policy_test.dart
@@ -1,0 +1,239 @@
+// Pure-policy tests for the live HR/IMU ownership model (discussion #287):
+// which owners want which stream, and the single-step reconciler that walks
+// the applied state towards the desired one. No engine, no band.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ble/ble_state.dart';
+
+const _off = LiveStreamIntent.off;
+const _hrOnly = LiveStreamIntent(hr: true, imu: false);
+const _imuOnly = LiveStreamIntent(hr: false, imu: true);
+const _both = LiveStreamIntent(hr: true, imu: true);
+
+LiveStreamIntent _gen5(LiveStreamOwners o, {bool fallback = false}) =>
+    desiredLiveStreams(o, gen5: true, standardHrFallback: fallback);
+LiveStreamIntent _gen4(LiveStreamOwners o, {bool fallback = false}) =>
+    desiredLiveStreams(o, gen5: false, standardHrFallback: fallback);
+
+/// Walk the reconciler to convergence, returning the steps it emitted.
+List<LiveStreamStep> _walk({
+  LiveStreamIntent applied = _off,
+  required LiveStreamIntent desired,
+  bool imuFresh = false,
+  bool imuDirty = false,
+  bool hrDirty = false,
+}) {
+  final steps = <LiveStreamStep>[];
+  var a = applied;
+  var fresh = imuFresh, iDirty = imuDirty, hDirty = hrDirty;
+  for (var i = 0; i < 8; i++) {
+    final s = nextLiveStreamStep(
+      applied: a,
+      desired: desired,
+      imuFresh: fresh,
+      imuDirty: iDirty,
+      hrDirty: hDirty,
+    );
+    if (s == null) return steps;
+    steps.add(s);
+    a = applyLiveStreamStep(a, s);
+    if (s.isImu) {
+      fresh = false;
+      iDirty = false;
+    } else {
+      hDirty = false;
+    }
+  }
+  fail('did not converge: $steps');
+}
+
+void main() {
+  group('desiredLiveStreams — gen5 policy table (#287)', () {
+    test('ordinary READY with no owner: off', () {
+      expect(_gen5(LiveStreamOwners.none), _off);
+      // A foreground connection is NOT an owner on gen5.
+      expect(_gen5(const LiveStreamOwners(foreground: true)), _off);
+    });
+    test('visible live-HR view: HR only', () {
+      expect(
+        _gen5(const LiveStreamOwners(visibleLiveHrView: true, foreground: true)),
+        _hrOnly,
+      );
+    });
+    test('foreground gait workout: HR + IMU', () {
+      expect(
+        _gen5(const LiveStreamOwners(
+          activeWorkout: true,
+          foregroundGaitWorkout: true,
+          foreground: true,
+        )),
+        _both,
+      );
+    });
+    test('non-gait workout (incl. manual strength): HR only', () {
+      expect(
+        _gen5(const LiveStreamOwners(activeWorkout: true, foreground: true)),
+        _hrOnly,
+      );
+    });
+    test('background gait workout: HR stays, IMU off pending measurement', () {
+      expect(_gen5(const LiveStreamOwners(activeWorkout: true)), _hrOnly);
+    });
+    test('breathing session/window: HR only', () {
+      expect(
+        _gen5(const LiveStreamOwners(breathing: true, foreground: true)),
+        _hrOnly,
+      );
+    });
+    test('bounded movement-sampling window: IMU only', () {
+      expect(_gen5(const LiveStreamOwners(movementSampling: true)), _imuOnly);
+    });
+    test('passive strap-step opt-in: IMU only', () {
+      expect(_gen5(const LiveStreamOwners(passiveStrapSteps: true)), _imuOnly);
+    });
+    test('iOS background with no physiological owner: HR only', () {
+      expect(
+        _gen5(const LiveStreamOwners(iosBackgroundKeepalive: true)),
+        _hrOnly,
+      );
+    });
+    test('Android background with no owner: off', () {
+      expect(_gen5(LiveStreamOwners.none), _off);
+    });
+    test('marginal-radio fallback masks IMU only', () {
+      expect(
+        _gen5(
+          const LiveStreamOwners(
+            activeWorkout: true,
+            foregroundGaitWorkout: true,
+          ),
+          fallback: true,
+        ),
+        _hrOnly,
+      );
+      expect(
+        _gen5(const LiveStreamOwners(movementSampling: true), fallback: true),
+        _off,
+      );
+    });
+    test('history sync has no owner field at all', () {
+      // Nothing in LiveStreamOwners describes a sync; the type is the proof.
+      expect(LiveStreamOwners.none.toString(), isNot(contains('sync')));
+    });
+  });
+
+  group('desiredLiveStreams — gen4 keeps today\'s behaviour', () {
+    test('foreground connection alone arms HR + the bundle', () {
+      expect(_gen4(const LiveStreamOwners(foreground: true)), _both);
+    });
+    test('background with no owner: off (Android) / HR-only (iOS keepalive)', () {
+      expect(_gen4(LiveStreamOwners.none), _off);
+      expect(
+        _gen4(const LiveStreamOwners(iosBackgroundKeepalive: true)),
+        _hrOnly,
+      );
+    });
+    test('background workout keeps HR and drops the bundle', () {
+      expect(_gen4(const LiveStreamOwners(activeWorkout: true)), _hrOnly);
+    });
+    test('fallback masks the bundle on gen4 too', () {
+      expect(
+        _gen4(const LiveStreamOwners(foreground: true), fallback: true),
+        _hrOnly,
+      );
+    });
+  });
+
+  group('nextLiveStreamStep — order and convergence', () {
+    test('converged: null', () {
+      for (final i in [_off, _hrOnly, _imuOnly, _both]) {
+        expect(nextLiveStreamStep(applied: i, desired: i), isNull);
+      }
+    });
+    test('full arm: HR ON then bundle ON (today\'s enable order)', () {
+      expect(
+        _walk(desired: _both),
+        [LiveStreamStep.hrOn, LiveStreamStep.imuOn],
+      );
+    });
+    test('full disarm: bundle OFF then HR OFF (today\'s disable order)', () {
+      expect(
+        _walk(applied: _both, desired: _off),
+        [LiveStreamStep.imuOff, LiveStreamStep.hrOff],
+      );
+    });
+    test('full → HR-only: bundle OFF only', () {
+      expect(_walk(applied: _both, desired: _hrOnly), [LiveStreamStep.imuOff]);
+    });
+    test('HR-only → full: bundle ON only', () {
+      expect(_walk(applied: _hrOnly, desired: _both), [LiveStreamStep.imuOn]);
+    });
+    test('HR-only ↔ IMU-only swaps ON before OFF', () {
+      expect(
+        _walk(applied: _hrOnly, desired: _imuOnly),
+        [LiveStreamStep.imuOn, LiveStreamStep.hrOff],
+      );
+      expect(
+        _walk(applied: _imuOnly, desired: _hrOnly),
+        [LiveStreamStep.hrOn, LiveStreamStep.imuOff],
+      );
+    });
+    test('applyLiveStreamStep flips exactly one bit', () {
+      expect(applyLiveStreamStep(_off, LiveStreamStep.hrOn), _hrOnly);
+      expect(applyLiveStreamStep(_hrOnly, LiveStreamStep.imuOn), _both);
+      expect(applyLiveStreamStep(_both, LiveStreamStep.imuOff), _hrOnly);
+      expect(applyLiveStreamStep(_hrOnly, LiveStreamStep.hrOff), _off);
+    });
+  });
+
+  group('nextLiveStreamStep — fresh link (gen4 bundle state unknown)', () {
+    test('nothing desired: stays silent', () {
+      expect(_walk(desired: _off, imuFresh: true), isEmpty);
+    });
+    test('HR-only desired: HR ON then a defensive bundle OFF', () {
+      expect(
+        _walk(desired: _hrOnly, imuFresh: true),
+        [LiveStreamStep.hrOn, LiveStreamStep.imuOff],
+      );
+    });
+    test('full desired: same as a known-off link', () {
+      expect(
+        _walk(desired: _both, imuFresh: true),
+        [LiveStreamStep.hrOn, LiveStreamStep.imuOn],
+      );
+    });
+    test('IMU-only desired: bundle ON', () {
+      expect(_walk(desired: _imuOnly, imuFresh: true), [LiveStreamStep.imuOn]);
+    });
+  });
+
+  group('nextLiveStreamStep — dirty bits replay the newest direction', () {
+    test('dirty bundle with nothing desired: OFF is replayed (unlike fresh)', () {
+      expect(_walk(desired: _off, imuDirty: true), [LiveStreamStep.imuOff]);
+    });
+    test('dirty bundle, applied off, desired on: ON', () {
+      expect(_walk(desired: _imuOnly, imuDirty: true), [LiveStreamStep.imuOn]);
+    });
+    test('dirty bundle, applied on, desired on: re-applied ON', () {
+      expect(
+        _walk(applied: _imuOnly, desired: _imuOnly, imuDirty: true),
+        [LiveStreamStep.imuOn],
+      );
+    });
+    test('dirty HR after a failed ON, owner gone: HR OFF', () {
+      expect(_walk(desired: _off, hrDirty: true), [LiveStreamStep.hrOff]);
+    });
+    test('dirty HR after a failed OFF, new owner: HR ON', () {
+      expect(
+        _walk(applied: _hrOnly, desired: _hrOnly, hrDirty: true),
+        [LiveStreamStep.hrOn],
+      );
+    });
+    test('dirty HR and bundle with nothing desired: bundle OFF then HR OFF', () {
+      expect(
+        _walk(desired: _off, imuDirty: true, hrDirty: true),
+        [LiveStreamStep.imuOff, LiveStreamStep.hrOff],
+      );
+    });
+  });
+}


### PR DESCRIPTION
Implements the live HR/IMU ownership contract from #287.

## What changes

A foreground connection was an implicit request for both the realtime-HR stream (opcode 3) and the 100 Hz IMU stream (gen5 opcode 106), the enable / HR-only / disable methods flipped the engine's live flags *before* their writes went out, and nothing serialized them. Two races followed: a breathing close started an OFF unawaited, a workout starting inside that window saw "already enabled" and skipped its ON, and the older OFF finished and left the workout without a stream; and a feature that started while another already had streams on recorded no ownership, so when both left nothing recomputed the remaining owner set (`stopWorkout` never disabled at all) and the keep-alive kept re-arming a flood nobody read.

Now:

- **Explicit owners** (`LiveStreamOwners`, `lib/ble/ble_state.dart`): live-HR view mounted, active workout, foreground gait workout, breathing session/window, iOS background keepalive, bounded movement-sampling window, passive strap-step opt-in. History sync has no owner field. `AppState` only mutates owners and nudges; it never enables or disables a stream.
- **Two independent desired bits** (`desiredLiveStreams`): OFF, HR-only, IMU-only and HR+IMU are all representable.
- **One serialized, coalescing reconciler in the engine** is the only writer of opcode 3 and the high-rate bundle. Desired is recomputed inside the loop after every await; one transition is written per iteration; applied moves only after the write succeeded *and* the link it was written to is still the live one (link generation + session identity + a synchronous `closing` flag set at the top of teardown, checked after every write and delay); the pass runs until applied equals the newest desired. A failed write marks its bit *dirty* so the newest direction is replayed before convergence (a timed-out write can still have landed; a gen4 bundle can be half-applied). A nudge that arrives during a failed write is still honoured in the same pass, which is how `disconnect()`'s shutdown intent gets through.
- **The keep-alive re-arm** goes through the same pass, gated on *applied* state, so it can no longer resurrect a flood nothing owns; a tick never restales a pass in flight, so a failing multi-write bundle cannot be retried forever.
- **Nothing is written before the link is live-ready**: `listening` is set before the INIT packets go out, so the reconciler additionally waits for a per-link `_liveReady` flag set at the end of `_finishConnect`; a stale pass that lands on a bootstrapping replacement link ends, and the caller's post-connect reconcile applies the intent (after its pedometer reset, on every connect path).
- **Link priority** rises as soon as IMU is desired (before the flood starts) and holds until the OFF has landed, as before.

### gen5 policy (final, from #287)

| Situation | HR | IMU |
|---|---:|---:|
| Ordinary READY / foreground with no owner | off | off |
| Visible live-HR view (resting-HR live card, band device page) | on | off |
| Foreground gait workout | on | on |
| Non-gait workout, manual strength | on | off |
| Breathing session/window | on | off |
| Bounded movement-sampling window | off | on |
| Background gait workout | on | off (pending measured sample-rate validation) |
| iOS background, no other owner | on | off |
| Android background, no owner | off | off |
| History sync | off | off |

Gen5 never writes optical opcodes 107/108 from this state machine (the old disable/HR-only paths wrote both OFF unconditionally).

### gen4 is unchanged

A gen4 foreground connection remains an explicit owner of HR plus the R10/R11 + IMU + optical bundle, so gen4 users keep passive strap steps and live HR exactly as before — gen4 has no on-chip daily step fallback, and the "default off" decision was taken in gen5 terms. The byte sequences and spacing are those of the old methods, pinned by tests: full ON `03 3F 6A 6B`; full OFF `6C 6B 3F 6A 03`; full→HR-only `03(1) 6C 6B 3F 6A`; fresh-link HR-only `03(1) 6C 6B 3F 6A`; fresh link with nothing wanted stays silent. R10/R11 OFF persists across reconnects on the strap (protocol `cmdSendR10R11`), so a fresh gen4 link replays the defensive OFF tail the first time anything is wanted.

### Consequences worth knowing

- On gen5, live BPM / wrist-on stop updating in the foreground unless a screen that shows them is mounted. `isLinkStale` and the keep-alive's forced battery poll already cover the no-stream case.
- A gait workout with the phone locked stops accumulating live steps/cadence for that span until background delivery is measured (#287 decision 4).
- A mounted live-HR page does not keep HR on once the app is backgrounded (routes survive backgrounding; the owner is gated on foreground).
- Starting a workout offline clears the sticky marginal-radio fallback too, so the IMU owner is not masked for the whole session after the band reconnects.
- `setMovementSamplingWindow` exists with no production caller: the scheduler is a separate, validated follow-up (#287 decision 2).

## Tests

- `test/live_stream_policy_test.dart` — the owner→intent table (gen5 rows, gen4 legacy row, fallback masking) and the single-step reconciler (order, convergence, fresh vs dirty replay).
- `test/live_stream_ownership_test.dart` — engine + fake link: every scenario in the #287 acceptance list, plus delayed/failing/stale writes, `disconnect()` during delayed and failed transitions, link replacement mid-bundle (a gen4 tail never reaches a gen5 link), keep-alive reassert, link-priority ordering, and the gen4 byte sequences.
- `test/app_state_live_owners_test.dart` — the owner set per feature state, and that `startWorkout` assigns the workout before the engine is nudged.
- `test/live_hr_view_owner_test.dart` — both live-HR hosts retain on mount and release on dispose.

`flutter analyze` clean; full suite green with `--concurrency=1`.

## Non-goals (per #287)

Optical 107/108 role cleanup, the live R-R adjacency fix, realtime wearing-byte semantics, historical metrics, any battery claim, official-app parity claims, and the movement-reminder sampling scheduler.

## Summary by Sourcery

Replace implicit live-stream management with explicit ownership and a serialized reconciler that safely converges HR and IMU streams across feature changes, lifecycle events, failures, and reconnects.

New Features:
- Add explicit live HR and IMU stream ownership for workouts, breathing, live-HR views, background keepalive, movement sampling, and passive step collection.
- Support independent HR-only, IMU-only, combined, and disabled live-stream intents with generation-specific policies.

Bug Fixes:
- Prevent overlapping live-stream transitions, stale writes, failed writes, reconnects, and disconnects from leaving streams in an incorrect state.
- Prevent background keepalive from rearming unowned high-rate streams and avoid writing live toggles before link initialization completes.

Enhancements:
- Centralize live-stream changes in a serialized, coalescing desired-versus-applied reconciler while preserving gen4 wire behavior and applying the updated gen5 policy.
- Make live-HR screens acquire and release stream ownership based on their mounted lifecycle.
- Reset and retry the marginal-radio fallback when an explicit workout starts.

Tests:
- Add policy, ownership, lifecycle, transition-race, failure, reconnect, keepalive, link-priority, and gen4 protocol-sequence coverage for live streams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved reliability and consistency of live heart-rate and motion streaming.
  - Live heart-rate updates remain available while supported detail screens are open and stop when no longer needed.
  - Streaming transitions are coordinated more smoothly during connection, reconnection, backgrounding, and workouts.
  - Movement sampling, breathing, and other live-data activities now receive appropriate stream access.
  - Starting a workout can recover from temporary radio-quality fallback conditions and restore full streaming when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->