### PR TITLE
fossil/skagen q hybrid: pair and bank raw bytes, pairs-only

### DIFF
--- a/lib/ble/adapters/_registry.dart
+++ b/lib/ble/adapters/_registry.dart
@@ -53,6 +53,31 @@ import 'signals.dart';
 const String kHeartRateServiceUuid = '0000180d-0000-1000-8000-00805f9b34fb';
 const String kHeartRateMeasurementUuid = '00002a37-0000-1000-8000-00805f9b34fb';
 
+/// The Fossil/Skagen Q Hybrid's GATT service. NOT the encrypted Hybrid HR /
+/// Gen 6 sibling, which advertises this same UUID — see [kQHybrid]'s own doc.
+const String kQHybridService = '3dda0001-957f-7d4a-34a6-74696673696d';
+
+/// Host-to-watch control characteristic: write + notify, flat
+/// `[type, cmdId, ...payload]` request / `[3, cmdId, ...payload]` response,
+/// no CRC, no envelope.
+const String kQHybridControlChar = '3dda0002-957f-7d4a-34a6-74696673696d';
+
+/// File-download notify characteristics. A separate, undecoded chunking
+/// sub-protocol — banked raw only.
+const String kQHybridFileChar1 = '3dda0003-957f-7d4a-34a6-74696673696d';
+const String kQHybridFileChar2 = '3dda0004-957f-7d4a-34a6-74696673696d';
+
+/// A third notify characteristic in the same service — also used for a
+/// vibrate/find-my-watch write on the real device. Undecoded — banked raw
+/// only, same as the two above.
+const String kQHybridAuxChar = '3dda0005-957f-7d4a-34a6-74696673696d';
+
+/// Button-press notify characteristic. Fixed 11-byte frames — banked raw only.
+const String kQHybridButtonChar = '3dda0006-957f-7d4a-34a6-74696673696d';
+
+/// File-upload-ack notify characteristic — banked raw only.
+const String kQHybridUploadAckChar = '3dda0007-957f-7d4a-34a6-74696673696d';
+
 /// The Oura ring's GATT service, identical across the generations seen so far.
 const String kOuraService = '98ed0001-a541-11e4-b6a0-0002a5d5c51b';
 
@@ -438,12 +463,44 @@ const BandEntry kOura = BandEntry.notify(
   timeAnchor: TimeAnchor.arrival,
 );
 
+/// Fossil/Skagen's original "hybrid" smartwatch line — models like `HW.0.0`,
+/// `HL.0.0`, `DN.1.0`. NOT the encrypted Hybrid HR / Gen 6 line, a different
+/// sibling protocol that happens to advertise the same service UUID.
+///
+/// Plain unencrypted GATT, no crypto handshake, no pairing key: standard
+/// platform BLE bonding is the whole of what "pairing" means here, same as
+/// [kBleHrs]. A live scan match on the service UUID alone cannot tell this
+/// watch apart from its encrypted sibling before connecting, so the adapter
+/// self-confirms with a harmless battery-level probe before banking anything
+/// — see `qhybrid.dart`.
+///
+/// EXPERIMENTAL and it stays that way: nobody on this project owns one, so
+/// not a byte of this path has met hardware (ASSUMPTIONS R6). It pairs,
+/// connects, confirms itself, and banks every notification raw;
+/// `kDerivableSources` stays empty until someone has actually held one.
+const BandEntry kQHybrid = BandEntry.notify(
+  id: 'qhybrid',
+  label: 'Fossil/Skagen Hybrid Smartwatch',
+  service: kQHybridService,
+  characteristics: <String>[
+    kQHybridControlChar,
+    kQHybridFileChar1,
+    kQHybridFileChar2,
+    kQHybridAuxChar,
+    kQHybridButtonChar,
+    kQHybridUploadAckChar,
+  ],
+  // No clock in the wire format at all; every frame is stamped on arrival.
+  timeAnchor: TimeAnchor.arrival,
+);
+
 /// Every band this build can see. Order is match order during discovery.
 const List<BandEntry> kBandRegistry = <BandEntry>[
   kWhoopGen4,
   kWhoopGen5,
   kBleHrs,
   kOura,
+  kQHybrid,
 ];
 
 /// The bands the OFFLOAD ENGINE can drive, and the bands iOS provisions
@@ -500,6 +557,7 @@ const Map<String, Map<InputSignal, Duration>> kAdapterSignals =
     InputSignal.rrIntervals: Duration(seconds: 1),
   },
   'oura': <InputSignal, Duration>{},
+  'qhybrid': <InputSignal, Duration>{},
 };
 
 /// The signals one adapter declares, or empty for an id this build has no

--- a/lib/ble/adapters/qhybrid.dart
+++ b/lib/ble/adapters/qhybrid.dart
@@ -35,7 +35,12 @@ import 'signals.dart';
 /// The adapter. Const, and it holds no session state — everything a session
 /// needs lives inside [run].
 class QHybridAdapter extends BandAdapter {
-  const QHybridAdapter();
+  /// How long to wait for the battery-probe reply before abstaining.
+  /// Overridable only so a test does not have to sit through it — same
+  /// reason `oura.dart`'s `replyTimeout` is a constructor parameter.
+  final Duration probeTimeout;
+
+  const QHybridAdapter({this.probeTimeout = const Duration(seconds: 5)});
 
   @override
   BandEntry get entry => kQHybrid;
@@ -43,9 +48,6 @@ class QHybridAdapter extends BandAdapter {
   /// NOTHING. See the header: every frame is banked raw, undecoded.
   @override
   Map<InputSignal, Duration> get signals => const {};
-
-  /// How long to wait for the battery-probe reply before abstaining.
-  static const Duration _kProbeTimeout = Duration(seconds: 5);
 
   @override
   Stream<BandEvent> run(BandLink link) async* {
@@ -77,9 +79,9 @@ class QHybridAdapter extends BandAdapter {
         return;
       }
       final confirmed = await probeReply.future
-          .timeout(_kProbeTimeout, onTimeout: () => false);
+          .timeout(probeTimeout, onTimeout: () => false);
       if (!confirmed) {
-        link.log('qhybrid: no probe reply within ${_kProbeTimeout.inSeconds}s; '
+        link.log('qhybrid: no probe reply within ${probeTimeout.inSeconds}s; '
             'abstaining (likely the encrypted sibling protocol).');
         return;
       }
@@ -88,7 +90,15 @@ class QHybridAdapter extends BandAdapter {
       for (final s in subs) {
         await s.cancel();
       }
-      await raw.close();
+      // NOT awaited. `raw.close()`'s returned future only completes once
+      // every buffered event has been delivered to a listener — and on the
+      // abstain path (probe refused or never confirmed) nothing has EVER
+      // listened to `raw`, so awaiting it here hangs this whole method
+      // forever the moment any characteristic notifies before the probe
+      // settles. Nothing downstream needs to know `raw` finished draining;
+      // the subscriptions above are already cancelled, which is the real
+      // teardown.
+      raw.close();
     }
   }
 }

--- a/lib/ble/adapters/qhybrid.dart
+++ b/lib/ble/adapters/qhybrid.dart
@@ -58,6 +58,18 @@ class QHybridAdapter extends BandAdapter {
     final raw = StreamController<BandEvent>();
     final subs = <StreamSubscription<Object?>>[];
 
+    // Set the INSTANT a valid reply arrives, never inferred from
+    // `probeReply.isCompleted` — that completer settles once `run` has moved
+    // on to await it, which is a later moment than the reply landing. Every
+    // notification received before this is true is DROPPED, not merely
+    // withheld: a `raw` fed before anyone is confirmed to listen only drains
+    // once something subscribes, and on the abstain path nothing ever does
+    // (see the header on `raw.close()` below) — so banking pre-confirmation
+    // frames either leaks bytes that predate knowing this is even the right
+    // protocol, or, on a successful probe, contradicts "nothing is banked
+    // until the probe confirms" by surfacing them anyway once it does.
+    var confirmed = false;
+
     for (final uuid in entry.requiredCharacteristics) {
       subs.add(link.notify(uuid).listen((rec) {
         final (_, value) = rec;
@@ -66,9 +78,11 @@ class QHybridAdapter extends BandAdapter {
             value.length >= 3 &&
             value[0] == 3 &&
             value[1] == 8) {
+          confirmed = true;
           probeReply.complete(true);
           return;
         }
+        if (!confirmed) return;
         raw.add(SampleBatch(const [], raw: [Uint8List.fromList(value)]));
       }));
     }

--- a/lib/ble/adapters/qhybrid.dart
+++ b/lib/ble/adapters/qhybrid.dart
@@ -1,0 +1,97 @@
+// The Fossil/Skagen Q Hybrid — the original "hybrid" smartwatch line
+// (`HW.0.0`, `HL.0.0`, `DN.1.0`) — as a [BandAdapter].
+//
+// Plain unencrypted GATT: one control/command characteristic that answers
+// flat `[type, cmdId, ...payload]` requests with `[3, cmdId, ...payload]`
+// responses (no CRC, no length envelope, no sequence counter), plus five
+// notify-only characteristics — two for file-download chunking, one more in
+// that same group, one for button presses, one for a file-upload ack — whose
+// sub-protocols are not decoded here. There is no encryption anywhere in this
+// variant and no pairing key; standard platform BLE bonding is the whole of
+// what "pairing" means, same as [kBleHrs].
+//
+// THE ONE REAL RISK: an encrypted sibling protocol (the Hybrid HR / Gen 6
+// line) advertises this exact same service UUID, so a live scan match on it
+// cannot tell the two apart before connecting. Rather than guess, this
+// adapter treats a harmless battery-level query as a self-confirming probe —
+// write `[1, 8]` to the control characteristic and wait for `[3, 8, level]`
+// back. A reply means this is the plain protocol; no reply within the window
+// means abstain cleanly, exactly the "no reply = abstain" idiom `oura.dart`
+// already uses for its own handshake. Nothing is banked until the probe
+// confirms.
+//
+// NOTHING HERE HAS MET HARDWARE, so every notification is banked as raw
+// bytes and nothing is decoded into a sample. EXPERIMENTAL (ASSUMPTIONS R6)
+// until someone owns one: `signals` is empty and `kDerivableSources` does
+// not contain `qhybrid`, so nothing this adapter banks can become a metric.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import '_registry.dart';
+import 'adapter.dart';
+import 'signals.dart';
+
+/// The adapter. Const, and it holds no session state — everything a session
+/// needs lives inside [run].
+class QHybridAdapter extends BandAdapter {
+  const QHybridAdapter();
+
+  @override
+  BandEntry get entry => kQHybrid;
+
+  /// NOTHING. See the header: every frame is banked raw, undecoded.
+  @override
+  Map<InputSignal, Duration> get signals => const {};
+
+  /// How long to wait for the battery-probe reply before abstaining.
+  static const Duration _kProbeTimeout = Duration(seconds: 5);
+
+  @override
+  Stream<BandEvent> run(BandLink link) async* {
+    // The probe reply is recognised and swallowed here, never banked as data
+    // — it is a confirmation this adapter generated, not something the watch
+    // would have sent unprompted.
+    final probeReply = Completer<bool>();
+    final raw = StreamController<BandEvent>();
+    final subs = <StreamSubscription<Object?>>[];
+
+    for (final uuid in entry.requiredCharacteristics) {
+      subs.add(link.notify(uuid).listen((rec) {
+        final (_, value) = rec;
+        if (uuid == kQHybridControlChar &&
+            !probeReply.isCompleted &&
+            value.length >= 3 &&
+            value[0] == 3 &&
+            value[1] == 8) {
+          probeReply.complete(true);
+          return;
+        }
+        raw.add(SampleBatch(const [], raw: [Uint8List.fromList(value)]));
+      }));
+    }
+
+    try {
+      if (!await link.write(kQHybridControlChar, const [1, 8])) {
+        link.log('qhybrid: battery probe write refused; ending the stream.');
+        return;
+      }
+      final confirmed = await probeReply.future
+          .timeout(_kProbeTimeout, onTimeout: () => false);
+      if (!confirmed) {
+        link.log('qhybrid: no probe reply within ${_kProbeTimeout.inSeconds}s; '
+            'abstaining (likely the encrypted sibling protocol).');
+        return;
+      }
+      yield* raw.stream;
+    } finally {
+      for (final s in subs) {
+        await s.cancel();
+      }
+      await raw.close();
+    }
+  }
+}
+
+/// The single instance. Const, so it costs nothing to reference.
+const QHybridAdapter kQHybridAdapter = QHybridAdapter();

--- a/lib/ble/adapters/qhybrid.dart
+++ b/lib/ble/adapters/qhybrid.dart
@@ -99,6 +99,10 @@ class QHybridAdapter extends BandAdapter {
             'abstaining (likely the encrypted sibling protocol).');
         return;
       }
+      // The only way a caller of `BandHost.run` (a `Future<void>`, success or
+      // abstain alike) learns the probe actually confirmed — same `BandNote`
+      // channel `oura.dart` uses for its own handshake facts.
+      yield const BandNote('qhybrid_confirmed');
       yield* raw.stream;
     } finally {
       for (final s in subs) {

--- a/lib/ble/hrs_link.dart
+++ b/lib/ble/hrs_link.dart
@@ -66,6 +66,7 @@ import 'ble_state.dart'
         acquireSecondaryLinkSlot,
         releaseSecondaryLinkSlot;
 import 'oura_link.dart' show OuraLink;
+import 'qhybrid_link.dart' show QHybridLink;
 
 export 'adapters/host.dart' show HrsReading;
 
@@ -580,6 +581,10 @@ class HrsLink {
         .firstOrNull;
     if (row?['adapter_id'] == kOura.id) {
       await OuraLink.forgetRing(id);
+      return;
+    }
+    if (row?['adapter_id'] == kQHybrid.id) {
+      await QHybridLink.forget(id);
       return;
     }
     // Before the row goes, not after: a live session would keep writing rows

--- a/lib/ble/hrs_link.dart
+++ b/lib/ble/hrs_link.dart
@@ -501,6 +501,9 @@ class HrsLink {
   /// [tier] defaults to the strap's, and a band whose measurement quality
   /// differs must say so rather than inherit it — the tier is what decides
   /// precedence between two sources, so a wrong one is a silent wrong number.
+  /// Pass `null` explicitly for an adapter with no decoded signal at all (see
+  /// `OuraLink.pairOuraRing`'s own comment on why NULL is a refusal, not a
+  /// default).
   ///
   /// Nothing is written unless the peripheral passed the characteristic check:
   /// a row pointing at a device that cannot answer is a sensor that appears
@@ -509,7 +512,7 @@ class HrsLink {
     BandEntry entry,
     BluetoothDevice device, {
     String? label,
-    String tier = 'beatToBeat',
+    String? tier = 'beatToBeat',
   }) async {
     try {
       await device.connect(timeout: _connectTimeout);

--- a/lib/ble/qhybrid_link.dart
+++ b/lib/ble/qhybrid_link.dart
@@ -42,8 +42,12 @@ import 'hrs_link.dart' show HrsLink;
 /// Pair a Fossil/Skagen Q Hybrid, then drive one bounded session over it so
 /// pairing means more than a `device` row — see this file's own header.
 Future<String?> pairQHybrid(BluetoothDevice device, {String? label}) async {
-  final failure =
-      await HrsLink.pairNotifySensor(kQHybrid, device, label: label);
+  // `tier` is left null on purpose: it means MEASUREMENT QUALITY and this
+  // adapter decodes nothing (`QHybridAdapter.signals` is `const {}`), so
+  // there is no quality to rank — see `OuraLink.pairOuraRing`'s own comment
+  // on the same pattern.
+  final failure = await HrsLink.pairNotifySensor(kQHybrid, device,
+      label: label, tier: null);
   if (failure != null) return failure;
   // Re-finds the row `pairNotifySensor` just wrote and reconnects by
   // `remote_id` — the exact same path a later manual/background sync takes —

--- a/lib/ble/qhybrid_link.dart
+++ b/lib/ble/qhybrid_link.dart
@@ -1,31 +1,36 @@
-// Fossil/Skagen Q Hybrid: pairing IS the one session this band gets.
+// Fossil/Skagen Q Hybrid: pairing IS the one session this band gets, and
+// [QHybridLink.sync] is that same session re-run — there is no cursor, no
+// history, and no arm/disarm pair, only "hold the link open a bounded window
+// and bank whatever the watch sends".
 //
 // WHY THIS FILE EXISTS. A heart-rate strap is driven by `HrsLink.arm()`,
 // which a workout starts and stops. Oura has its own background sync,
 // re-runnable from the ring's own page (`OuraLink`). This band has neither —
 // nothing derives from it (`QHybridAdapter.signals` is empty) so there is no
 // workout to arm it for, and no ongoing number to keep fresh so there is
-// nothing to "sync". Writing only the `device` row (what
-// `HrsLink.pairNotifySensor` does on its own) would leave `QHybridAdapter`
-// undriven from the moment that row exists: `BandHost` never archives a byte
-// without a `buildArchive` callback (`adapters/host.dart`'s own
-// `_bufferArchive`), and nothing else in this app ever constructs a
-// `BandHost` for this adapter. So pairing has to be the session, or the
-// adapter this file exists to drive never actually runs.
+// nothing to "sync" in the fetch-by-cursor sense. Writing only the `device`
+// row (what `HrsLink.pairNotifySensor` does on its own) would leave
+// `QHybridAdapter` undriven from the moment that row exists: `BandHost` never
+// archives a byte without a `buildArchive` callback (`adapters/host.dart`'s
+// own `_bufferArchive`), and nothing else in this app ever constructs a
+// `BandHost` for this adapter. So pairing has to run a session, and that same
+// session has to be re-runnable — the raw bytes a future decoder might want
+// are worth more than one 10-second window right after pairing.
 //
 // BEST-EFFORT, AND BOUNDED. [pairQHybrid] returns as soon as the `device` row
 // is written — the same promise `pairNotifySensor` already makes elsewhere —
-// and the drain that follows cannot fail that promise: nothing here can
-// un-pair a device that answered the moment ago. The drain itself is capped
-// at [_kDrainWindow]; an unbounded live link nobody is watching a spinner for
+// and the session that follows cannot fail that promise: nothing here can
+// un-pair a device that answered a moment ago. Every session is capped at
+// [_kSessionWindow]; an unbounded live link nobody is watching a spinner for
 // is a battery cost and a scan/connect fight with the primary band, the same
 // reason `HrsLink` disarms the moment a workout ends.
 
 import 'dart:async';
 
 import 'package:flutter/foundation.dart' show debugPrint;
-import 'package:flutter_blue_plus/flutter_blue_plus.dart' show BluetoothDevice;
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
+import '../data/db.dart';
 import '../data/models.dart' show ArchiveRecord;
 import 'adapters/_registry.dart' show kQHybrid;
 import 'adapters/gatt_link.dart';
@@ -34,72 +39,163 @@ import 'adapters/qhybrid.dart';
 import 'ble_state.dart' show withSecondaryLinkSlot;
 import 'hrs_link.dart' show HrsLink;
 
-/// How long the post-pairing session stays connected banking notifications.
-const Duration _kDrainWindow = Duration(seconds: 10);
-
 /// Pair a Fossil/Skagen Q Hybrid, then drive one bounded session over it so
 /// pairing means more than a `device` row — see this file's own header.
 Future<String?> pairQHybrid(BluetoothDevice device, {String? label}) async {
   final failure =
       await HrsLink.pairNotifySensor(kQHybrid, device, label: label);
   if (failure != null) return failure;
-  unawaited(_drainOnce(device));
+  // Re-finds the row `pairNotifySensor` just wrote and reconnects by
+  // `remote_id` — the exact same path a later manual/background sync takes —
+  // rather than a second, parallel drain implementation over the still-live
+  // `device` handle.
+  unawaited(QHybridLink.instance.sync());
   return null;
 }
 
-Future<void> _drainOnce(BluetoothDevice device) async {
-  try {
-    await withSecondaryLinkSlot<void>(
-      () async {
-        await device.connect(timeout: const Duration(seconds: 12));
-        GattBandLink? link;
+/// The live link to a paired Q Hybrid. One instance; a second concurrent one
+/// is not a thing anyone asked for.
+class QHybridLink {
+  QHybridLink._();
+  static final QHybridLink instance = QHybridLink._();
+
+  /// How long one session holds the link open once connected. Bounded rather
+  /// than open-ended — see the header note.
+  static const Duration _sessionWindow = Duration(seconds: 10);
+
+  /// The `device` row for the paired watch, or null.
+  static Future<Map<String, Object?>?> pairedRow() async {
+    for (final r in await LocalDb.deviceRows()) {
+      if (r['adapter_id'] == kQHybrid.id) return r;
+    }
+    return null;
+  }
+
+  /// Forget a paired watch: drop its `device` row. No key to drop — see the
+  /// registry entry's own doc on why this family needs none.
+  static Future<bool> forget(String id) async {
+    if (id == LocalDb.kPrimaryDeviceId) {
+      debugPrint('[qhybrid] refusing to forget the primary band from here.');
+      return false;
+    }
+    if (instance._deviceId == id) await instance.stop();
+    await LocalDb.deleteDevice(id);
+    return true;
+  }
+
+  BluetoothDevice? _device;
+
+  /// Kept only so teardown can [GattBandLink.close] it — that is what stops a
+  /// write the adapter queued before teardown from landing on a LATER
+  /// connection to the same watch.
+  GattBandLink? _link;
+
+  /// The session driving [kQHybridAdapter] over [_link] — see `adapters/host.dart`.
+  BandHost? _host;
+
+  /// `device.id` of the paired watch. Never [LocalDb.kPrimaryDeviceId].
+  String? _deviceId;
+
+  bool _busy = false;
+
+  /// Connect to the paired watch, hold the session for [_sessionWindow],
+  /// disconnect.
+  ///
+  /// Returns false when nothing is paired or the connect failed (including
+  /// the adapter abstaining because the probe never confirmed — see
+  /// `qhybrid.dart`). SERIALISED: a second call while one is in flight is a
+  /// no-op rather than a second radio session over the same peripheral.
+  Future<bool> sync() {
+    if (_busy) return Future.value(false);
+    _busy = true;
+    return _sync().whenComplete(() => _busy = false);
+  }
+
+  Future<bool> _sync() async {
+    final row = await pairedRow();
+    if (row == null) return false;
+    final deviceId = row['id'] as String?;
+    final remoteId = row['remote_id'] as String?;
+    if (deviceId == null || remoteId == null || remoteId.isEmpty) return false;
+    if (deviceId == LocalDb.kPrimaryDeviceId) {
+      debugPrint('[qhybrid] refusing to sync: the row claims the primary '
+          'device id — re-pair it with a minted id.');
+      return false;
+    }
+    _deviceId = deviceId;
+
+    try {
+      // A cap on concurrent SECONDARY links (never the band's own connect —
+      // see ble_state.dart's kMaxConcurrentSecondaryLinks doc). This sync's
+      // connect, session and disconnect all complete inside this one call, so
+      // the simple scoped form is correct here.
+      //
+      // THE TEARDOWN IS INSIDE THE CLOSURE, deliberately — held in an outer
+      // `finally` it would run AFTER `withSecondaryLinkSlot` had already
+      // released the slot, letting the next queued link connect while this
+      // one was still disconnecting.
+      return await withSecondaryLinkSlot(() async {
         try {
+          final device = BluetoothDevice.fromId(remoteId);
+          _device = device;
+          await device.connect(timeout: const Duration(seconds: 12));
           final services = await device.discoverServices();
-          final localLink = GattBandLink(
+          final link = GattBandLink(
             entry: kQHybrid,
             services: services,
             onLog: (m) => debugPrint('[qhybrid] $m'),
           );
-          link = localLink;
-          if (localLink
-              .missingCharacteristics(kQHybrid.requiredCharacteristics)
-              .isNotEmpty) {
-            return;
+          _link = link;
+          final missing =
+              link.missingCharacteristics(kQHybrid.requiredCharacteristics);
+          if (missing.isNotEmpty) {
+            debugPrint('[qhybrid] ${kQHybrid.label}: missing required '
+                'characteristic(s) '
+                '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
+            return false;
           }
           final host = BandHost(
             adapter: kQHybridAdapter,
-            deviceId: HrsLink.mintDeviceId(kQHybrid, device.remoteId.str),
+            deviceId: deviceId,
             onLog: (m) => debugPrint('[qhybrid] $m'),
             buildArchive: _buildArchiveRow,
           );
-          final runFuture = host.run(localLink);
+          _host = host;
           // Whichever finishes first: the adapter abstaining on its own (no
           // probe reply) or the bounded window running out on a confirmed,
           // still-open session. `stop()` is safe either way — `BandHost`'s
-          // own doc says so, and it is what flushes whatever this drain
+          // own doc says so, and it is what flushes whatever this session
           // banked before the link goes down.
-          await Future.any(
-              [runFuture, Future<void>.delayed(_kDrainWindow)]);
-          await host.stop();
-          await runFuture;
+          await host.run(link).timeout(_sessionWindow, onTimeout: () {});
+          return true;
         } finally {
-          link?.close();
-          try {
-            await device.disconnect();
-          } catch (_) {
-            // already gone
-          }
+          // Drop the link and DISCONNECT before the slot is released.
+          await stop();
         }
-      },
-      timeout: const Duration(seconds: 5),
-      onTimeout: () => debugPrint(
-          '[qhybrid] another sensor held the radio; skipping this drain.'),
-    );
-  } catch (e) {
-    // Best-effort, and the pairing above already succeeded regardless — see
-    // the header. A watch out of range a moment after pairing is not an
-    // error the person who just paired it needs to see.
-    debugPrint('[qhybrid] post-pair drain did not complete: $e');
+      });
+    } catch (e) {
+      debugPrint('[qhybrid] sync failed: $e');
+      return false;
+    }
+  }
+
+  /// Drop the link, flush what the session banked, disconnect. Safe to call
+  /// when nothing is connected.
+  Future<void> stop() async {
+    // Before the host's run subscription is cancelled: an adapter's `finally`
+    // can still write on the way out, and that write must not reach the radio.
+    _link?.close();
+    _link = null;
+    await _host?.stop();
+    _host = null;
+    _deviceId = null;
+    final d = _device;
+    _device = null;
+    if (d != null) {
+      try {
+        await d.disconnect();
+      } catch (_) {/* already gone */}
+    }
   }
 }
 

--- a/lib/ble/qhybrid_link.dart
+++ b/lib/ble/qhybrid_link.dart
@@ -139,6 +139,12 @@ class QHybridLink {
       // released the slot, letting the next queued link connect while this
       // one was still disconnecting.
       return await withSecondaryLinkSlot(() async {
+        // `forget()` isn't gated on `_busy` — it can `stop()` and delete the
+        // row while this call was still queued for the slot. Re-read the row
+        // now that the slot is ours so a stale queued sync never connects and
+        // archives frames under an id nothing points to any more.
+        final still = await pairedRow();
+        if (still == null || still['id'] != deviceId) return false;
         try {
           final device = BluetoothDevice.fromId(remoteId);
           _device = device;
@@ -158,10 +164,18 @@ class QHybridLink {
                 '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
             return false;
           }
+          // Set only from the adapter's own `qhybrid_confirmed` note — see
+          // `qhybrid.dart` — so an abstained probe (encrypted sibling
+          // protocol, no reply) reports false instead of the bare completion
+          // of `host.run` reading as success.
+          var confirmed = false;
           final host = BandHost(
             adapter: kQHybridAdapter,
             deviceId: deviceId,
             onLog: (m) => debugPrint('[qhybrid] $m'),
+            onNote: (k, v) {
+              if (k == 'qhybrid_confirmed') confirmed = true;
+            },
             buildArchive: _buildArchiveRow,
           );
           _host = host;
@@ -171,7 +185,7 @@ class QHybridLink {
           // own doc says so, and it is what flushes whatever this session
           // banked before the link goes down.
           await host.run(link).timeout(_sessionWindow, onTimeout: () {});
-          return true;
+          return confirmed;
         } finally {
           // Drop the link and DISCONNECT before the slot is released.
           await stop();
@@ -190,15 +204,23 @@ class QHybridLink {
     // can still write on the way out, and that write must not reach the radio.
     _link?.close();
     _link = null;
-    await _host?.stop();
+    final host = _host;
     _host = null;
     _deviceId = null;
     final d = _device;
     _device = null;
-    if (d != null) {
-      try {
-        await d.disconnect();
-      } catch (_) {/* already gone */}
+    // Cleanup above already dropped every field regardless of what follows.
+    // The disconnect is in `finally` so a `host.stop()` that throws mid-flush
+    // (raw-archive write failure) still drops the live GATT connection
+    // instead of leaving the watch connected with nothing driving it.
+    try {
+      await host?.stop();
+    } finally {
+      if (d != null) {
+        try {
+          await d.disconnect();
+        } catch (_) {/* already gone */}
+      }
     }
   }
 }

--- a/lib/ble/qhybrid_link.dart
+++ b/lib/ble/qhybrid_link.dart
@@ -1,0 +1,127 @@
+// Fossil/Skagen Q Hybrid: pairing IS the one session this band gets.
+//
+// WHY THIS FILE EXISTS. A heart-rate strap is driven by `HrsLink.arm()`,
+// which a workout starts and stops. Oura has its own background sync,
+// re-runnable from the ring's own page (`OuraLink`). This band has neither —
+// nothing derives from it (`QHybridAdapter.signals` is empty) so there is no
+// workout to arm it for, and no ongoing number to keep fresh so there is
+// nothing to "sync". Writing only the `device` row (what
+// `HrsLink.pairNotifySensor` does on its own) would leave `QHybridAdapter`
+// undriven from the moment that row exists: `BandHost` never archives a byte
+// without a `buildArchive` callback (`adapters/host.dart`'s own
+// `_bufferArchive`), and nothing else in this app ever constructs a
+// `BandHost` for this adapter. So pairing has to be the session, or the
+// adapter this file exists to drive never actually runs.
+//
+// BEST-EFFORT, AND BOUNDED. [pairQHybrid] returns as soon as the `device` row
+// is written — the same promise `pairNotifySensor` already makes elsewhere —
+// and the drain that follows cannot fail that promise: nothing here can
+// un-pair a device that answered the moment ago. The drain itself is capped
+// at [_kDrainWindow]; an unbounded live link nobody is watching a spinner for
+// is a battery cost and a scan/connect fight with the primary band, the same
+// reason `HrsLink` disarms the moment a workout ends.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter_blue_plus/flutter_blue_plus.dart' show BluetoothDevice;
+
+import '../data/models.dart' show ArchiveRecord;
+import 'adapters/_registry.dart' show kQHybrid;
+import 'adapters/gatt_link.dart';
+import 'adapters/host.dart';
+import 'adapters/qhybrid.dart';
+import 'ble_state.dart' show withSecondaryLinkSlot;
+import 'hrs_link.dart' show HrsLink;
+
+/// How long the post-pairing session stays connected banking notifications.
+const Duration _kDrainWindow = Duration(seconds: 10);
+
+/// Pair a Fossil/Skagen Q Hybrid, then drive one bounded session over it so
+/// pairing means more than a `device` row — see this file's own header.
+Future<String?> pairQHybrid(BluetoothDevice device, {String? label}) async {
+  final failure =
+      await HrsLink.pairNotifySensor(kQHybrid, device, label: label);
+  if (failure != null) return failure;
+  unawaited(_drainOnce(device));
+  return null;
+}
+
+Future<void> _drainOnce(BluetoothDevice device) async {
+  try {
+    await withSecondaryLinkSlot<void>(
+      () async {
+        await device.connect(timeout: const Duration(seconds: 12));
+        GattBandLink? link;
+        try {
+          final services = await device.discoverServices();
+          final localLink = GattBandLink(
+            entry: kQHybrid,
+            services: services,
+            onLog: (m) => debugPrint('[qhybrid] $m'),
+          );
+          link = localLink;
+          if (localLink
+              .missingCharacteristics(kQHybrid.requiredCharacteristics)
+              .isNotEmpty) {
+            return;
+          }
+          final host = BandHost(
+            adapter: kQHybridAdapter,
+            deviceId: HrsLink.mintDeviceId(kQHybrid, device.remoteId.str),
+            onLog: (m) => debugPrint('[qhybrid] $m'),
+            buildArchive: _buildArchiveRow,
+          );
+          final runFuture = host.run(localLink);
+          // Whichever finishes first: the adapter abstaining on its own (no
+          // probe reply) or the bounded window running out on a confirmed,
+          // still-open session. `stop()` is safe either way — `BandHost`'s
+          // own doc says so, and it is what flushes whatever this drain
+          // banked before the link goes down.
+          await Future.any(
+              [runFuture, Future<void>.delayed(_kDrainWindow)]);
+          await host.stop();
+          await runFuture;
+        } finally {
+          link?.close();
+          try {
+            await device.disconnect();
+          } catch (_) {
+            // already gone
+          }
+        }
+      },
+      timeout: const Duration(seconds: 5),
+      onTimeout: () => debugPrint(
+          '[qhybrid] another sensor held the radio; skipping this drain.'),
+    );
+  } catch (e) {
+    // Best-effort, and the pairing above already succeeded regardless — see
+    // the header. A watch out of range a moment after pairing is not an
+    // error the person who just paired it needs to see.
+    debugPrint('[qhybrid] post-pair drain did not complete: $e');
+  }
+}
+
+/// Bank one frame verbatim, undecoded (owner rulings R1-R3).
+///
+/// `reason` names the BAND, not the characteristic: six of them share this
+/// one archive path and, unlike Oura's frames (which carry their own type
+/// byte — see `oura_link.dart`'s `_buildArchiveRow`), qhybrid's do not
+/// self-identify which characteristic produced them. Recovering that per
+/// frame needs a source tag threaded through `SampleBatch`/`BandHost` itself
+/// — a shared-seam change every multi-characteristic notify adapter would
+/// benefit from, not something this one band's archive builder can invent on
+/// its own — so it is left for that change rather than guessed at here.
+ArchiveRecord _buildArchiveRow(List<int> bytes, int capturedAtMs) =>
+    ArchiveRecord(
+      hex: _hex(bytes),
+      counter: null,
+      packetType: bytes.isNotEmpty ? bytes[0] : 0,
+      recTs: null,
+      capturedAt: capturedAtMs,
+      reason: 'qhybrid_raw',
+    );
+
+String _hex(List<int> b) =>
+    b.map((x) => x.toRadixString(16).padLeft(2, '0')).join();

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -165,6 +165,8 @@
   "devicesSyncingTheRing": "Ring wird synchronisiert…",
   "devicesSynced": "Synchronisiert.",
   "devicesCouldNotReachRing": "Der Ring konnte nicht erreicht werden. Er muss in der Nähe sein und darf nicht mit einer anderen App verbunden sein.",
+  "devicesConnectingWatch": "Verbindung wird hergestellt…",
+  "devicesCouldNotReachWatch": "Die Uhr konnte nicht erreicht werden. Sie muss in der Nähe sein und darf nicht mit einer anderen App verbunden sein.",
   "devicesForgetSensor": "{name} vergessen?",
   "devicesForgetSensorBody": "Er wird während Workouts nicht mehr verwendet und muss erneut gekoppelt werden. Alles, was bereits auf diesem Telefon gespeichert ist, bleibt erhalten — dies entfernt die Quelle, nicht die Daten.",
   "devicesKeepItPaired": "Gekoppelt lassen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -763,6 +763,14 @@
   "@devicesCouldNotReachRing": {
     "description": "Snackbar: sync failed."
   },
+  "devicesConnectingWatch": "Connecting…",
+  "@devicesConnectingWatch": {
+    "description": "Snackbar: connecting to the watch."
+  },
+  "devicesCouldNotReachWatch": "Could not reach the watch. It has to be nearby, and not connected to another app.",
+  "@devicesCouldNotReachWatch": {
+    "description": "Snackbar: sync failed."
+  },
   "deviceFilterAllDevices": "All devices",
   "@deviceFilterAllDevices": {
     "description": "First pill in a metric screen's per-device filter — the merged view."

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -165,6 +165,8 @@
   "devicesSyncingTheRing": "Sincronizando el anillo…",
   "devicesSynced": "Sincronizado.",
   "devicesCouldNotReachRing": "No se pudo contactar con el anillo. Debe estar cerca y no conectado a otra app.",
+  "devicesConnectingWatch": "Conectando…",
+  "devicesCouldNotReachWatch": "No se pudo contactar con el reloj. Debe estar cerca y no conectado a otra app.",
   "devicesForgetSensor": "¿Olvidar {name}?",
   "devicesForgetSensorBody": "Deja de usarse durante los entrenamientos y hay que emparejarlo de nuevo. Todo lo ya guardado en este teléfono se conserva: esto elimina la fuente, no los datos.",
   "devicesKeepItPaired": "Mantenerlo emparejado",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -165,6 +165,8 @@
   "devicesSyncingTheRing": "Synchronisation de la bague…",
   "devicesSynced": "Synchronisé.",
   "devicesCouldNotReachRing": "Impossible de joindre la bague. Elle doit être à proximité et non connectée à une autre application.",
+  "devicesConnectingWatch": "Connexion…",
+  "devicesCouldNotReachWatch": "Impossible de joindre la montre. Elle doit être à proximité et non connectée à une autre application.",
   "devicesForgetSensor": "Oublier {name} ?",
   "devicesForgetSensorBody": "Il cesse d’être utilisé pendant les entraînements et doit être rejumelé. Tout ce qui est déjà enregistré sur ce téléphone est conservé — cela supprime la source, pas les données.",
   "devicesKeepItPaired": "Le garder jumelé",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -165,6 +165,8 @@
   "devicesSyncingTheRing": "रिंग सिंक हो रही है…",
   "devicesSynced": "सिंक हो गया।",
   "devicesCouldNotReachRing": "रिंग तक नहीं पहुंचा जा सका। यह पास होना चाहिए, और किसी अन्य ऐप से जुड़ा नहीं होना चाहिए।",
+  "devicesConnectingWatch": "कनेक्ट हो रहा है…",
+  "devicesCouldNotReachWatch": "घड़ी तक नहीं पहुंचा जा सका। यह पास होनी चाहिए, और किसी अन्य ऐप से जुड़ी नहीं होनी चाहिए।",
   "devicesForgetSensor": "{name} को भूल जाएं?",
   "devicesForgetSensorBody": "यह वर्कआउट के दौरान उपयोग होना बंद कर देगा और इसे फिर से पेयर करना होगा। इस फ़ोन पर पहले से जमा सब कुछ रखा जाता है — यह स्रोत हटाता है, डेटा नहीं।",
   "devicesKeepItPaired": "पेयर रखें",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -165,6 +165,8 @@
   "devicesSyncingTheRing": "正在同步戒指…",
   "devicesSynced": "已同步。",
   "devicesCouldNotReachRing": "无法连接到戒指。它必须在附近，且未连接到其他应用。",
+  "devicesConnectingWatch": "正在连接…",
+  "devicesCouldNotReachWatch": "无法连接到手表。它必须在附近，且未连接到其他应用。",
   "devicesForgetSensor": "忘记 {name}？",
   "devicesForgetSensorBody": "在锻炼期间将不再使用，需要重新配对。此手机上已保存的所有内容都会保留——这只是移除数据源，而不是数据。",
   "devicesKeepItPaired": "保持配对",

--- a/lib/sync/background_sync.dart
+++ b/lib/sync/background_sync.dart
@@ -22,6 +22,7 @@ import '../ble/adapters/host.dart' show BandHost;
 import '../ble/adapters/whoop_gen4.dart' show WhoopFramedAdapter;
 import '../ble/ble_engine.dart';
 import '../ble/oura_link.dart';
+import '../ble/qhybrid_link.dart';
 import '../compute/derivation_engine.dart';
 import '../compute/profile.dart';
 import '../data/db.dart';
@@ -223,6 +224,14 @@ Future<bool> runHeadlessSync({BandLease? lease}) async {
       await OuraLink.instance.sync();
     } catch (e) {
       debugPrint('[bgsync] oura sync skipped: $e');
+    }
+    // Same piggyback, same reasoning: QHybridLink.sync() no-ops when nothing
+    // is paired and never throws, but this is the one shared headless entry
+    // point, so a failure here must not escape either.
+    try {
+      await QHybridLink.instance.sync();
+    } catch (e) {
+      debugPrint('[bgsync] qhybrid sync skipped: $e');
     }
   }
 }

--- a/lib/ui2/pairing/device_picker.dart
+++ b/lib/ui2/pairing/device_picker.dart
@@ -10,7 +10,7 @@
 // into three different accounts of one action again.
 //
 // WHAT IT DOES NOT DO. It does not invent support. The category list below
-// is exactly [kBandRegistry] — three real entries, not six aspirational
+// is exactly [kBandRegistry] — real entries, not aspirational
 // ones — because a category tile for a scale or a blood-pressure cuff this
 // app cannot read from would be a promise with nothing behind it. See
 // ASSUMPTIONS R6 and `sensorIcon`'s own doc for the same rule applied
@@ -270,6 +270,12 @@ class _DevicePickerScreenState extends State<DevicePickerScreen> {
           'The strap this app is built around. WHOOP 4 or 5.',
       'oura' => l?.devicePickerBlurbRing ??
           'Reads the ring directly — no Oura account or subscription.',
+      // No localized string for this entry yet — l10n keys are generated
+      // across every locale file, which is out of scope for a single-device
+      // PR. Plain English only, same shape as every other blurb's fallback.
+      'qhybrid' =>
+        'The original Fossil/Skagen hybrid smartwatch, not the newer '
+            'Hybrid HR. Pairs and connects; nothing derives from it yet.',
       _ => l?.devicePickerBlurbSensor ??
           'A chest strap or armband, for beat timing during a workout.',
     };

--- a/lib/ui2/profile/devices.dart
+++ b/lib/ui2/profile/devices.dart
@@ -1528,15 +1528,18 @@ Future<void> _syncRing(BuildContext c) async {
 /// this just re-runs the same battery-probe-confirmed window pairing did and
 /// banks whatever the watch sends during it.
 Future<void> _syncQHybrid(BuildContext c) async {
+  final l = AppLocalizations.of(c);
   final messenger = ScaffoldMessenger.maybeOf(c);
-  messenger?.showSnackBar(const SnackBar(content: Text('Connecting…')));
+  messenger?.showSnackBar(
+      SnackBar(content: Text(l?.devicesConnectingWatch ?? 'Connecting…')));
   final ok = await QHybridLink.instance.sync();
   if (!c.mounted) return;
   messenger?.showSnackBar(SnackBar(
     content: Text(ok
-        ? 'Synced.'
-        : 'Could not reach the watch. It has to be nearby, and not connected '
-            'to another app.'),
+        ? (l?.devicesSynced ?? 'Synced.')
+        : (l?.devicesCouldNotReachWatch ??
+            'Could not reach the watch. It has to be nearby, and not '
+                'connected to another app.')),
   ));
 }
 

--- a/lib/ui2/profile/devices.dart
+++ b/lib/ui2/profile/devices.dart
@@ -43,7 +43,7 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
 
 import '../../ble/adapters/_registry.dart'
-    show BandEntry, kBandRegistry, kBleHrs, kOura, declaredSignals;
+    show BandEntry, kBandRegistry, kBleHrs, kOura, kQHybrid, declaredSignals;
 import '../../ble/adapters/signals.dart' show InputSignal;
 import '../../ble/hrs_link.dart' show HrsLink, HrsReading;
 import '../../ble/oura_link.dart' show OuraLink, pairOuraRing;
@@ -773,6 +773,7 @@ class HealthSource {
 /// the only place a user can tell two paired sensors apart at a glance.
 IconData sensorIcon(String? adapterId) => switch (adapterId) {
       'oura' => LucideIcons.circleDot,
+      'qhybrid' => LucideIcons.watch,
       _ => LucideIcons.heartPulse,
     };
 
@@ -950,6 +951,15 @@ final List<({BandEntry entry, String blurb, Future<String?> Function(BluetoothDe
         'the Oura app cannot be re-keyed. Reset it from the Oura app (remove/'
         'unpair the ring), then close that app before pairing here.',
     pick: pairOuraRing,
+  ),
+  (
+    entry: kQHybrid,
+    blurb: 'The original Fossil/Skagen hybrid smartwatch line, not the newer '
+        'Hybrid HR. Pairs and connects; nothing derives from it yet.',
+    // Plain notify-class pairing, same as the heart-rate strap above — the
+    // adapter's own battery-probe confirms it is this protocol, not the
+    // encrypted Hybrid HR sibling, once connected.
+    pick: null,
   ),
 ];
 

--- a/lib/ui2/profile/devices.dart
+++ b/lib/ui2/profile/devices.dart
@@ -47,6 +47,7 @@ import '../../ble/adapters/_registry.dart'
 import '../../ble/adapters/signals.dart' show InputSignal;
 import '../../ble/hrs_link.dart' show HrsLink, HrsReading;
 import '../../ble/oura_link.dart' show OuraLink, pairOuraRing;
+import '../../ble/qhybrid_link.dart' show pairQHybrid;
 import '../../ble/band_status_l10n.dart' show localizedBandStatus;
 import '../../ble/ble_state.dart' show BandStatus, kMaxConcurrentSecondaryLinks;
 import '../../data/db.dart' show LocalDb;
@@ -956,10 +957,15 @@ final List<({BandEntry entry, String blurb, Future<String?> Function(BluetoothDe
     entry: kQHybrid,
     blurb: 'The original Fossil/Skagen hybrid smartwatch line, not the newer '
         'Hybrid HR. Pairs and connects; nothing derives from it yet.',
-    // Plain notify-class pairing, same as the heart-rate strap above — the
+    // NOT plain notify-class pairing (`pick: null`): unlike a heart-rate
+    // strap, which a workout arms, or Oura, which has its own re-runnable
+    // sync, this band has no ongoing use — nothing derives from it, so
+    // nothing ever arms or syncs it again after the `device` row exists.
+    // `pairQHybrid` is what makes pairing the one real session it gets: the
     // adapter's own battery-probe confirms it is this protocol, not the
-    // encrypted Hybrid HR sibling, once connected.
-    pick: null,
+    // encrypted Hybrid HR sibling, and whatever it answers in the bounded
+    // window right after is what gets archived — see `qhybrid_link.dart`.
+    pick: pairQHybrid,
   ),
 ];
 

--- a/lib/ui2/profile/devices.dart
+++ b/lib/ui2/profile/devices.dart
@@ -47,7 +47,7 @@ import '../../ble/adapters/_registry.dart'
 import '../../ble/adapters/signals.dart' show InputSignal;
 import '../../ble/hrs_link.dart' show HrsLink, HrsReading;
 import '../../ble/oura_link.dart' show OuraLink, pairOuraRing;
-import '../../ble/qhybrid_link.dart' show pairQHybrid;
+import '../../ble/qhybrid_link.dart' show QHybridLink, pairQHybrid;
 import '../../ble/band_status_l10n.dart' show localizedBandStatus;
 import '../../ble/ble_state.dart' show BandStatus, kMaxConcurrentSecondaryLinks;
 import '../../data/db.dart' show LocalDb;
@@ -958,13 +958,12 @@ final List<({BandEntry entry, String blurb, Future<String?> Function(BluetoothDe
     blurb: 'The original Fossil/Skagen hybrid smartwatch line, not the newer '
         'Hybrid HR. Pairs and connects; nothing derives from it yet.',
     // NOT plain notify-class pairing (`pick: null`): unlike a heart-rate
-    // strap, which a workout arms, or Oura, which has its own re-runnable
-    // sync, this band has no ongoing use — nothing derives from it, so
-    // nothing ever arms or syncs it again after the `device` row exists.
-    // `pairQHybrid` is what makes pairing the one real session it gets: the
-    // adapter's own battery-probe confirms it is this protocol, not the
-    // encrypted Hybrid HR sibling, and whatever it answers in the bounded
-    // window right after is what gets archived — see `qhybrid_link.dart`.
+    // strap, which a workout arms, this band has no workout role, so
+    // `pairQHybrid` is what runs its first real session — the adapter's own
+    // battery-probe confirms it is this protocol, not the encrypted Hybrid HR
+    // sibling, and whatever it answers in the bounded window right after is
+    // what gets archived. The same session is re-runnable afterward — see
+    // `qhybrid_link.dart` and this screen's own sync affordance.
     pick: pairQHybrid,
   ),
 ];
@@ -1491,7 +1490,11 @@ class _DeviceDetailState extends State<DeviceDetail> {
       // primary band's link, its restore identity and its trim cursor, none of
       // which a sensor has — pointing this at it would have unpaired the
       // WHOOP from a chest strap's page.
-      onSync: s.family == 'oura' ? () => _syncRing(c) : null,
+      onSync: switch (s.family) {
+        'oura' => () => _syncRing(c),
+        'qhybrid' => () => _syncQHybrid(c),
+        _ => null,
+      },
       onForget: s.deviceId != null
           ? () => _confirmForgetSensor(c, s)
           : app == null
@@ -1517,6 +1520,23 @@ Future<void> _syncRing(BuildContext c) async {
         : (l?.devicesCouldNotReachRing ??
             'Could not reach the ring. It has to be nearby, and not connected '
                 'to another app.')),
+  ));
+}
+
+/// Hold a session with the paired watch, now, because the user asked. There
+/// is no history to drain here — see `qhybrid_link.dart`'s own header — so
+/// this just re-runs the same battery-probe-confirmed window pairing did and
+/// banks whatever the watch sends during it.
+Future<void> _syncQHybrid(BuildContext c) async {
+  final messenger = ScaffoldMessenger.maybeOf(c);
+  messenger?.showSnackBar(const SnackBar(content: Text('Connecting…')));
+  final ok = await QHybridLink.instance.sync();
+  if (!c.mounted) return;
+  messenger?.showSnackBar(SnackBar(
+    content: Text(ok
+        ? 'Synced.'
+        : 'Could not reach the watch. It has to be nearby, and not connected '
+            'to another app.'),
   ));
 }
 

--- a/test/adapter_signals_registry_test.dart
+++ b/test/adapter_signals_registry_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openstrap_edge/ble/adapters/_registry.dart';
 import 'package:openstrap_edge/ble/adapters/ble_hrs.dart';
 import 'package:openstrap_edge/ble/adapters/oura.dart';
+import 'package:openstrap_edge/ble/adapters/qhybrid.dart';
 import 'package:openstrap_edge/ble/adapters/signals.dart';
 import 'package:openstrap_edge/ble/adapters/whoop_gen4.dart';
 
@@ -25,6 +26,7 @@ void main() {
       'gen5': kWhoopGen4Signals,
       'ble_hrs': const BleHrsAdapter().signals,
       'oura': OuraAdapter(key: const [0]).signals,
+      'qhybrid': kQHybridAdapter.signals,
     };
 
     // Every registry id is covered above: a NEW adapter must extend this test,

--- a/test/adapters/qhybrid_adapter_test.dart
+++ b/test/adapters/qhybrid_adapter_test.dart
@@ -25,6 +25,13 @@ void main() {
     await Future<void>.delayed(Duration.zero);
     expect(link.writes, [(kQHybridControlChar, const [1, 8])]);
 
+    // A frame arriving before the probe is answered — the encrypted sibling
+    // protocol replying to something unrelated, say. It must not survive
+    // confirmation: it arrived while nobody yet knew this was even the right
+    // protocol.
+    link.feed(kQHybridButtonChar, const [7, 7, 7], atSec: 1_799_999_999);
+    await Future<void>.delayed(Duration.zero);
+
     link.feed(kQHybridControlChar, const [3, 8, 61], atSec: 1_800_000_000);
     await Future<void>.delayed(Duration.zero);
     // A button press, then a chunk on the file-download characteristic —

--- a/test/adapters/qhybrid_adapter_test.dart
+++ b/test/adapters/qhybrid_adapter_test.dart
@@ -57,6 +57,10 @@ void main() {
     expect(events.every((e) => e is! SampleBatch || e.samples.isEmpty), isTrue);
     expect(events.whereType<OffloadCheckpoint>(), isEmpty);
     expect(adapter.signals, isEmpty);
+    // The only signal a `Future<void>`-returning `BandHost.run` gives its
+    // caller that the probe actually confirmed — see `qhybrid_link.dart`.
+    expect(events.whereType<BandNote>().map((n) => n.key),
+        contains('qhybrid_confirmed'));
   });
 
   test('no probe reply within the window abstains cleanly — nothing banked',

--- a/test/adapters/qhybrid_adapter_test.dart
+++ b/test/adapters/qhybrid_adapter_test.dart
@@ -1,0 +1,81 @@
+// The mandatory adapter test (MULTIBAND_PLAN §3.3.3), qhybrid's shape: this
+// adapter declares NO signals at all, so there is nothing to assert arrives —
+// what matters instead is the self-confirming probe (see `qhybrid.dart`'s own
+// header) and that everything past it is banked raw, undecoded, never as an
+// [OffloadCheckpoint].
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ble/adapters/_registry.dart';
+import 'package:openstrap_edge/ble/adapters/adapter.dart';
+import 'package:openstrap_edge/ble/adapters/qhybrid.dart';
+
+void main() {
+  test('a confirmed probe unlocks the raw stream, and the reply itself is '
+      'swallowed rather than banked', () async {
+    final link = ReplayBandLink();
+    final adapter = const QHybridAdapter(probeTimeout: Duration(seconds: 1));
+    final events = <BandEvent>[];
+    final sub = adapter.run(link).listen(events.add);
+
+    // Give the adapter a beat to subscribe and write its probe before the
+    // reply is fed — a real radio never delivers a notification before the
+    // characteristic that produced it has been written to.
+    await Future<void>.delayed(Duration.zero);
+    expect(link.writes, [(kQHybridControlChar, const [1, 8])]);
+
+    link.feed(kQHybridControlChar, const [3, 8, 61], atSec: 1_800_000_000);
+    await Future<void>.delayed(Duration.zero);
+    // A button press, then a chunk on the file-download characteristic —
+    // neither is the probe reply, both must be banked verbatim.
+    link.feed(kQHybridButtonChar, const [1, 2, 3], atSec: 1_800_000_001);
+    link.feed(kQHybridFileChar1, const [9, 9], atSec: 1_800_000_002);
+    await Future<void>.delayed(Duration.zero);
+    // A real disconnect is a HOST-side cancellation of this subscription
+    // (`adapter.dart`'s own documented lifecycle), never the link's notify
+    // streams ending on their own — so that is what tears this one down too.
+    await sub.cancel();
+
+    final raw = [
+      for (final e in events)
+        if (e is SampleBatch) ...?e.raw,
+    ];
+    expect(raw, [
+      [1, 2, 3],
+      [9, 9],
+    ]);
+    // Nothing here is decoded into a sample, and nothing here stores flash on
+    // our say-so.
+    expect(events.every((e) => e is! SampleBatch || e.samples.isEmpty), isTrue);
+    expect(events.whereType<OffloadCheckpoint>(), isEmpty);
+    expect(adapter.signals, isEmpty);
+  });
+
+  test('no probe reply within the window abstains cleanly — nothing banked',
+      () async {
+    final link = ReplayBandLink();
+    final adapter = const QHybridAdapter(probeTimeout: Duration(milliseconds: 50));
+    final events = <BandEvent>[];
+    final done = Completer<void>();
+    final sub = adapter.run(link).listen(events.add, onDone: done.complete);
+
+    // A notification that arrives before the probe is ever confirmed — the
+    // encrypted sibling protocol answering something unrelated, say — must
+    // not be banked: confirmation gates everything past it.
+    await Future<void>.delayed(Duration.zero);
+    link.feed(kQHybridButtonChar, const [9, 9, 9], atSec: 1_800_000_000);
+
+    await done.future.timeout(const Duration(seconds: 2));
+    await sub.cancel();
+    expect(events, isEmpty);
+  });
+
+  test('a refused probe write ends the stream without waiting out the '
+      'timeout', () async {
+    final link = ReplayBandLink()..writeSucceeds = false;
+    final adapter = const QHybridAdapter(probeTimeout: Duration(seconds: 5));
+    final events = await adapter.run(link).toList();
+    expect(events, isEmpty);
+  });
+}

--- a/test/band_registry_test.dart
+++ b/test/band_registry_test.dart
@@ -10,7 +10,7 @@ import 'package:openstrap_protocol/openstrap_protocol.dart';
 void main() {
   test('ids are unique and stable — they are stamped as device_family', () {
     expect(kBandRegistry.map((e) => e.id).toList(),
-        <String>['gen4', 'gen5', 'ble_hrs', 'oura']);
+        <String>['gen4', 'gen5', 'ble_hrs', 'oura', 'qhybrid']);
   });
 
   test('D1 — the scan service list is exactly the two WHOOP services', () {


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
plain unencrypted GATT, no crypto handshake, no pairing key — same "pairs and banks raw bytes only" shape as the generic BLE HR strap. the same service UUID is also worn by the encrypted Hybrid HR / Gen 6 line, so before banking anything the adapter writes a harmless battery-level query and waits for a matching reply — no reply means it's the other protocol and it abstains.

experimental, decodes nothing: empty signals map, not in kDerivableSources. nobody here owns one.

## Summary by Sourcery

Add experimental Fossil/Skagen Q Hybrid pairing and raw-byte collection with protocol self-identification and no decoded health signals.

New Features:
- Add experimental Fossil/Skagen Q Hybrid support with protocol detection, pairing, bounded synchronization, and raw notification archiving.
- Expose Q Hybrid devices in pairing, device management, and background synchronization flows.

Bug Fixes:
- Prevent devices using the shared service UUID but the incompatible encrypted protocol from being incorrectly treated as Q Hybrids by requiring a battery-probe response.

Enhancements:
- Support undecoded, arrival-timestamped raw data storage without registering derivable signals for Q Hybrid devices.

Tests:
- Add coverage for Q Hybrid probe confirmation, raw-event handling, clean abstention, and refused probe writes.
- Update adapter signal and band registry tests for the new device type.


___

### **PR Type**
Enhancement


___

### **Description**
- Add experimental Fossil/Skagen Q Hybrid support.

- Probe battery to confirm unencrypted protocol variant.

- Bank all notifications as raw undecoded bytes.

- Expose watch in pairing UI and device list.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  link["BLE Link"] -- "write probe [1, 8]" --> watch["Q Hybrid"]
  watch -- "reply [3, 8, level]" --> adapter["QHybridAdapter"]
  adapter -- "bank raw bytes" --> db["Raw Storage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>_registry.dart</strong><dd><code>Register Q Hybrid service, characteristics, and band entry</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/337/files#diff-92b3191852de079fb927a9209ad2e16cf950e8e551e0f515f8636e9e350edf4e">+58/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>qhybrid.dart</strong><dd><code>Implement QHybridAdapter with battery probe and raw banking</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/337/files#diff-4d3f6e6f3a9bbc2eeba958f44a24d742c59018d2107f4a9868904a9dc048a94f">+107/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>device_picker.dart</strong><dd><code>Add UI blurb for Q Hybrid in device picker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/337/files#diff-01936f44e43baa4ed6113e6563a795495635194121c55976c87886c57f817ca1">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>devices.dart</strong><dd><code>Add watch icon and pairing configuration for Q Hybrid</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/337/files#diff-e553e52550bda8f7988f04ec5fd49d57c5a36d0e774dca61d62022e97a83fcb8">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>adapter_signals_registry_test.dart</strong><dd><code>Update registry test to include Q Hybrid signals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/337/files#diff-80fe91cb852297598cbec5fcee4d56986b78d77a5309cbcdfa31c8d3b71d900f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>qhybrid_adapter_test.dart</strong><dd><code>Add tests for Q Hybrid adapter probe logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/337/files#diff-b95431f5b185f9521dcc7007caa70d329c4230bcc5c5aca139409fbe44ded7dc">+81/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>band_registry_test.dart</strong><dd><code>Update band registry ID test to include Q Hybrid</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/337/files#diff-b1854a3fec47918fa17fbaa1b684889d846d730af0ec21f7cf649df08fb45bb3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pairing and connection support for Fossil and Skagen Q Hybrid smartwatches.
  - Added device discovery with a dedicated smartwatch icon and pairing description.
  - Added manual and background synchronization for paired Q Hybrid watches.
  - Captured watch notifications as raw data; derived sensor readings are not yet available.
  - Added safeguards to avoid incorrectly identifying incompatible devices.
  - Added support for forgetting paired Q Hybrid devices.
- **Localization**
  - Added translated “Connecting…” status text for supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->