### PR TITLE
pinetime: pairs and banks raw data

### DIFF
--- a/lib/ble/adapters/_registry.dart
+++ b/lib/ble/adapters/_registry.dart
@@ -63,6 +63,16 @@ const String kOuraCommandChar = '98ed0002-a541-11e4-b6a0-0002a5d5c51b';
 /// event share this one characteristic — there is no separate data pipe.
 const String kOuraNotifyChar = '98ed0003-a541-11e4-b6a0-0002a5d5c51b';
 
+/// A PineTime's motion service. Vendor-custom 128-bit uuid — its own GATT
+/// identity, distinct from the SIG heart-rate service this same watch also
+/// answers on (see [kHeartRateServiceUuid]).
+const String kPineTimeMotionService = '00030000-78fc-48fe-8e23-433b3a1942d0';
+
+/// Step count, notify. The only motion-service characteristic subscribed here
+/// — the same service's raw tri-axial characteristic is a separate, less
+/// settled read on real firmware, so nothing here touches it.
+const String kPineTimeStepCountChar = '00030001-78fc-48fe-8e23-433b3a1942d0';
+
 /// What a stored timestamp actually IS for a given band.
 ///
 /// The distinction is load-bearing and it is not cosmetic. A WHOOP record
@@ -438,12 +448,38 @@ const BandEntry kOura = BandEntry.notify(
   timeAnchor: TimeAnchor.arrival,
 );
 
+/// A PineTime running its open firmware. No auth, no write of any kind — two
+/// independent notify characteristics on two different services: this
+/// watch's own motion service, and the SIG heart-rate service [kBleHrs] also
+/// answers on.
+///
+/// [kPineTimeMotionService] is the scan-filter service (a vendor uuid unique
+/// to this entry — the heart-rate service is [kBleHrs]'s own scan filter, and
+/// two registry rows filtering on the same service is the collision
+/// `HrsLink.scanForAny` treats as a registry bug, not a runtime ambiguity).
+/// Both notify characteristics are still required: `GattBandLink` matches a
+/// characteristic across every service the peripheral discovers, not only
+/// the scan-filter one.
+///
+/// EXPERIMENTAL, and it stays that way: nobody on this project owns one, so
+/// not a byte of this path has met hardware (ASSUMPTIONS R6). `signals` is
+/// `const {}` and `kDerivableSources` never gets this id — step count and
+/// heart rate are both readable and neither is decoded.
+const BandEntry kPineTime = BandEntry.notify(
+  id: 'pinetime',
+  label: 'PineTime',
+  service: kPineTimeMotionService,
+  characteristics: <String>[kPineTimeStepCountChar, kHeartRateMeasurementUuid],
+  timeAnchor: TimeAnchor.arrival,
+);
+
 /// Every band this build can see. Order is match order during discovery.
 const List<BandEntry> kBandRegistry = <BandEntry>[
   kWhoopGen4,
   kWhoopGen5,
   kBleHrs,
   kOura,
+  kPineTime,
 ];
 
 /// The bands the OFFLOAD ENGINE can drive, and the bands iOS provisions
@@ -471,10 +507,11 @@ BandEntry bandEntryFor(BandProfile wire) =>
 /// `signals` getter is a plain literal with no computed dependency, so this
 /// maps straight to the declared signals instead of a constructed instance —
 /// KEPT IN SYNC BY HAND with `whoop_gen4.dart`'s `kWhoopGen4Signals`,
-/// `ble_hrs.dart`'s `BleHrsAdapter.signals` and `oura.dart`'s
-/// `OuraAdapter.signals`, since importing those three back into this file
-/// (each of which already imports THIS file for its `BandEntry`) would be a
-/// needless import cycle for three lines of data.
+/// `ble_hrs.dart`'s `BleHrsAdapter.signals`, `oura.dart`'s
+/// `OuraAdapter.signals` and `pinetime.dart`'s `PineTimeAdapter.signals`,
+/// since importing those back into this file (each of which already imports
+/// THIS file for its `BandEntry`) would be a needless import cycle for a few
+/// lines of data.
 ///
 /// gen5 reuses gen4's map: `kWhoopGen5`'s own doc comment states "same inner
 /// payload layout as gen4 — only the envelope differs", so gen4's declared
@@ -500,6 +537,7 @@ const Map<String, Map<InputSignal, Duration>> kAdapterSignals =
     InputSignal.rrIntervals: Duration(seconds: 1),
   },
   'oura': <InputSignal, Duration>{},
+  'pinetime': <InputSignal, Duration>{},
 };
 
 /// The signals one adapter declares, or empty for an id this build has no

--- a/lib/ble/adapters/pinetime.dart
+++ b/lib/ble/adapters/pinetime.dart
@@ -47,25 +47,32 @@ class PineTimeAdapter extends BandAdapter {
       if (openSubs == 0) merged.close();
     }
 
-    // `cancelOnError: true` on BOTH: without it, a channel that errors but
-    // does not itself close keeps delivering — `onOneDone` would already have
-    // closed `merged` on the error, and the next `merged.add` from either
-    // channel throws a StateError into a stream nothing here catches.
-    final subSteps = link.notify(kPineTimeStepCountChar).listen(
-          merged.add,
-          onDone: onOneDone,
-          onError: (Object _) => onOneDone(),
-          cancelOnError: true,
-        );
-    final subHr = link.notify(kHeartRateMeasurementUuid).listen(
-          merged.add,
-          onDone: onOneDone,
-          onError: (Object _) => onOneDone(),
-          cancelOnError: true,
-        );
     // No write of any kind: both channels stream on their own the moment
     // they are subscribed.
+    //
+    // BOTH `.listen()` calls are INSIDE this try, not before it — a throw out
+    // of the second one would otherwise leave the first subscription active
+    // with nothing here left to cancel it.
+    StreamSubscription<(int, List<int>)>? subSteps;
+    StreamSubscription<(int, List<int>)>? subHr;
     try {
+      // `cancelOnError: true` on BOTH: without it, a channel that errors but
+      // does not itself close keeps delivering — `onOneDone` would already
+      // have closed `merged` on the error, and the next `merged.add` from
+      // either channel throws a StateError into a stream nothing here
+      // catches.
+      subSteps = link.notify(kPineTimeStepCountChar).listen(
+        merged.add,
+        onDone: onOneDone,
+        onError: (Object _) => onOneDone(),
+        cancelOnError: true,
+      );
+      subHr = link.notify(kHeartRateMeasurementUuid).listen(
+        merged.add,
+        onDone: onOneDone,
+        onError: (Object _) => onOneDone(),
+        cancelOnError: true,
+      );
       await for (final (_, value) in merged.stream) {
         final bytes = Uint8List.fromList(value);
         if (bytes.isEmpty) continue;
@@ -76,8 +83,8 @@ class PineTimeAdapter extends BandAdapter {
         yield SampleBatch(const [], raw: [bytes], ephemeral: false);
       }
     } finally {
-      await subSteps.cancel();
-      await subHr.cancel();
+      await subSteps?.cancel();
+      await subHr?.cancel();
     }
     // No OffloadCheckpoint: nothing here trims a flash on our ACK, and there
     // is no flash to trim from our side of the wire — the watch just streams

--- a/lib/ble/adapters/pinetime.dart
+++ b/lib/ble/adapters/pinetime.dart
@@ -1,0 +1,83 @@
+// A PineTime as a [BandAdapter]: subscribe to both notify channels, archive
+// every frame. Nothing else.
+//
+// NO AUTH, NO HANDSHAKE, NO WRITE OF ANY KIND. Both characteristics start
+// notifying the moment something subscribes to them — there is no bonding
+// flag, no bind command, nothing this adapter has to say first.
+//
+// TWO INDEPENDENT NOTIFY CHANNELS ON TWO DIFFERENT SERVICES, merged into one
+// stream by hand rather than reaching for `package:async`'s `StreamGroup`
+// (same call `id115.dart` makes, for the same reason): the step-count
+// characteristic on this watch's own motion service, and the standard SIG
+// heart-rate measurement characteristic [kBleHrs] also answers on.
+//
+// STEP COUNT AND HEART RATE ARE BOTH READABLE HERE, and neither is decoded
+// (ASSUMPTIONS R6): nobody on this project owns one, so nothing is claimed
+// until a decoder exists and a real capture has met it. Declaring a signal
+// off the heart-rate characteristic the way `ble_hrs.dart` does would need
+// its own cross-confirmed capture on THIS firmware, not a borrowed decoder —
+// a frame that parses does not mean this watch's clock, contact-sensing or
+// units agree with the strap that decoder was proven against.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import '_registry.dart';
+import 'adapter.dart';
+import 'signals.dart';
+
+/// The adapter. Const, and it holds no session state.
+class PineTimeAdapter extends BandAdapter {
+  const PineTimeAdapter();
+
+  @override
+  BandEntry get entry => kPineTime;
+
+  /// Empty on purpose (the hard invariant). Step count and heart rate are
+  /// both readable off the wire and neither is claimed here.
+  @override
+  Map<InputSignal, Duration> get signals => const {};
+
+  @override
+  Stream<BandEvent> run(BandLink link) async* {
+    final merged = StreamController<(int, List<int>)>();
+    var openSubs = 2;
+    void onOneDone() {
+      openSubs--;
+      if (openSubs == 0) merged.close();
+    }
+
+    final subSteps = link.notify(kPineTimeStepCountChar).listen(
+          merged.add,
+          onDone: onOneDone,
+          onError: (Object _) => onOneDone(),
+        );
+    final subHr = link.notify(kHeartRateMeasurementUuid).listen(
+          merged.add,
+          onDone: onOneDone,
+          onError: (Object _) => onOneDone(),
+        );
+    // No write of any kind: both channels stream on their own the moment
+    // they are subscribed.
+    try {
+      await for (final (_, value) in merged.stream) {
+        final bytes = Uint8List.fromList(value);
+        if (bytes.isEmpty) continue;
+        // EVERY frame is archived, decoded or not, from either channel — the
+        // bytes are banked now so a decoder written when someone owns one of
+        // these can run over them, instead of a guess running over them
+        // today.
+        yield SampleBatch(const [], raw: [bytes], ephemeral: false);
+      }
+    } finally {
+      await subSteps.cancel();
+      await subHr.cancel();
+    }
+    // No OffloadCheckpoint: nothing here trims a flash on our ACK, and there
+    // is no flash to trim from our side of the wire — the watch just streams
+    // live.
+  }
+}
+
+/// The single instance. Const, so it costs nothing to reference.
+const PineTimeAdapter kPineTimeAdapter = PineTimeAdapter();

--- a/lib/ble/adapters/pinetime.dart
+++ b/lib/ble/adapters/pinetime.dart
@@ -47,15 +47,21 @@ class PineTimeAdapter extends BandAdapter {
       if (openSubs == 0) merged.close();
     }
 
+    // `cancelOnError: true` on BOTH: without it, a channel that errors but
+    // does not itself close keeps delivering — `onOneDone` would already have
+    // closed `merged` on the error, and the next `merged.add` from either
+    // channel throws a StateError into a stream nothing here catches.
     final subSteps = link.notify(kPineTimeStepCountChar).listen(
           merged.add,
           onDone: onOneDone,
           onError: (Object _) => onOneDone(),
+          cancelOnError: true,
         );
     final subHr = link.notify(kHeartRateMeasurementUuid).listen(
           merged.add,
           onDone: onOneDone,
           onError: (Object _) => onOneDone(),
+          cancelOnError: true,
         );
     // No write of any kind: both channels stream on their own the moment
     // they are subscribed.

--- a/lib/ble/pinetime_link.dart
+++ b/lib/ble/pinetime_link.dart
@@ -91,31 +91,30 @@ class PineTimeLink {
               onLog: (m) => debugPrint('[pinetime] $m'),
             );
             _link = link;
-            final missing =
-                link.missingCharacteristics(kPineTime.requiredCharacteristics);
-            if (missing.isNotEmpty) {
-              debugPrint('[pinetime] ${kPineTime.label}: missing required '
-                  'characteristic(s) '
-                  '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
-              // Clears `_link` too — leaving it set here is the one failure
-              // exit that skipped the same cleanup every other exit runs
-              // through `finally { await stop(); }`.
-              await stop();
-              return false;
-            }
-            final host = BandHost(
-              adapter: const PineTimeAdapter(),
-              deviceId: deviceId,
-              onLog: (m) => debugPrint('[pinetime] $m'),
-            );
-            _host = host;
-            final done = host.run(link);
+            // ONE `finally { await stop(); }` for everything past this point
+            // — a throw out of `missingCharacteristics`, `BandHost(...)` or
+            // `host.run` itself would otherwise leave `_link`/`_host` set
+            // with nothing left to clear them.
             try {
-              await done.timeout(_listenWindow, onTimeout: () {});
+              final missing = link
+                  .missingCharacteristics(kPineTime.requiredCharacteristics);
+              if (missing.isNotEmpty) {
+                debugPrint('[pinetime] ${kPineTime.label}: missing required '
+                    'characteristic(s) '
+                    '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
+                return false;
+              }
+              final host = BandHost(
+                adapter: const PineTimeAdapter(),
+                deviceId: deviceId,
+                onLog: (m) => debugPrint('[pinetime] $m'),
+              );
+              _host = host;
+              await host.run(link).timeout(_listenWindow, onTimeout: () {});
+              return true;
             } finally {
               await stop();
             }
-            return true;
           } finally {
             try {
               await device.disconnect();

--- a/lib/ble/pinetime_link.dart
+++ b/lib/ble/pinetime_link.dart
@@ -92,6 +92,10 @@ class PineTimeLink {
             debugPrint('[pinetime] ${kPineTime.label}: missing required '
                 'characteristic(s) '
                 '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
+            // Clears `_link` too — leaving it set here is the one failure
+            // exit that skipped the same cleanup every other exit runs
+            // through `finally { await stop(); }`.
+            await stop();
             await device.disconnect().catchError((_) {});
             return false;
           }

--- a/lib/ble/pinetime_link.dart
+++ b/lib/ble/pinetime_link.dart
@@ -79,42 +79,48 @@ class PineTimeLink {
         try {
           final device = BluetoothDevice.fromId(remoteId);
           await device.connect(timeout: const Duration(seconds: 20));
-          final services = await device.discoverServices();
-          final link = GattBandLink(
-            entry: kPineTime,
-            services: services,
-            onLog: (m) => debugPrint('[pinetime] $m'),
-          );
-          _link = link;
-          final missing =
-              link.missingCharacteristics(kPineTime.requiredCharacteristics);
-          if (missing.isNotEmpty) {
-            debugPrint('[pinetime] ${kPineTime.label}: missing required '
-                'characteristic(s) '
-                '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
-            // Clears `_link` too — leaving it set here is the one failure
-            // exit that skipped the same cleanup every other exit runs
-            // through `finally { await stop(); }`.
-            await stop();
-            await device.disconnect().catchError((_) {});
-            return false;
-          }
-          final host = BandHost(
-            adapter: const PineTimeAdapter(),
-            deviceId: deviceId,
-            onLog: (m) => debugPrint('[pinetime] $m'),
-          );
-          _host = host;
-          final done = host.run(link);
+          // EVERYTHING past the connect is inside this `finally` now — a
+          // throw out of `discoverServices()` or `GattBandLink(...)` used to
+          // skip the disconnect below entirely, wedging the device connected
+          // with nothing left to tear it down.
           try {
-            await done.timeout(_listenWindow, onTimeout: () {});
+            final services = await device.discoverServices();
+            final link = GattBandLink(
+              entry: kPineTime,
+              services: services,
+              onLog: (m) => debugPrint('[pinetime] $m'),
+            );
+            _link = link;
+            final missing =
+                link.missingCharacteristics(kPineTime.requiredCharacteristics);
+            if (missing.isNotEmpty) {
+              debugPrint('[pinetime] ${kPineTime.label}: missing required '
+                  'characteristic(s) '
+                  '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
+              // Clears `_link` too — leaving it set here is the one failure
+              // exit that skipped the same cleanup every other exit runs
+              // through `finally { await stop(); }`.
+              await stop();
+              return false;
+            }
+            final host = BandHost(
+              adapter: const PineTimeAdapter(),
+              deviceId: deviceId,
+              onLog: (m) => debugPrint('[pinetime] $m'),
+            );
+            _host = host;
+            final done = host.run(link);
+            try {
+              await done.timeout(_listenWindow, onTimeout: () {});
+            } finally {
+              await stop();
+            }
+            return true;
           } finally {
-            await stop();
             try {
               await device.disconnect();
             } catch (_) {/* already gone */}
           }
-          return true;
         } catch (e) {
           debugPrint('[pinetime] connect failed: $e');
           return false;

--- a/lib/ble/pinetime_link.dart
+++ b/lib/ble/pinetime_link.dart
@@ -58,21 +58,27 @@ class PineTimeLink {
   }
 
   Future<bool> _sync() async {
-    final row = await pairedRow();
-    if (row == null) return false;
-    final deviceId = row['id'] as String?;
-    final remoteId = row['remote_id'] as String?;
-    if (deviceId == null || remoteId == null || remoteId.isEmpty) return false;
-    if (deviceId == LocalDb.kPrimaryDeviceId) {
-      // The primary band's id, permanently. This watch writing under it
-      // would interleave its (undecoded, sample-less) rows with the band's
-      // own.
-      debugPrint('[pinetime] refusing to sync: the row claims the primary '
-          'device id — re-pair it with a minted id.');
-      return false;
-    }
-
+    // The WHOLE body is inside this try now, `pairedRow()` included — a
+    // `LocalDb.deviceRows()` failure used to escape uncaught, breaking
+    // `sync()`'s no-throw contract and leaving the manual caller's "Syncing"
+    // snackbar never replaced with a result.
     try {
+      final row = await pairedRow();
+      if (row == null) return false;
+      final deviceId = row['id'] as String?;
+      final remoteId = row['remote_id'] as String?;
+      if (deviceId == null || remoteId == null || remoteId.isEmpty) {
+        return false;
+      }
+      if (deviceId == LocalDb.kPrimaryDeviceId) {
+        // The primary band's id, permanently. This watch writing under it
+        // would interleave its (undecoded, sample-less) rows with the band's
+        // own.
+        debugPrint('[pinetime] refusing to sync: the row claims the primary '
+            'device id — re-pair it with a minted id.');
+        return false;
+      }
+
       // A cap on concurrent SECONDARY links (never the primary band's own
       // connect — see ble_state.dart's kMaxConcurrentSecondaryLinks doc).
       return await withSecondaryLinkSlot(() async {

--- a/lib/ble/pinetime_link.dart
+++ b/lib/ble/pinetime_link.dart
@@ -1,0 +1,133 @@
+// The HOST for a paired PineTime: connect to its stored remote id, drive
+// [PineTimeAdapter] over the link, bank what comes back, disconnect.
+//
+// NOTHING HERE HAS MET HARDWARE (ASSUMPTIONS R6). The registry entry stays
+// EXPERIMENTAL, `PineTimeAdapter.signals` stays `const {}`, and nothing this
+// file writes becomes a number — every row it commits carries a non-null
+// `source`.
+//
+// THIN COUSIN OF `watch9_link.dart`. There is no auth, no drain cursor and
+// no time anchor to hold — nothing here writes anything at all — so this is
+// the same one-shot `sync()` shape: connect, listen for whatever the watch
+// sends over one flush window, tear down.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+import '../data/db.dart';
+import 'adapters/_registry.dart';
+import 'adapters/gatt_link.dart';
+import 'adapters/host.dart' show BandHost;
+import 'adapters/pinetime.dart';
+import 'ble_state.dart' show withSecondaryLinkSlot;
+
+/// The live link to a paired PineTime. One instance; a second concurrent
+/// unit is not a thing anyone asked for.
+class PineTimeLink {
+  PineTimeLink._();
+  static final PineTimeLink instance = PineTimeLink._();
+
+  /// The `device` row for the paired watch, or null.
+  static Future<Map<String, Object?>?> pairedRow() async {
+    for (final r in await LocalDb.deviceRows()) {
+      if (r['adapter_id'] == kPineTime.id) return r;
+    }
+    return null;
+  }
+
+  GattBandLink? _link;
+  BandHost? _host;
+  bool _busy = false;
+
+  /// How long one sync session listens before tearing down. There is no
+  /// drain to finish and no cursor to exhaust — the watch just streams
+  /// whatever it has — so this is a plain window, not a completion signal.
+  static const Duration _listenWindow = Duration(seconds: 20);
+
+  /// Connect, listen for [_listenWindow], disconnect.
+  ///
+  /// Returns false when nothing is paired or the connect failed. Never
+  /// throws. SERIALISED: a second call while one is in flight is a no-op
+  /// rather than a second radio session over the same peripheral.
+  Future<bool> sync() {
+    if (_busy) return Future.value(false);
+    _busy = true;
+    return _sync().whenComplete(() => _busy = false);
+  }
+
+  Future<bool> _sync() async {
+    final row = await pairedRow();
+    if (row == null) return false;
+    final deviceId = row['id'] as String?;
+    final remoteId = row['remote_id'] as String?;
+    if (deviceId == null || remoteId == null || remoteId.isEmpty) return false;
+    if (deviceId == LocalDb.kPrimaryDeviceId) {
+      // The primary band's id, permanently. This watch writing under it
+      // would interleave its (undecoded, sample-less) rows with the band's
+      // own.
+      debugPrint('[pinetime] refusing to sync: the row claims the primary '
+          'device id — re-pair it with a minted id.');
+      return false;
+    }
+
+    try {
+      // A cap on concurrent SECONDARY links (never the primary band's own
+      // connect — see ble_state.dart's kMaxConcurrentSecondaryLinks doc).
+      return await withSecondaryLinkSlot(() async {
+        try {
+          final device = BluetoothDevice.fromId(remoteId);
+          await device.connect(timeout: const Duration(seconds: 20));
+          final services = await device.discoverServices();
+          final link = GattBandLink(
+            entry: kPineTime,
+            services: services,
+            onLog: (m) => debugPrint('[pinetime] $m'),
+          );
+          _link = link;
+          final missing =
+              link.missingCharacteristics(kPineTime.requiredCharacteristics);
+          if (missing.isNotEmpty) {
+            debugPrint('[pinetime] ${kPineTime.label}: missing required '
+                'characteristic(s) '
+                '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
+            await device.disconnect().catchError((_) {});
+            return false;
+          }
+          final host = BandHost(
+            adapter: const PineTimeAdapter(),
+            deviceId: deviceId,
+            onLog: (m) => debugPrint('[pinetime] $m'),
+          );
+          _host = host;
+          final done = host.run(link);
+          try {
+            await done.timeout(_listenWindow, onTimeout: () {});
+          } finally {
+            await stop();
+            try {
+              await device.disconnect();
+            } catch (_) {/* already gone */}
+          }
+          return true;
+        } catch (e) {
+          debugPrint('[pinetime] connect failed: $e');
+          return false;
+        }
+      });
+    } catch (e) {
+      debugPrint('[pinetime] sync failed: $e');
+      return false;
+    }
+  }
+
+  /// Drop the link, flush what has been buffered. Safe when nothing is
+  /// connected.
+  Future<void> stop() async {
+    _link?.close();
+    _link = null;
+    await _host?.stop();
+    _host = null;
+  }
+}

--- a/lib/ble/pinetime_link.dart
+++ b/lib/ble/pinetime_link.dart
@@ -13,15 +13,35 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter/foundation.dart'
+    show debugPrint, visibleForTesting;
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
 import '../data/db.dart';
+import '../data/models.dart' show ArchiveRecord;
 import 'adapters/_registry.dart';
+import 'adapters/adapter.dart' show ReplayBandLink;
 import 'adapters/gatt_link.dart';
 import 'adapters/host.dart' show BandHost;
 import 'adapters/pinetime.dart';
 import 'ble_state.dart' show withSecondaryLinkSlot;
+
+String _hex(List<int> b) =>
+    b.map((x) => x.toRadixString(16).padLeft(2, '0')).join();
+
+/// Bank one frame verbatim, decoded or not — same call `oura_link.dart` makes.
+/// `packetType` is the frame's own first byte, not a real tag: the two notify
+/// channels are merged upstream (`pinetime.dart`) with no marker for which one
+/// a frame came from, so `reason` cannot name a channel either.
+ArchiveRecord _buildArchiveRow(List<int> bytes, int capturedAtMs) =>
+    ArchiveRecord(
+      hex: _hex(bytes),
+      counter: null,
+      packetType: bytes.isNotEmpty ? bytes[0] : 0,
+      recTs: null,
+      capturedAt: capturedAtMs,
+      reason: 'pinetime_frame',
+    );
 
 /// The live link to a paired PineTime. One instance; a second concurrent
 /// unit is not a thing anyone asked for.
@@ -110,11 +130,7 @@ class PineTimeLink {
                     '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
                 return false;
               }
-              final host = BandHost(
-                adapter: const PineTimeAdapter(),
-                deviceId: deviceId,
-                onLog: (m) => debugPrint('[pinetime] $m'),
-              );
+              final host = _makeHost(deviceId);
               _host = host;
               await host.run(link).timeout(_listenWindow, onTimeout: () {});
               return true;
@@ -143,6 +159,37 @@ class PineTimeLink {
     _link?.close();
     _link = null;
     await _host?.stop();
+    _host = null;
+  }
+
+  /// Build this session's [BandHost]. One place, so `_sync()` and
+  /// [ingestForTest] cannot drift on whether raw frames get archived — see
+  /// `oura_link.dart`'s own `_makeHost` for the same discipline.
+  BandHost _makeHost(String deviceId) => BandHost(
+        adapter: const PineTimeAdapter(),
+        deviceId: deviceId,
+        onLog: (m) => debugPrint('[pinetime] $m'),
+        buildArchive: _buildArchiveRow,
+      );
+
+  /// Replay scripted notifications through the REAL [PineTimeAdapter] and the
+  /// real write path. The only way in: the entry point is a BLE notification
+  /// and `flutter_blue_plus` has no simulator path.
+  @visibleForTesting
+  Future<void> ingestForTest(
+    String deviceId,
+    List<(String characteristicUuid, int atSec, List<int> value)> arrivals,
+  ) async {
+    final host = _makeHost(deviceId);
+    _host = host;
+    final link = ReplayBandLink();
+    final done = host.run(link);
+    for (final (uuid, sec, value) in arrivals) {
+      link.feed(uuid, value, atSec: sec);
+    }
+    await link.close();
+    await done;
+    await host.stop();
     _host = null;
   }
 }

--- a/lib/sync/background_sync.dart
+++ b/lib/sync/background_sync.dart
@@ -22,6 +22,7 @@ import '../ble/adapters/host.dart' show BandHost;
 import '../ble/adapters/whoop_gen4.dart' show WhoopFramedAdapter;
 import '../ble/ble_engine.dart';
 import '../ble/oura_link.dart';
+import '../ble/pinetime_link.dart';
 import '../compute/derivation_engine.dart';
 import '../compute/profile.dart';
 import '../data/db.dart';
@@ -223,6 +224,14 @@ Future<bool> runHeadlessSync({BandLease? lease}) async {
       await OuraLink.instance.sync();
     } catch (e) {
       debugPrint('[bgsync] oura sync skipped: $e');
+    }
+    // Same piggyback, same reasoning: PineTimeLink.sync() no-ops when
+    // nothing is paired and never throws, but the shared entry point must
+    // never let it escape and mark the WHOOP cycle as errored.
+    try {
+      await PineTimeLink.instance.sync();
+    } catch (e) {
+      debugPrint('[bgsync] pinetime sync skipped: $e');
     }
   }
 }

--- a/lib/ui2/pairing/device_picker.dart
+++ b/lib/ui2/pairing/device_picker.dart
@@ -270,6 +270,10 @@ class _DevicePickerScreenState extends State<DevicePickerScreen> {
           'The strap this app is built around. WHOOP 4 or 5.',
       'oura' => l?.devicePickerBlurbRing ??
           'Reads the ring directly — no Oura account or subscription.',
+      // No dedicated l10n key yet — same untranslated sentence
+      // `kPairableSensors` already carries for this entry.
+      'pinetime' => 'Pairs and banks its raw data in the background, but '
+          'does not derive anything from it yet.',
       _ => l?.devicePickerBlurbSensor ??
           'A chest strap or armband, for beat timing during a workout.',
     };

--- a/lib/ui2/profile/devices.dart
+++ b/lib/ui2/profile/devices.dart
@@ -1535,6 +1535,7 @@ Future<void> _syncPineTime(BuildContext c) async {
       SnackBar(content: Text(l?.devicesSyncing ?? 'Syncing')));
   final ok = await PineTimeLink.instance.sync();
   if (!c.mounted) return;
+  messenger?.hideCurrentSnackBar();
   messenger?.showSnackBar(SnackBar(
     content: Text(ok
         ? (l?.devicesSynced ?? 'Synced.')

--- a/lib/ui2/profile/devices.dart
+++ b/lib/ui2/profile/devices.dart
@@ -43,10 +43,11 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
 
 import '../../ble/adapters/_registry.dart'
-    show BandEntry, kBandRegistry, kBleHrs, kOura, declaredSignals;
+    show BandEntry, kBandRegistry, kBleHrs, kOura, kPineTime, declaredSignals;
 import '../../ble/adapters/signals.dart' show InputSignal;
 import '../../ble/hrs_link.dart' show HrsLink, HrsReading;
 import '../../ble/oura_link.dart' show OuraLink, pairOuraRing;
+import '../../ble/pinetime_link.dart' show PineTimeLink;
 import '../../ble/band_status_l10n.dart' show localizedBandStatus;
 import '../../ble/ble_state.dart' show BandStatus, kMaxConcurrentSecondaryLinks;
 import '../../data/db.dart' show LocalDb;
@@ -773,6 +774,7 @@ class HealthSource {
 /// the only place a user can tell two paired sensors apart at a glance.
 IconData sensorIcon(String? adapterId) => switch (adapterId) {
       'oura' => LucideIcons.circleDot,
+      'pinetime' => LucideIcons.watch,
       _ => LucideIcons.heartPulse,
     };
 
@@ -950,6 +952,15 @@ final List<({BandEntry entry, String blurb, Future<String?> Function(BluetoothDe
         'the Oura app cannot be re-keyed. Reset it from the Oura app (remove/'
         'unpair the ring), then close that app before pairing here.',
     pick: pairOuraRing,
+  ),
+  (
+    entry: kPineTime,
+    blurb: 'Pairs and banks its raw data in the background, but does not '
+        'derive anything from it yet — nobody on this project owns one to '
+        'verify its numbers against.',
+    // Null means the plain notify-class pairing, which is the whole of what
+    // this watch needs — no auth, no key.
+    pick: null,
   ),
 ];
 
@@ -1475,7 +1486,11 @@ class _DeviceDetailState extends State<DeviceDetail> {
       // primary band's link, its restore identity and its trim cursor, none of
       // which a sensor has — pointing this at it would have unpaired the
       // WHOOP from a chest strap's page.
-      onSync: s.family == 'oura' ? () => _syncRing(c) : null,
+      onSync: s.family == 'oura'
+          ? () => _syncRing(c)
+          : s.family == 'pinetime'
+              ? () => _syncPineTime(c)
+              : null,
       onForget: s.deviceId != null
           ? () => _confirmForgetSensor(c, s)
           : app == null
@@ -1501,6 +1516,30 @@ Future<void> _syncRing(BuildContext c) async {
         : (l?.devicesCouldNotReachRing ??
             'Could not reach the ring. It has to be nearby, and not connected '
                 'to another app.')),
+  ));
+}
+
+/// Connect and bank the watch's raw bytes, now, because the user asked. Same
+/// shape as [_syncRing] — a sync that silently did nothing is
+/// indistinguishable from a watch that had nothing to give, and those need
+/// different remedies.
+Future<void> _syncPineTime(BuildContext c) async {
+  final l = AppLocalizations.of(c);
+  final messenger = ScaffoldMessenger.maybeOf(c);
+  // `devicesSyncing`/`devicesSynced` are genuinely generic ("Syncing"/
+  // "Synced."), unlike `devicesSyncingTheRing`/`devicesCouldNotReachRing`,
+  // which name the ring by copy — reusing those here would show the wrong
+  // device in the snack bar, so the failure sentence stays untranslated
+  // rather than borrowing one that says the wrong thing.
+  messenger?.showSnackBar(
+      SnackBar(content: Text(l?.devicesSyncing ?? 'Syncing')));
+  final ok = await PineTimeLink.instance.sync();
+  if (!c.mounted) return;
+  messenger?.showSnackBar(SnackBar(
+    content: Text(ok
+        ? (l?.devicesSynced ?? 'Synced.')
+        : 'Could not reach the watch. It has to be nearby, and not connected '
+            'to another app.'),
   ));
 }
 

--- a/test/adapter_signals_registry_test.dart
+++ b/test/adapter_signals_registry_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openstrap_edge/ble/adapters/_registry.dart';
 import 'package:openstrap_edge/ble/adapters/ble_hrs.dart';
 import 'package:openstrap_edge/ble/adapters/oura.dart';
+import 'package:openstrap_edge/ble/adapters/pinetime.dart';
 import 'package:openstrap_edge/ble/adapters/signals.dart';
 import 'package:openstrap_edge/ble/adapters/whoop_gen4.dart';
 
@@ -25,6 +26,7 @@ void main() {
       'gen5': kWhoopGen4Signals,
       'ble_hrs': const BleHrsAdapter().signals,
       'oura': OuraAdapter(key: const [0]).signals,
+      'pinetime': kPineTimeAdapter.signals,
     };
 
     // Every registry id is covered above: a NEW adapter must extend this test,

--- a/test/adapters/pinetime_test.dart
+++ b/test/adapters/pinetime_test.dart
@@ -1,0 +1,97 @@
+// The mandatory adapter test (MULTIBAND_PLAN §3.3.3), PineTime's shape: no
+// signal is declared, nothing is ever written, both notify channels are
+// merged, and every notification comes back as raw bytes and nothing else.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ble/adapters/_registry.dart';
+import 'package:openstrap_edge/ble/adapters/adapter.dart';
+import 'package:openstrap_edge/ble/adapters/pinetime.dart';
+
+/// A plausible step-count notification: a little-endian u32.
+final Uint8List kStepsFrame = Uint8List.fromList([0x2a, 0x00, 0x00, 0x00]);
+
+/// A plausible heart-rate-measurement notification: flags byte 0x00 (u8 bpm
+/// format, no contact bit), bpm 0x3c.
+final Uint8List kHrFrame = Uint8List.fromList([0x00, 0x3c]);
+
+/// Let the adapter's `async*` body actually run before this test touches the
+/// link again — same idiom `id115_test.dart`'s own two-characteristic replay
+/// spins on: a stream's generator body is scheduled, not entered
+/// synchronously, so a `link.close()` right after `.listen()` can beat both
+/// of this adapter's `notify()` calls into existence.
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+Future<List<BandEvent>> replay(
+    List<(String uuid, int sec, Uint8List value)> arrivals) async {
+  final link = ReplayBandLink();
+  final events = <BandEvent>[];
+  final done = Completer<void>();
+  final sub =
+      kPineTimeAdapter.run(link).listen(events.add, onDone: done.complete);
+  await _settle();
+  for (final (uuid, sec, value) in arrivals) {
+    link.feed(uuid, value, atSec: sec);
+  }
+  await link.close();
+  await done.future;
+  await sub.cancel();
+  return events;
+}
+
+void main() {
+  test('declares no signals — no card may ever key off this adapter', () {
+    expect(kPineTimeAdapter.signals, isEmpty);
+    expect(kPineTimeAdapter.entry.isFramed, isFalse);
+    expect(kPineTimeAdapter.entry.requiredCharacteristics,
+        [kPineTimeStepCountChar, kHeartRateMeasurementUuid]);
+  });
+
+  test('writes nothing at all: both channels stream unprompted', () async {
+    final link = ReplayBandLink();
+    final sub = kPineTimeAdapter.run(link).listen((_) {});
+    await Future<void>.delayed(Duration.zero);
+    await link.close();
+    await sub.cancel();
+    expect(link.writes, isEmpty);
+  });
+
+  test('both notify channels are merged into raw frames, neither one lost',
+      () async {
+    final events = await replay([
+      (kPineTimeStepCountChar, 1_800_000_000, kStepsFrame),
+      (kHeartRateMeasurementUuid, 1_800_000_001, kHrFrame),
+    ]);
+    final batches = events.whereType<SampleBatch>().toList();
+    expect(batches, hasLength(2));
+    expect(batches.every((b) => b.samples.isEmpty), isTrue);
+    expect(batches.every((b) => !b.ephemeral), isTrue);
+    final raws = batches.map((b) => b.raw!.single).toList();
+    expect(raws, containsAll([kStepsFrame, kHrFrame]));
+  });
+
+  test('no flash storage, never emits an OffloadCheckpoint', () async {
+    final events =
+        await replay([(kPineTimeStepCountChar, 1_800_000_000, kStepsFrame)]);
+    expect(events.whereType<OffloadCheckpoint>(), isEmpty);
+  });
+
+  test('the session ends once BOTH notify channels close', () async {
+    final link = ReplayBandLink();
+    final events = <BandEvent>[];
+    final done = Completer<void>();
+    final sub =
+        kPineTimeAdapter.run(link).listen(events.add, onDone: done.complete);
+    await _settle();
+    link.feed(kPineTimeStepCountChar, kStepsFrame, atSec: 1_800_000_000);
+    // Closing the whole link is the only way `ReplayBandLink` ends a
+    // channel — this proves the merge does not hang waiting on a stream
+    // that was never fed, not that one channel alone can end the session.
+    await link.close();
+    await done.future;
+    await sub.cancel();
+    expect(events.whereType<SampleBatch>(), hasLength(1));
+  });
+}

--- a/test/band_registry_test.dart
+++ b/test/band_registry_test.dart
@@ -10,7 +10,7 @@ import 'package:openstrap_protocol/openstrap_protocol.dart';
 void main() {
   test('ids are unique and stable — they are stamped as device_family', () {
     expect(kBandRegistry.map((e) => e.id).toList(),
-        <String>['gen4', 'gen5', 'ble_hrs', 'oura']);
+        <String>['gen4', 'gen5', 'ble_hrs', 'oura', 'pinetime']);
   });
 
   test('D1 — the scan service list is exactly the two WHOOP services', () {
@@ -45,6 +45,21 @@ void main() {
     // The two halves that could NOT be expressed — see the registry header.
     expect(kBleHrs.gatt, isNull, reason: 'GattProfile is six WHOOP UUIDs');
     expect(kBleHrs.wire, isNull, reason: 'BandProfile is a framed envelope');
+  });
+
+  test('a PineTime entry filters on its OWN service, not the shared HRS one',
+      () {
+    expect(kPineTime.isFramed, isFalse);
+    expect(kPineTime.service, kPineTimeMotionService);
+    expect(kPineTime.servicePrefix, '00030000');
+    // Distinct from kBleHrs's own scan filter — two rows sharing one service
+    // is the collision `HrsLink.scanForAny` treats as a registry bug.
+    expect(kPineTime.service, isNot(kBleHrs.service));
+    // Both required, even though they sit on two different GATT services —
+    // `GattBandLink` matches a characteristic across every discovered
+    // service, not only the scan-filter one.
+    expect(kPineTime.requiredCharacteristics,
+        [kPineTimeStepCountChar, kHeartRateMeasurementUuid]);
   });
 
   test('D3 — frameOpcodeIndex lands on the opcode of a real built frame', () {

--- a/test/pinetime_link_test.dart
+++ b/test/pinetime_link_test.dart
@@ -1,0 +1,62 @@
+// The PineTime HOST: scripted notifications in, `raw_archive` out.
+//
+// NOTHING HERE HAS MET HARDWARE (ASSUMPTIONS R6). `pinetime_test.dart` already
+// proves the adapter merges both notify channels into raw frames; this file
+// exists for the one thing only a host can get wrong — whether those frames
+// actually reach the database, which `oura_link_test.dart` and
+// `hrs_link_test.dart` each already guard for their own band.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:openstrap_edge/ble/adapters/_registry.dart';
+import 'package:openstrap_edge/ble/pinetime_link.dart';
+import 'package:openstrap_edge/data/db.dart';
+
+const String _deviceId = 'pinetime-0a1b2c3d';
+
+final List<int> _stepsFrame = [0x2a, 0x00, 0x00, 0x00];
+final List<int> _hrFrame = [0x00, 0x3c];
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    await LocalDb.close();
+    LocalDb.dbName = 'pinetime_link_test.db';
+    final dir = await databaseFactory.getDatabasesPath();
+    await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+  });
+
+  tearDown(() async => LocalDb.close());
+
+  test('every frame from either channel is banked, not silently dropped',
+      () async {
+    await PineTimeLink.instance.ingestForTest(_deviceId, [
+      (kPineTimeStepCountChar, 1_800_000_000, _stepsFrame),
+      (kHeartRateMeasurementUuid, 1_800_000_001, _hrFrame),
+    ]);
+
+    final db = await LocalDb.instance;
+    final archive = await db.query('raw_archive', orderBy: 'hex');
+    expect(archive, hasLength(2));
+    final hexes = archive.map((a) => a['hex']).toSet();
+    expect(hexes, {'2a000000', '003c'});
+    expect(archive.every((a) => a['reason'] == 'pinetime_frame'), isTrue);
+    // No signal is ever declared, so nothing here writes a decoded row.
+    expect(await db.query('decoded_onehz'), isEmpty);
+    // Not re-drivable: `redriveArchivedRecords` replays a row's hex through
+    // the WHOOP R24 chain, the wrong decoder over the right bytes.
+    for (final a in archive) {
+      expect(LocalDb.redrivableArchiveReasons, isNot(contains(a['reason'])));
+    }
+  });
+
+  test('nothing paired means nothing to sync', () async {
+    expect(await PineTimeLink.pairedRow(), isNull);
+    expect(await PineTimeLink.instance.sync(), isFalse);
+  });
+}


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
pairs a PineTime (InfiniTime firmware) as a notify-only sensor, same shape as the oura/hrs entries. subscribes to the motion service's step-count characteristic and the standard heart-rate measurement characteristic, banks every frame to raw_archive. no auth, no writes, no decode — ships experimental, no signals declared, nothing derives from it yet.

## Summary by Sourcery

Add experimental PineTime pairing and raw notification archiving without interpreting sensor metrics.

New Features:
- Add PineTime as a pairable notify-only sensor with device-picker and profile-device support.
- Subscribe to PineTime step-count and standard heart-rate notifications during background and manual syncs.
- Archive incoming PineTime frames as raw data without decoding or deriving signals.

Enhancements:
- Manage serialized 20-second PineTime sync sessions with cleanup and secondary-link limits.

Tests:
- Add coverage for PineTime registry configuration, empty signal declarations, raw frame handling, channel merging, and session behavior.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds PineTime as a pairable sensor.

- Subscribes to step and heart rate notifications.

- Banks raw frames without decoding metrics.

- Implements a 20-second sync session window.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["Device Picker"] -- "Pairs & Syncs" --> Link["PineTimeLink"]
  Link -- "Connects" --> Adapter["PineTimeAdapter"]
  Adapter -- "Subscribes" --> BLE["PineTime Watch"]
  BLE -- "Raw Bytes" --> Adapter
  Adapter -- "Banks Data" --> DB["raw_archive"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>_registry.dart</strong><dd><code>Registers PineTime UUIDs and band entry configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/338/files#diff-92b3191852de079fb927a9209ad2e16cf950e8e551e0f515f8636e9e350edf4e">+42/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>pinetime.dart</strong><dd><code>Implements adapter to stream and bank raw bytes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/338/files#diff-2eb5c4e15266484de3a18c9385029038852d8d6f65d0b7cd0425d62f56ea7394">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pinetime_link.dart</strong><dd><code>Manages 20-second connection and sync sessions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/338/files#diff-f8046c854d9498b29e1848cff1e52bdc0d280609992138afb39695c600c15034">+133/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>device_picker.dart</strong><dd><code>Adds PineTime description to the device picker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/338/files#diff-01936f44e43baa4ed6113e6563a795495635194121c55976c87886c57f817ca1">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>devices.dart</strong><dd><code>Wires PineTime pairing, icon, and manual sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/338/files#diff-e553e52550bda8f7988f04ec5fd49d57c5a36d0e774dca61d62022e97a83fcb8">+41/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>adapter_signals_registry_test.dart</strong><dd><code>Includes PineTime in adapter signals registry tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/338/files#diff-80fe91cb852297598cbec5fcee4d56986b78d77a5309cbcdfa31c8d3b71d900f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pinetime_test.dart</strong><dd><code>Tests PineTime adapter streaming and banking behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/338/files#diff-297f5a7ee921f36759d2897aa02621447f4997433790bc72e46ebdc91cd154e9">+97/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>band_registry_test.dart</strong><dd><code>Verifies PineTime registry entry and service filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/338/files#diff-b1854a3fec47918fa17fbaa1b684889d846d730af0ec21f7cf649df08fb45bb3">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PineTime smartwatch support for pairing and Bluetooth synchronization.
  * Added automatic background syncing during scheduled sync windows.
  * Added manual sync from the PineTime device details screen.
  * Stores synchronized PineTime data as raw samples without derived metrics.
  * Added PineTime identification and a dedicated watch icon in device selection and profiles.
  * Added safeguards for connection failures, repeated sync attempts, and clean disconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->