### PR TITLE
jyou band: pairs and banks raw data, decodes nothing yet

### DIFF
--- a/lib/ble/adapters/_registry.dart
+++ b/lib/ble/adapters/_registry.dart
@@ -63,6 +63,17 @@ const String kOuraCommandChar = '98ed0002-a541-11e4-b6a0-0002a5d5c51b';
 /// event share this one characteristic — there is no separate data pipe.
 const String kOuraNotifyChar = '98ed0003-a541-11e4-b6a0-0002a5d5c51b';
 
+/// A Jyou/Y5-class band's GATT service. No auth, no envelope, no ambiguity
+/// with either rebrand's own service UUID (BFH16, Teclast H30 — a separate,
+/// unbuilt PR), so no scan-time name fallback is needed here.
+const String kJyouService = '000056ff-0000-1000-8000-00805f9b34fb';
+
+/// Host to band, write-with-response. Fixed 10-byte command frames.
+const String kJyouControlChar = '000033f3-0000-1000-8000-00805f9b34fb';
+
+/// Band to host. Variable-length frames tagged by their first byte.
+const String kJyouMeasureChar = '000033f4-0000-1000-8000-00805f9b34fb';
+
 /// What a stored timestamp actually IS for a given band.
 ///
 /// The distinction is load-bearing and it is not cosmetic. A WHOOP record
@@ -438,12 +449,33 @@ const BandEntry kOura = BandEntry.notify(
   timeAnchor: TimeAnchor.arrival,
 );
 
+/// A Jyou/Y5-class band: fixed 10-byte write commands, tag-byte notify
+/// frames, no auth and no envelope. One product family of three that share
+/// this opcode/checksum scheme over different GATT service sets — this entry
+/// is the base Y5 device ONLY; the BFH16 and Teclast H30 rebrands each layer
+/// their own service UUIDs on top and are a separate, unbuilt PR.
+///
+/// EXPERIMENTAL and it stays that way: nobody on this project owns one, so
+/// not a byte of this path has met hardware (ASSUMPTIONS R6). Every decoded
+/// field — HR, steps, blood pressure, SpO2 — is a proprietary on-device
+/// estimate with no accuracy spec behind it, so `kDerivableSources` stays
+/// empty. See `jyou.dart`.
+const BandEntry kJyou = BandEntry.notify(
+  id: 'jyou',
+  label: 'Jyou Band',
+  service: kJyouService,
+  characteristics: <String>[kJyouControlChar, kJyouMeasureChar],
+  // No frame carries the band's own clock; every chunk is stamped on arrival.
+  timeAnchor: TimeAnchor.arrival,
+);
+
 /// Every band this build can see. Order is match order during discovery.
 const List<BandEntry> kBandRegistry = <BandEntry>[
   kWhoopGen4,
   kWhoopGen5,
   kBleHrs,
   kOura,
+  kJyou,
 ];
 
 /// The bands the OFFLOAD ENGINE can drive, and the bands iOS provisions
@@ -500,6 +532,7 @@ const Map<String, Map<InputSignal, Duration>> kAdapterSignals =
     InputSignal.rrIntervals: Duration(seconds: 1),
   },
   'oura': <InputSignal, Duration>{},
+  'jyou': <InputSignal, Duration>{},
 };
 
 /// The signals one adapter declares, or empty for an id this build has no

--- a/lib/ble/adapters/jyou.dart
+++ b/lib/ble/adapters/jyou.dart
@@ -1,0 +1,77 @@
+// A Jyou/Y5-class band as a [BandAdapter]: subscribe, archive every frame,
+// surface only battery and firmware as [BandNote]s. Nothing else.
+//
+// NO AUTH, NO HANDSHAKE. Every write is a fixed 10-byte command (one opcode
+// byte, two big-endian int32 argument slots, one additive checksum byte) and
+// every notification is a variable-length frame tagged by its first byte —
+// there is no session state on the wire at all, which is why [run] never
+// writes anything and just listens.
+//
+// EVERY DECODED FIELD IS AN ON-DEVICE ESTIMATE WITH NO PPG/ACCEL GROUND TRUTH
+// BEHIND IT, and nobody on this project owns one (ASSUMPTIONS R6). Heart
+// rate, steps, blood pressure and SpO2 are all readable at fixed offsets —
+// and all deliberately left undecoded into a [NeutralSample]: a
+// declared-but-absent signal is worse than a missing one (see
+// [BandAdapter.signals]), so nothing is claimed here until a decoder exists
+// and a real capture has met it. Battery and firmware are device housekeeping,
+// not physiology, which is why they cross as notes the same way Oura's
+// `battery`/`battery_mv` do.
+
+import 'dart:typed_data';
+
+import '_registry.dart';
+import 'adapter.dart';
+import 'signals.dart';
+
+/// Notify-frame tags this adapter recognises. Everything else still lands in
+/// `raw` — an unrecognised tag is not an error, just nothing to name here.
+const int _kTagDeviceInfo = 0xF6;
+const int _kTagBattery = 0xF7;
+
+/// The adapter. Const, and it holds no session state.
+class JyouAdapter extends BandAdapter {
+  const JyouAdapter();
+
+  @override
+  BandEntry get entry => kJyou;
+
+  /// Empty on purpose (the hard invariant). HR, steps, blood pressure and
+  /// SpO2 are all readable off the wire and none of them is claimed — see
+  /// this file's own header.
+  @override
+  Map<InputSignal, Duration> get signals => const {};
+
+  @override
+  Stream<BandEvent> run(BandLink link) async* {
+    // No clock-sync write, no command channel touched at all: the device
+    // streams device info, battery, steps and HR on its own the moment
+    // something is subscribed, and the housekeeping write is not worth the
+    // extra diff for a band nobody has met.
+    await for (final (_, value) in link.notify(kJyouMeasureChar)) {
+      final bytes = Uint8List.fromList(value);
+      if (bytes.isEmpty) continue;
+      switch (bytes[0]) {
+        case _kTagBattery:
+          if (bytes.length > 8) yield BandNote('battery', bytes[8]);
+        case _kTagDeviceInfo:
+          if (bytes.length > 7) {
+            final ver = bytes[4];
+            yield BandNote(
+              'firmware',
+              '${ver ~/ 100}.${(ver % 100) ~/ 10}.${ver % 100 % 10}',
+            );
+          }
+      }
+      // EVERY frame is archived, known tag or not — including the two just
+      // read above, and every HR/steps/BP/SpO2 frame this band ever sends.
+      // The bytes are banked now so a decoder written when someone owns one
+      // can run over them, instead of a guess running over them today.
+      yield SampleBatch(const [], raw: [bytes], ephemeral: false);
+    }
+    // No OffloadCheckpoint: nothing here trims a flash on our ACK, the device
+    // just streams live.
+  }
+}
+
+/// The single instance. Const, so it costs nothing to reference.
+const JyouAdapter kJyouAdapter = JyouAdapter();

--- a/lib/ble/jyou_link.dart
+++ b/lib/ble/jyou_link.dart
@@ -67,20 +67,23 @@ class JyouLink {
   }
 
   Future<bool> _sync() async {
-    final row = await pairedRow();
-    if (row == null) return false;
-    final deviceId = row['id'] as String?;
-    final remoteId = row['remote_id'] as String?;
-    if (deviceId == null || remoteId == null || remoteId.isEmpty) return false;
-    if (deviceId == LocalDb.kPrimaryDeviceId) {
-      // The primary band's id, permanently. This band writing under it would
-      // interleave its (undecoded, sample-less) rows with the band's own.
-      debugPrint('[jyou] refusing to sync: the row claims the primary '
-          'device id — re-pair it with a minted id.');
-      return false;
-    }
-
     try {
+      final row = await pairedRow();
+      if (row == null) return false;
+      final deviceId = row['id'] as String?;
+      final remoteId = row['remote_id'] as String?;
+      if (deviceId == null || remoteId == null || remoteId.isEmpty) {
+        return false;
+      }
+      if (deviceId == LocalDb.kPrimaryDeviceId) {
+        // The primary band's id, permanently. This band writing under it
+        // would interleave its (undecoded, sample-less) rows with the
+        // band's own.
+        debugPrint('[jyou] refusing to sync: the row claims the primary '
+            'device id — re-pair it with a minted id.');
+        return false;
+      }
+
       // A cap on concurrent SECONDARY links (never the primary band's own
       // connect — see ble_state.dart's kMaxConcurrentSecondaryLinks doc).
       return await withSecondaryLinkSlot(() async {

--- a/lib/ble/jyou_link.dart
+++ b/lib/ble/jyou_link.dart
@@ -80,6 +80,11 @@ class JyouLink {
   /// signal.
   static const Duration _listenWindow = Duration(seconds: 20);
 
+  /// Bounds `discoverServices()` — an unbound wait there would hold the
+  /// secondary-link slot (and `_busy`) forever if the BLE stack wedges.
+  /// Same bound `ble_engine.dart` uses for the primary band's own connect.
+  static const Duration _serviceDiscoveryTimeout = Duration(seconds: 15);
+
   /// Connect, listen for [_listenWindow], disconnect.
   ///
   /// Returns false when nothing is paired or the connect failed. Never
@@ -116,7 +121,9 @@ class JyouLink {
           final device = BluetoothDevice.fromId(remoteId);
           await device.connect(timeout: const Duration(seconds: 20));
           try {
-            final services = await device.discoverServices();
+            final services = await device
+                .discoverServices()
+                .timeout(_serviceDiscoveryTimeout);
             final link = GattBandLink(
               entry: kJyou,
               services: services,

--- a/lib/ble/jyou_link.dart
+++ b/lib/ble/jyou_link.dart
@@ -14,15 +14,40 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter/foundation.dart'
+    show debugPrint, visibleForTesting;
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
 import '../data/db.dart';
+import '../data/models.dart' show ArchiveRecord;
 import 'adapters/_registry.dart';
+import 'adapters/adapter.dart' show ReplayBandLink;
 import 'adapters/gatt_link.dart';
 import 'adapters/host.dart' show BandHost;
 import 'adapters/jyou.dart';
 import 'ble_state.dart' show withSecondaryLinkSlot;
+
+String _hex(List<int> b) =>
+    b.map((x) => x.toRadixString(16).padLeft(2, '0')).join();
+
+/// Bank one frame verbatim, decoded or not — nothing here owns a decoder for
+/// this band (see jyou.dart's own header), so the tag byte is all there is
+/// to name it by.
+ArchiveRecord? _buildArchiveRow(List<int> bytes, int capturedAtMs) {
+  if (bytes.isEmpty) return null;
+  return ArchiveRecord(
+    hex: _hex(bytes),
+    // NULL, not 0: no flash-record counter on this band (it only streams
+    // live) — see ArchiveRecord.counter's own doc on why 0 is not the same
+    // as absent for `thinRawArchiveBefore`.
+    counter: null,
+    packetType: bytes[0],
+    // NULL: nothing on the wire carries a record time for this band.
+    recTs: null,
+    capturedAt: capturedAtMs,
+    reason: 'jyou_evt_0x${bytes[0].toRadixString(16).padLeft(2, '0')}',
+  );
+}
 
 /// The live link to a paired Jyou band. One instance; a second concurrent
 /// band of this family is not a thing anyone asked for.
@@ -111,6 +136,7 @@ class JyouLink {
               deviceId: deviceId,
               onLog: (m) => debugPrint('[jyou] $m'),
               onNote: _handleNote,
+              buildArchive: _buildArchiveRow,
             );
             _host = host;
             final done = host.run(link);
@@ -155,5 +181,22 @@ class JyouLink {
     _link = null;
     await _host?.stop();
     _host = null;
+  }
+
+  /// The SAME `BandHost` wiring `_sync` uses, over a [ReplayBandLink] instead
+  /// of a real peripheral — `flutter_blue_plus` has no simulator path (see
+  /// `OuraLink.ingestForTest`). Proves the host is wired to actually bank a
+  /// frame, not just that the adapter yields one.
+  @visibleForTesting
+  (BandHost, ReplayBandLink) hostForTest(String deviceId) {
+    final link = ReplayBandLink();
+    final host = BandHost(
+      adapter: const JyouAdapter(),
+      deviceId: deviceId,
+      onNote: _handleNote,
+      buildArchive: _buildArchiveRow,
+    );
+    _host = host;
+    return (host, link);
   }
 }

--- a/lib/ble/jyou_link.dart
+++ b/lib/ble/jyou_link.dart
@@ -90,39 +90,42 @@ class JyouLink {
         try {
           final device = BluetoothDevice.fromId(remoteId);
           await device.connect(timeout: const Duration(seconds: 20));
-          final services = await device.discoverServices();
-          final link = GattBandLink(
-            entry: kJyou,
-            services: services,
-            onLog: (m) => debugPrint('[jyou] $m'),
-          );
-          _link = link;
-          final missing =
-              link.missingCharacteristics(kJyou.requiredCharacteristics);
-          if (missing.isNotEmpty) {
-            debugPrint('[jyou] ${kJyou.label}: missing required '
-                'characteristic(s) '
-                '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
-            await device.disconnect().catchError((_) {});
-            return false;
-          }
-          final host = BandHost(
-            adapter: const JyouAdapter(),
-            deviceId: deviceId,
-            onLog: (m) => debugPrint('[jyou] $m'),
-            onNote: _handleNote,
-          );
-          _host = host;
-          final done = host.run(link);
           try {
-            await done.timeout(_listenWindow, onTimeout: () {});
-          } finally {
-            await stop();
+            final services = await device.discoverServices();
+            final link = GattBandLink(
+              entry: kJyou,
+              services: services,
+              onLog: (m) => debugPrint('[jyou] $m'),
+            );
+            _link = link;
+            final missing =
+                link.missingCharacteristics(kJyou.requiredCharacteristics);
+            if (missing.isNotEmpty) {
+              debugPrint('[jyou] ${kJyou.label}: missing required '
+                  'characteristic(s) '
+                  '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
+              return false;
+            }
+            final host = BandHost(
+              adapter: const JyouAdapter(),
+              deviceId: deviceId,
+              onLog: (m) => debugPrint('[jyou] $m'),
+              onNote: _handleNote,
+            );
+            _host = host;
+            final done = host.run(link);
             try {
-              await device.disconnect();
-            } catch (_) {/* already gone */}
+              await done.timeout(_listenWindow, onTimeout: () {});
+            } finally {
+              await stop();
+            }
+            return true;
+          } finally {
+            // Covers every post-connect failure (discoverServices, missing
+            // characteristics, host.run) as well as the success path — one
+            // teardown site instead of one per branch.
+            await device.disconnect().catchError((_) {});
           }
-          return true;
         } catch (e) {
           debugPrint('[jyou] connect failed: $e');
           return false;

--- a/lib/ble/jyou_link.dart
+++ b/lib/ble/jyou_link.dart
@@ -1,0 +1,153 @@
+// The HOST for a paired Jyou/Y5-class band: connect to its stored remote id,
+// drive [JyouAdapter] over the link, bank what comes back, disconnect.
+//
+// NOTHING HERE HAS MET HARDWARE (ASSUMPTIONS R6). The registry entry stays
+// EXPERIMENTAL, `JyouAdapter.signals` stays `const {}`, and nothing this file
+// writes becomes a number — every row it commits carries a non-null `source`.
+//
+// THIN COUSIN OF `oura_link.dart`, MINUS THE AUTH/CURSOR MACHINERY. There is
+// no pairing key, no drain cursor and no time anchor to hold: the band has no
+// auth, offloads nothing (it just streams live), and every frame is stamped
+// on arrival. So this is a one-shot [JyouLink.sync] — connect, listen for
+// whatever the band sends on its own over one flush window, tear down —
+// with none of the state [OuraLink] persists between sessions.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+import '../data/db.dart';
+import 'adapters/_registry.dart';
+import 'adapters/gatt_link.dart';
+import 'adapters/host.dart' show BandHost;
+import 'adapters/jyou.dart';
+import 'ble_state.dart' show withSecondaryLinkSlot;
+
+/// The live link to a paired Jyou band. One instance; a second concurrent
+/// band of this family is not a thing anyone asked for.
+class JyouLink {
+  JyouLink._();
+  static final JyouLink instance = JyouLink._();
+
+  /// The `device` row for the paired band, or null.
+  static Future<Map<String, Object?>?> pairedRow() async {
+    for (final r in await LocalDb.deviceRows()) {
+      if (r['adapter_id'] == kJyou.id) return r;
+    }
+    return null;
+  }
+
+  /// The most recent battery/firmware note the band reported, or null.
+  int? get batteryPct => _batteryPct;
+  String? get firmware => _firmware;
+  int? _batteryPct;
+  String? _firmware;
+
+  GattBandLink? _link;
+  BandHost? _host;
+  bool _busy = false;
+
+  /// How long one sync session listens before tearing down. There is no
+  /// drain to finish and no cursor to exhaust — the band just streams
+  /// whatever it has (device info/battery on connect, steps/HR as its own
+  /// sensor produces one) — so this is a plain window, not a completion
+  /// signal.
+  static const Duration _listenWindow = Duration(seconds: 20);
+
+  /// Connect, listen for [_listenWindow], disconnect.
+  ///
+  /// Returns false when nothing is paired or the connect failed. Never
+  /// throws. SERIALISED: a second call while one is in flight is a no-op
+  /// rather than a second radio session over the same peripheral.
+  Future<bool> sync() {
+    if (_busy) return Future.value(false);
+    _busy = true;
+    return _sync().whenComplete(() => _busy = false);
+  }
+
+  Future<bool> _sync() async {
+    final row = await pairedRow();
+    if (row == null) return false;
+    final deviceId = row['id'] as String?;
+    final remoteId = row['remote_id'] as String?;
+    if (deviceId == null || remoteId == null || remoteId.isEmpty) return false;
+    if (deviceId == LocalDb.kPrimaryDeviceId) {
+      // The primary band's id, permanently. This band writing under it would
+      // interleave its (undecoded, sample-less) rows with the band's own.
+      debugPrint('[jyou] refusing to sync: the row claims the primary '
+          'device id — re-pair it with a minted id.');
+      return false;
+    }
+
+    try {
+      // A cap on concurrent SECONDARY links (never the primary band's own
+      // connect — see ble_state.dart's kMaxConcurrentSecondaryLinks doc).
+      return await withSecondaryLinkSlot(() async {
+        try {
+          final device = BluetoothDevice.fromId(remoteId);
+          await device.connect(timeout: const Duration(seconds: 20));
+          final services = await device.discoverServices();
+          final link = GattBandLink(
+            entry: kJyou,
+            services: services,
+            onLog: (m) => debugPrint('[jyou] $m'),
+          );
+          _link = link;
+          final missing =
+              link.missingCharacteristics(kJyou.requiredCharacteristics);
+          if (missing.isNotEmpty) {
+            debugPrint('[jyou] ${kJyou.label}: missing required '
+                'characteristic(s) '
+                '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
+            await device.disconnect().catchError((_) {});
+            return false;
+          }
+          final host = BandHost(
+            adapter: const JyouAdapter(),
+            deviceId: deviceId,
+            onLog: (m) => debugPrint('[jyou] $m'),
+            onNote: _handleNote,
+          );
+          _host = host;
+          final done = host.run(link);
+          try {
+            await done.timeout(_listenWindow, onTimeout: () {});
+          } finally {
+            await stop();
+            try {
+              await device.disconnect();
+            } catch (_) {/* already gone */}
+          }
+          return true;
+        } catch (e) {
+          debugPrint('[jyou] connect failed: $e');
+          return false;
+        }
+      });
+    } catch (e) {
+      debugPrint('[jyou] sync failed: $e');
+      return false;
+    }
+  }
+
+  void _handleNote(String key, Object? value) {
+    switch (key) {
+      case 'battery':
+        if (value is int) _batteryPct = value;
+      case 'firmware':
+        if (value is String) _firmware = value;
+      default:
+        debugPrint('[jyou] $key = $value');
+    }
+  }
+
+  /// Drop the link, flush what has been buffered. Safe when nothing is
+  /// connected.
+  Future<void> stop() async {
+    _link?.close();
+    _link = null;
+    await _host?.stop();
+    _host = null;
+  }
+}

--- a/lib/sync/background_sync.dart
+++ b/lib/sync/background_sync.dart
@@ -21,6 +21,7 @@ import '../ble/adapters/_registry.dart' show kWhoopGen4;
 import '../ble/adapters/host.dart' show BandHost;
 import '../ble/adapters/whoop_gen4.dart' show WhoopFramedAdapter;
 import '../ble/ble_engine.dart';
+import '../ble/jyou_link.dart';
 import '../ble/oura_link.dart';
 import '../compute/derivation_engine.dart';
 import '../compute/profile.dart';
@@ -223,6 +224,14 @@ Future<bool> runHeadlessSync({BandLease? lease}) async {
       await OuraLink.instance.sync();
     } catch (e) {
       debugPrint('[bgsync] oura sync skipped: $e');
+    }
+    // Same piggyback, same reasoning: JyouLink.sync() already no-ops when
+    // nothing is paired and never throws, but a failure here still must not
+    // escape and mark the WHOOP cycle as errored.
+    try {
+      await JyouLink.instance.sync();
+    } catch (e) {
+      debugPrint('[bgsync] jyou sync skipped: $e');
     }
   }
 }

--- a/lib/ui2/pairing/device_picker.dart
+++ b/lib/ui2/pairing/device_picker.dart
@@ -270,6 +270,10 @@ class _DevicePickerScreenState extends State<DevicePickerScreen> {
           'The strap this app is built around. WHOOP 4 or 5.',
       'oura' => l?.devicePickerBlurbRing ??
           'Reads the ring directly — no Oura account or subscription.',
+      // No localized key: this falls through to English only, the same
+      // reason `asteroidos`'s own row (a different, unbuilt PR) does.
+      'jyou' => 'A budget activity band. Pairs and banks its raw data, but '
+          'nothing is derived from it yet.',
       _ => l?.devicePickerBlurbSensor ??
           'A chest strap or armband, for beat timing during a workout.',
     };

--- a/lib/ui2/profile/devices.dart
+++ b/lib/ui2/profile/devices.dart
@@ -774,6 +774,7 @@ class HealthSource {
 /// the only place a user can tell two paired sensors apart at a glance.
 IconData sensorIcon(String? adapterId) => switch (adapterId) {
       'oura' => LucideIcons.circleDot,
+      'jyou' => LucideIcons.watch,
       _ => LucideIcons.heartPulse,
     };
 

--- a/lib/ui2/profile/devices.dart
+++ b/lib/ui2/profile/devices.dart
@@ -43,9 +43,10 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
 
 import '../../ble/adapters/_registry.dart'
-    show BandEntry, kBandRegistry, kBleHrs, kOura, declaredSignals;
+    show BandEntry, kBandRegistry, kBleHrs, kJyou, kOura, declaredSignals;
 import '../../ble/adapters/signals.dart' show InputSignal;
 import '../../ble/hrs_link.dart' show HrsLink, HrsReading;
+import '../../ble/jyou_link.dart' show JyouLink;
 import '../../ble/oura_link.dart' show OuraLink, pairOuraRing;
 import '../../ble/band_status_l10n.dart' show localizedBandStatus;
 import '../../ble/ble_state.dart' show BandStatus, kMaxConcurrentSecondaryLinks;
@@ -951,6 +952,15 @@ final List<({BandEntry entry, String blurb, Future<String?> Function(BluetoothDe
         'unpair the ring), then close that app before pairing here.',
     pick: pairOuraRing,
   ),
+  (
+    entry: kJyou,
+    blurb: 'Pairs and banks its raw data, but does not derive anything from '
+        'it yet — nobody on this project owns one to verify its numbers '
+        'against.',
+    // Null means the plain notify-class pairing, same as the heart-rate
+    // sensor above.
+    pick: null,
+  ),
 ];
 
 /// Choose which kind of sensor to pair, then hand off to the pairing screen.
@@ -1475,7 +1485,11 @@ class _DeviceDetailState extends State<DeviceDetail> {
       // primary band's link, its restore identity and its trim cursor, none of
       // which a sensor has — pointing this at it would have unpaired the
       // WHOOP from a chest strap's page.
-      onSync: s.family == 'oura' ? () => _syncRing(c) : null,
+      onSync: s.family == 'oura'
+          ? () => _syncRing(c)
+          : s.family == 'jyou'
+              ? () => _syncJyou(c)
+              : null,
       onForget: s.deviceId != null
           ? () => _confirmForgetSensor(c, s)
           : app == null
@@ -1501,6 +1515,21 @@ Future<void> _syncRing(BuildContext c) async {
         : (l?.devicesCouldNotReachRing ??
             'Could not reach the ring. It has to be nearby, and not connected '
                 'to another app.')),
+  ));
+}
+
+/// Pull whatever a Jyou band has streamed since the last connect, now,
+/// because the user asked. Same shape as [_syncRing] one function up.
+Future<void> _syncJyou(BuildContext c) async {
+  final messenger = ScaffoldMessenger.maybeOf(c);
+  messenger?.showSnackBar(const SnackBar(content: Text('Syncing…')));
+  final ok = await JyouLink.instance.sync();
+  if (!c.mounted) return;
+  messenger?.showSnackBar(SnackBar(
+    content: Text(ok
+        ? 'Synced.'
+        : 'Could not reach the band. It has to be nearby, and not connected '
+            'to another app.'),
   ));
 }
 

--- a/test/adapter_signals_registry_test.dart
+++ b/test/adapter_signals_registry_test.dart
@@ -12,6 +12,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openstrap_edge/ble/adapters/_registry.dart';
 import 'package:openstrap_edge/ble/adapters/ble_hrs.dart';
+import 'package:openstrap_edge/ble/adapters/jyou.dart';
 import 'package:openstrap_edge/ble/adapters/oura.dart';
 import 'package:openstrap_edge/ble/adapters/signals.dart';
 import 'package:openstrap_edge/ble/adapters/whoop_gen4.dart';
@@ -25,6 +26,7 @@ void main() {
       'gen5': kWhoopGen4Signals,
       'ble_hrs': const BleHrsAdapter().signals,
       'oura': OuraAdapter(key: const [0]).signals,
+      'jyou': const JyouAdapter().signals,
     };
 
     // Every registry id is covered above: a NEW adapter must extend this test,

--- a/test/adapters/jyou_test.dart
+++ b/test/adapters/jyou_test.dart
@@ -1,0 +1,93 @@
+// The mandatory adapter test (MULTIBAND_PLAN §3.3.3), Jyou's shape: no
+// signal is declared, so the only thing to prove is that battery/firmware
+// reach the host as notes and every other frame — including a decodable-
+// looking HR one — comes back as raw bytes and nothing else.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ble/adapters/_registry.dart';
+import 'package:openstrap_edge/ble/adapters/adapter.dart';
+import 'package:openstrap_edge/ble/adapters/jyou.dart';
+
+/// Battery frame: tag 0xF7, level 77 at byte 8.
+final Uint8List kBatteryFrame =
+    Uint8List.fromList([0xF7, 0, 0, 0, 0, 0, 0, 0, 77]);
+
+/// Device-info frame: tag 0xF6, firmware byte 0x8F (143 -> "1.4.3") at byte 4.
+final Uint8List kDeviceInfoFrame =
+    Uint8List.fromList([0xF6, 0, 0, 0, 143, 0, 0, 0]);
+
+/// Heart-rate frame: tag 0xFC, bpm 68 at byte 8 — decodable by spec, but this
+/// adapter must never turn it into a [NeutralSample].
+final Uint8List kHrFrame =
+    Uint8List.fromList([0xFC, 0, 0, 0, 0, 0, 0, 0, 68]);
+
+Future<List<BandEvent>> replay(List<(int, Uint8List)> arrivals) async {
+  final link = ReplayBandLink();
+  final events = <BandEvent>[];
+  final done = Completer<void>();
+  final sub =
+      kJyouAdapter.run(link).listen(events.add, onDone: done.complete);
+  for (final (sec, value) in arrivals) {
+    link.feed(kJyouMeasureChar, value, atSec: sec);
+  }
+  await link.close();
+  await done.future;
+  await sub.cancel();
+  return events;
+}
+
+void main() {
+  test('declares no signals — no card may ever key off this adapter', () {
+    expect(kJyouAdapter.signals, isEmpty);
+    expect(kJyouAdapter.entry.isFramed, isFalse);
+  });
+
+  test('battery and firmware reach the host as notes', () async {
+    final events = await replay([
+      (1_800_000_000, kBatteryFrame),
+      (1_800_000_001, kDeviceInfoFrame),
+    ]);
+    final notes = events.whereType<BandNote>().toList();
+    expect(notes.any((n) => n.key == 'battery' && n.value == 77), isTrue);
+    expect(
+      notes.any((n) => n.key == 'firmware' && n.value == '1.4.3'),
+      isTrue,
+    );
+  });
+
+  test('a heart-rate frame never becomes a NeutralSample, only raw bytes',
+      () async {
+    final events = await replay([(1_800_000_000, kHrFrame)]);
+    final batches = events.whereType<SampleBatch>().toList();
+    expect(batches, hasLength(1));
+    expect(batches.single.samples, isEmpty);
+    expect(batches.single.ephemeral, isFalse);
+    expect(batches.single.raw!.single, kHrFrame);
+  });
+
+  test('every frame is archived, known tag or not', () async {
+    final events = await replay([
+      (1_800_000_000, kBatteryFrame),
+      (1_800_000_001, kDeviceInfoFrame),
+      (1_800_000_002, kHrFrame),
+    ]);
+    expect(events.whereType<SampleBatch>(), hasLength(3));
+  });
+
+  test('never writes to the peripheral', () async {
+    final link = ReplayBandLink();
+    final sub = kJyouAdapter.run(link).listen((_) {});
+    link.feed(kJyouMeasureChar, kBatteryFrame, atSec: 1_800_000_000);
+    await link.close();
+    await sub.cancel();
+    expect(link.writes, isEmpty);
+  });
+
+  test('no flash storage, never emits an OffloadCheckpoint', () async {
+    final events = await replay([(1_800_000_000, kBatteryFrame)]);
+    expect(events.whereType<OffloadCheckpoint>(), isEmpty);
+  });
+}

--- a/test/band_registry_test.dart
+++ b/test/band_registry_test.dart
@@ -10,7 +10,7 @@ import 'package:openstrap_protocol/openstrap_protocol.dart';
 void main() {
   test('ids are unique and stable — they are stamped as device_family', () {
     expect(kBandRegistry.map((e) => e.id).toList(),
-        <String>['gen4', 'gen5', 'ble_hrs', 'oura']);
+        <String>['gen4', 'gen5', 'ble_hrs', 'oura', 'jyou']);
   });
 
   test('D1 — the scan service list is exactly the two WHOOP services', () {

--- a/test/jyou_link_test.dart
+++ b/test/jyou_link_test.dart
@@ -1,0 +1,46 @@
+// Proves `JyouLink` actually wires its `BandHost` with a `buildArchive`
+// callback — the adapter yielding `raw` bytes is not enough on its own (see
+// `BandHost._bufferArchive`, which silently drops every frame when the host
+// was built with no `buildArchive`).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:openstrap_edge/ble/adapters/_registry.dart';
+import 'package:openstrap_edge/ble/jyou_link.dart';
+import 'package:openstrap_edge/data/db.dart';
+
+void main() {
+  const deviceId = 'jyou-a1b2c3d4';
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    await LocalDb.close();
+    LocalDb.dbName = 'jyou_link_test.db';
+    final dir = await databaseFactory.getDatabasesPath();
+    await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+  });
+
+  tearDown(() async => LocalDb.close());
+
+  test('a frame the adapter yields actually lands in raw_archive', () async {
+    final (host, link) = JyouLink.instance.hostForTest(deviceId);
+    final done = host.run(link);
+    link.feed(kJyouMeasureChar, [0xFC, 0, 0, 0, 0, 0, 0, 0, 68],
+        atSec: 1_800_000_000);
+    await link.close();
+    await done;
+    await host.stop();
+
+    final db = await LocalDb.instance;
+    final archive = await db.query('raw_archive');
+    expect(archive, hasLength(1));
+    expect(archive.single['device_id'], deviceId);
+    expect(archive.single['hex'], 'fc0000000000000044');
+    expect(archive.single['reason'], 'jyou_evt_0xfc');
+  });
+}


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
adds the jyou/y5-class activity band as a pairable sensor. no auth, no envelope — fixed 10-byte checksummed writes and tag-byte notify frames. this adapter never writes anything, it just subscribes and archives every frame.

battery and firmware cross as notes for the device row. hr, steps, blood pressure and spo2 are all readable at documented offsets but stay undecoded — nobody here owns one, so `signals` is empty and kDerivableSources stays untouched. bfh16 and teclast h30 rebrands share the opcode scheme but use different service uuids, not covered here.

edge-only, no protocol repo change needed.

## Summary by Sourcery

Integrate the Jyou/Y5 band as an experimental raw-data sensor throughout BLE synchronization, pairing, and device management.

New Features:
- Add the Jyou/Y5 activity band as a pairable BLE sensor with manual and background synchronization.
- Archive all received Jyou frames as raw data while exposing battery level and firmware information as device notes.

Enhancements:
- Keep physiological measurements undecoded and declare no derived signals until the protocol is validated against hardware.
- Add Jyou pairing presentation, device management, and watch-style UI treatment.

Tests:
- Add coverage for Jyou signal registration, raw frame archiving, housekeeping notes, write-free operation, and link-to-database integration.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds Jyou/Y5 band as pairable sensor.

- Archives received frames as raw data.
  - Leaves physiological metrics undecoded.
  - Extracts battery and firmware notes.

- Integrates Jyou into headless background sync.
  - Note: Modifies BLE sync ordering.

- Adds manual sync and UI pairing options.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Device Picker"] -- "Pairs" --> B["JyouLink"]
  B -- "Drives" --> C["JyouAdapter"]
  C -- "Yields" --> D["Raw SampleBatch"]
  C -- "Yields" --> E["Battery/Firmware Notes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>_registry.dart</strong><dd><code>Registers Jyou GATT characteristics and empty signal map</code>&nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/339/files#diff-92b3191852de079fb927a9209ad2e16cf950e8e551e0f515f8636e9e350edf4e">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>jyou.dart</strong><dd><code>Implements JyouAdapter for raw archiving and note extraction</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/339/files#diff-66673cc1a0e222b235e9b8464d5eef39bfed871a3f9f8a5c1569bf12b04a6f3d">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>jyou_link.dart</strong><dd><code>Implements JyouLink for BLE connection and sync lifecycle</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/339/files#diff-ba3c05074d5db42a4d4c8fe35fa50ddb4f74799b5a7edf79213b14a7aba95109">+153/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>background_sync.dart</strong><dd><code>Adds Jyou sync to headless background sync sequence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/339/files#diff-16ac57f05bd5fda34d2e44e6b163a9053f857df64e384dd6b6ec95170d07dab9">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>device_picker.dart</strong><dd><code>Adds descriptive blurb for Jyou band in pairing UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/339/files#diff-01936f44e43baa4ed6113e6563a795495635194121c55976c87886c57f817ca1">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>devices.dart</strong><dd><code>Wires up Jyou pairing, icon, and manual sync action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/339/files#diff-e553e52550bda8f7988f04ec5fd49d57c5a36d0e774dca61d62022e97a83fcb8">+32/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>adapter_signals_registry_test.dart</strong><dd><code>Updates registry tests to include Jyou adapter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/339/files#diff-80fe91cb852297598cbec5fcee4d56986b78d77a5309cbcdfa31c8d3b71d900f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>jyou_test.dart</strong><dd><code>Adds tests verifying Jyou adapter behavior and raw archiving</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/339/files#diff-a17aae7b9e05347611291a18a42797805caa5a1be104bdd07b48541ee3346d3b">+93/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>band_registry_test.dart</strong><dd><code>Updates expected band IDs list with Jyou</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/339/files#diff-b1854a3fec47918fa17fbaa1b684889d846d730af0ec21f7cf649df08fb45bb3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for pairing and syncing Jyou/Y5-class activity bands.
  - Displays Jyou devices with a watch icon and provides synchronization status feedback.
  - Retrieves battery and firmware information during synchronization.
  - Includes Jyou synchronization in background sync cycles.
  - Stores raw band data for future analysis; activity signals are not currently derived.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->