### PR TITLE
hplus generic hr band, pairs-only

### DIFF
--- a/lib/ble/adapters/_registry.dart
+++ b/lib/ble/adapters/_registry.dart
@@ -63,6 +63,18 @@ const String kOuraCommandChar = '98ed0002-a541-11e4-b6a0-0002a5d5c51b';
 /// event share this one characteristic — there is no separate data pipe.
 const String kOuraNotifyChar = '98ed0003-a541-11e4-b6a0-0002a5d5c51b';
 
+/// The HPlus reference GATT service — one service shared across a whole
+/// family of low-cost wrist bands, not one product.
+const String kHPlusService = '14701820-620a-3973-7c78-9cfff0876abd';
+
+/// Host to band. Every HPlus command is written here, plaintext, no
+/// response required by the device.
+const String kHPlusControlChar = '14702856-620a-3973-7c78-9cfff0876abd';
+
+/// Band to host. Every notification — realtime stats, firmware version,
+/// sleep and day-summary records — shares this one characteristic.
+const String kHPlusMeasureChar = '14702853-620a-3973-7c78-9cfff0876abd';
+
 /// What a stored timestamp actually IS for a given band.
 ///
 /// The distinction is load-bearing and it is not cosmetic. A WHOOP record
@@ -438,12 +450,36 @@ const BandEntry kOura = BandEntry.notify(
   timeAnchor: TimeAnchor.arrival,
 );
 
+/// The HPlus reference profile — HPlus itself and every OEM re-skin sharing
+/// its firmware (same service, same two characteristics, same command byte).
+///
+/// Plaintext vendor command channel: no bonding, no encryption, no key
+/// material anywhere in the protocol. Unlike every other notify-only entry
+/// above, this band does not answer at all until a short init sequence has
+/// been written to it; see `hplus.dart` for what that sequence is and the one
+/// thing about it nobody has confirmed.
+///
+/// EXPERIMENTAL and it stays that way: nobody on this project owns one, so not
+/// a byte of this path has met hardware (ASSUMPTIONS R6). It pairs, connects,
+/// and banks every reply raw; `kDerivableSources` stays empty until someone
+/// has actually held one.
+const BandEntry kHPlus = BandEntry.notify(
+  id: 'hplus',
+  label: 'HPlus HR band',
+  service: kHPlusService,
+  characteristics: <String>[kHPlusControlChar, kHPlusMeasureChar],
+  // No clock in any channel this adapter reads; every frame is stamped on
+  // arrival.
+  timeAnchor: TimeAnchor.arrival,
+);
+
 /// Every band this build can see. Order is match order during discovery.
 const List<BandEntry> kBandRegistry = <BandEntry>[
   kWhoopGen4,
   kWhoopGen5,
   kBleHrs,
   kOura,
+  kHPlus,
 ];
 
 /// The bands the OFFLOAD ENGINE can drive, and the bands iOS provisions
@@ -500,6 +536,7 @@ const Map<String, Map<InputSignal, Duration>> kAdapterSignals =
     InputSignal.rrIntervals: Duration(seconds: 1),
   },
   'oura': <InputSignal, Duration>{},
+  'hplus': <InputSignal, Duration>{},
 };
 
 /// The signals one adapter declares, or empty for an id this build has no

--- a/lib/ble/adapters/hplus.dart
+++ b/lib/ble/adapters/hplus.dart
@@ -1,0 +1,211 @@
+// The HPlus reference GATT profile, as a [BandAdapter]. Not one device — the
+// same service, the same two characteristics and the same command byte sit
+// behind a whole family of low-cost wrist bands (HPlus itself, and the OEM
+// re-skins that share its firmware). One adapter covers all of them.
+//
+// NOTHING HERE HAS MET HARDWARE. Nobody on this project owns one, so every
+// byte below is verified by the compiler and by
+// `test/adapters/hplus_adapter_test.dart` fixtures, never by a real unit. It
+// ships EXPERIMENTAL (ASSUMPTIONS R6): `signals` is `const {}` and
+// `kAdapterSignals` carries no entry for it beyond the empty map, exactly
+// like `kOura`.
+//
+// THE WIRE SHAPE. Plaintext, no bonding, no encryption, no key material
+// anywhere in the protocol — a vendor command channel, not a ratified
+// characteristic. No envelope, no CRC, no sequence counter: a notification is
+// `[tag, ...payload]`, the tag says what kind of record it is, and that is the
+// whole of the framing — a tag-and-payload shape, not the six-characteristic
+// WHOOP profile or Oura's cursor-and-key one.
+//
+// THE INIT SEQUENCE IS WHAT MAKES THIS ADAPTER WORTH WRITING, AND ALSO ITS ONE
+// REAL UNKNOWN. The band does not appear to push realtime stats until it has
+// been configured — enabling notify alone is not documented as sufficient —
+// so this session writes a short, fixed command sequence before it expects to
+// hear anything back. Only the ALLDAY_HRM write is load-bearing for streaming;
+// the others are documented preconditions the reference always sends
+// alongside it. WHETHER THIS MINIMAL SEQUENCE IS ENOUGH, OR WHETHER A GIVEN
+// UNIT ALSO WANTS THE FULLER PREFERENCE BLOCK (date/time/gender/age/weight/
+// height/goal/units/language/screentime) FIRST, IS NOT KNOWN. It costs nothing
+// to send and is data, not a decode risk, so it ships as the first thing to
+// try — a silent, permanently-empty stream from here on is the visible failure
+// mode if a unit turns out to need more, not a crash and not a wrong number.
+//
+// HARD INVARIANT COMPLIANCE. The realtime-stats record (tag 0x33) carries
+// steps, distance, calories, battery, heart rate and active-time at fixed
+// offsets — every field in it is vendor-stated, not hardware-confirmed, so
+// none of it becomes a `NeutralSample`. The one exception is the battery
+// byte: a wrong offset there shows a wrong PERCENTAGE, never a fabricated
+// health metric, which is why it is trusted enough to surface as a
+// [BandNote] the same way `oura.dart` surfaces its own battery and firmware
+// facts. The firmware-version record (tag 0x18 or 0x2e) carries two raw
+// version bytes, not text — decoded into a plain "major.minor" string the
+// same way. Everything else — every field of every record, decoded or not —
+// is archived verbatim by the host and thrown away by nobody.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import '_registry.dart';
+import 'adapter.dart';
+import 'signals.dart';
+
+/// One HPlus-family session. Const: it holds no state of its own — everything
+/// a session needs lives inside [run].
+class HPlusAdapter extends BandAdapter {
+  /// How long to wait for the next notification before ending the session.
+  /// A quiet band this long is either done streaming or was never configured
+  /// correctly — either way there is nothing left to do but let the host tear
+  /// the link down; the outer session (`hplus_link.dart`) also bounds this on
+  /// its own collection window, so this is a second, independent backstop
+  /// rather than the only one.
+  final Duration idleTimeout;
+
+  const HPlusAdapter({this.idleTimeout = const Duration(seconds: 60)});
+
+  @override
+  BandEntry get entry => kHPlus;
+
+  /// NOTHING, and that is the honest answer today rather than a placeholder.
+  /// The realtime-stats layout is vendor-inferred, not ratified — see this
+  /// file's own header — so nothing goes into `NeutralSample.hr` or any other
+  /// field.
+  @override
+  Map<InputSignal, Duration> get signals => const {};
+
+  /// The tag naming a realtime-stats record: tag(1) + steps(u16) +
+  /// distance(u16) + calories(u32) + battery(u8) + a reserved byte + heart
+  /// rate(u8) + active-time(u16), all little-endian. Only [_kBatteryOffset]
+  /// of it is decoded here.
+  static const int kTagRealtime = 0x33;
+
+  /// Both tags carry a firmware version as two raw bytes, minor then major —
+  /// not text — at different offsets each; which one a given unit answers
+  /// with is not documented, so both are decoded the same way.
+  static const int kTagVersionA = 0x18;
+  static const int kTagVersionB = 0x2e;
+
+  /// Offset of the battery byte inside a [kTagRealtime] payload: tag(1) +
+  /// steps(u16) + distance(u16) + calories(u32) lands battery at byte 9.
+  static const int _kBatteryOffset = 9;
+
+  /// The sentinel for "not measured" on the battery byte.
+  static const int _kBatteryUnmeasured = 0xff;
+
+  /// The init sequence, in order. Every write's result is logged; the
+  /// sequence continues regardless of a refusal because there is no
+  /// protocol-level ACK to gate on here, and a refused write shows up
+  /// downstream as a silent, empty session rather than a stuck one.
+  static const List<(String label, List<int> cmd)> kInitSequence = [
+    ('pref_start', <int>[0x4f, 0x5a]),
+    ('pref_start1', <int>[0x4d]),
+    // The only write that is actually load-bearing for streaming.
+    ('allday_hrm_on', <int>[0x35, 0x0a]),
+    ('conf_end', <int>[0x4f]),
+  ];
+
+  @override
+  Stream<BandEvent> run(BandLink link) async* {
+    final inbox = _Inbox();
+    final sub = link.notify(kHPlusMeasureChar).listen(
+          (rec) => inbox.add(Uint8List.fromList(rec.$2)),
+          onDone: inbox.close,
+          onError: (Object _) => inbox.close(),
+        );
+    try {
+      for (final (label, cmd) in kInitSequence) {
+        if (!await link.write(kHPlusControlChar, cmd)) {
+          link.log('hplus: $label write refused.');
+        }
+      }
+      while (true) {
+        final frame = await inbox.next(idleTimeout);
+        if (frame == null) return; // link closed, or nothing for a long time
+        if (frame.isEmpty) continue;
+        switch (frame[0]) {
+          case kTagRealtime:
+            final battery = _decodeBattery(frame);
+            if (battery != null) yield BandNote('battery', battery);
+          case kTagVersionA:
+          case kTagVersionB:
+            final version = _decodeVersion(frame);
+            if (version != null) yield BandNote('firmware', version);
+        }
+        // Every frame archived verbatim, decoded or not — owner rulings
+        // R1-R3: the bytes are banked now so a decoder written when someone
+        // owns a unit can be run over them.
+        yield SampleBatch(const [], raw: [frame]);
+      }
+    } finally {
+      await sub.cancel();
+    }
+    // No OffloadCheckpoint, ever. This wire has no stored history to drain —
+    // every notification is a live reading, not a flash record — so there is
+    // nothing here for the band to be told to forget.
+  }
+
+  int? _decodeBattery(Uint8List frame) {
+    if (frame.length <= _kBatteryOffset) return null;
+    final b = frame[_kBatteryOffset];
+    if (b == _kBatteryUnmeasured || b > 100) return null;
+    return b;
+  }
+
+  /// Two raw bytes, minor then major, at a tag-dependent offset — not text.
+  /// Tag 0x18 is `[tag, minor, major]`; tag 0x2e is `[tag, 8 reserved bytes,
+  /// minor, major]`. Rendered "major.minor", the ordinary reading of two
+  /// version bytes; the reference gives their position, not their meaning.
+  String? _decodeVersion(Uint8List frame) {
+    final int minorAt;
+    switch (frame[0]) {
+      case kTagVersionA:
+        minorAt = 1;
+      case kTagVersionB:
+        minorAt = 9;
+      default:
+        return null;
+    }
+    final majorAt = minorAt + 1;
+    if (frame.length <= majorAt) return null;
+    return '${frame[majorAt]}.${frame[minorAt]}';
+  }
+}
+
+/// The single instance. Const, so it costs nothing to reference.
+const HPlusAdapter kHPlusAdapter = HPlusAdapter();
+
+/// Frames off the notify characteristic, buffered so a reply landing before
+/// anyone is waiting is not dropped. This wire has no request/reply matching
+/// to do, only "the next frame, or nothing".
+class _Inbox {
+  final List<Uint8List> _buf = [];
+  Completer<Uint8List?>? _waiter;
+  bool _closed = false;
+
+  void add(Uint8List v) {
+    final w = _waiter;
+    if (w != null && !w.isCompleted) {
+      _waiter = null;
+      w.complete(v);
+      return;
+    }
+    _buf.add(v);
+  }
+
+  void close() {
+    _closed = true;
+    final w = _waiter;
+    _waiter = null;
+    if (w != null && !w.isCompleted) w.complete(null);
+  }
+
+  Future<Uint8List?> next(Duration timeout) {
+    if (_buf.isNotEmpty) return Future.value(_buf.removeAt(0));
+    if (_closed) return Future.value(null);
+    final w = Completer<Uint8List?>();
+    _waiter = w;
+    return w.future.timeout(timeout, onTimeout: () {
+      if (identical(_waiter, w)) _waiter = null;
+      return null;
+    });
+  }
+}

--- a/lib/ble/hplus_link.dart
+++ b/lib/ble/hplus_link.dart
@@ -1,0 +1,207 @@
+// The HOST for a paired HPlus-family band: connect, run [HPlusAdapter] over
+// the link for one bounded collection window, bank what comes back,
+// disconnect.
+//
+// NOTHING HERE HAS MET HARDWARE (ASSUMPTIONS R6). The registry entry stays
+// EXPERIMENTAL, `HPlusAdapter.signals` stays `const {}`, and nothing this
+// file writes becomes a number: it banks battery and firmware notes plus raw
+// frames only, never a `NeutralSample`.
+//
+// CONNECT-ON-DEMAND, SYNC TRIGGERED EXPLICITLY — the same shape as
+// `oura_link.dart`'s one-shot `sync()`, not `hrs_link.dart`'s workout-armed
+// session: this is a continuously-worn band, not a chest-strap-for-a-workout
+// accessory. But unlike the ring, it has no fetch-by-cursor history to drain
+// either — every notification is a live reading, not a flash record — so
+// there is no cursor and no anchor to persist between connections. A sync
+// connects, gives the band [collectFor] to answer the init sequence and
+// stream, then tears the link down.
+//
+// NO PAIRING KEY, EITHER. Unlike the ring and the Mi Band, this wire has no
+// auth handshake — pairing is the plain notify-class flow
+// `HrsLink.pairNotifySensor` already runs for every unauthenticated sensor —
+// so there is no secret to store, drop, or clean up on forgetting; forgetting
+// this band is the same generic `HrsLink.forgetDevice` every other
+// unauthenticated notify-class sensor already uses.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+import '../data/db.dart';
+import '../data/models.dart' show ArchiveRecord;
+import 'adapters/_registry.dart';
+import 'adapters/gatt_link.dart';
+import 'adapters/host.dart' show BandHost;
+import 'adapters/hplus.dart';
+import 'ble_state.dart' show withSecondaryLinkSlot;
+
+String _hex(List<int> b) =>
+    b.map((x) => x.toRadixString(16).padLeft(2, '0')).join();
+
+/// The live link to a paired HPlus-family band. One instance; a second
+/// concurrent band of this kind is not a thing anyone asked for.
+class HPlusLink {
+  HPlusLink._();
+  static final HPlusLink instance = HPlusLink._();
+
+  /// The `device` row for the paired band, or null.
+  static Future<Map<String, Object?>?> pairedSensorRow() async {
+    for (final r in await LocalDb.deviceRows()) {
+      if (r['adapter_id'] == kHPlus.id) return r;
+    }
+    return null;
+  }
+
+  /// The most recent battery reading the band reported, or null.
+  ///
+  /// DELIBERATELY NOT WRITTEN TO `band_battery` — see `oura_link.dart`'s
+  /// identical reasoning: that table has no `device_id` column, so a
+  /// stranger's cell voltage would land in the WHOOP band's own pack-health
+  /// series with no way to tell them apart.
+  int? get batteryPct => _batteryPct;
+  int? _batteryPct;
+
+  /// The most recent firmware-version string the band reported, or null.
+  String? get firmwareVersion => _firmwareVersion;
+  String? _firmwareVersion;
+
+  BluetoothDevice? _device;
+  GattBandLink? _link;
+  BandHost? _host;
+  bool _busy = false;
+
+  /// Connect to the paired band, run the init sequence, collect for
+  /// [collectFor], then disconnect.
+  ///
+  /// Returns false when nothing is paired or the connect failed. SERIALISED:
+  /// a second call while one is in flight is a no-op rather than a second
+  /// radio session over the same peripheral.
+  Future<bool> sync({Duration collectFor = const Duration(seconds: 20)}) {
+    if (_busy) return Future.value(false);
+    _busy = true;
+    return _sync(collectFor).whenComplete(() => _busy = false);
+  }
+
+  Future<bool> _sync(Duration collectFor) async {
+    final row = await pairedSensorRow();
+    if (row == null) return false;
+    final deviceId = row['id'] as String?;
+    final remoteId = row['remote_id'] as String?;
+    if (deviceId == null || remoteId == null || remoteId.isEmpty) return false;
+    if (deviceId == LocalDb.kPrimaryDeviceId) {
+      // The primary band's id, permanently. A sensor writing under it would
+      // interleave its rows with the band's own.
+      debugPrint('[hplus] refusing to sync: the row claims the primary '
+          'device id — re-pair it with a minted id.');
+      return false;
+    }
+
+    try {
+      // A cap on concurrent SECONDARY links (never the primary band's own
+      // connect — see `ble_state.dart`'s `kMaxConcurrentSecondaryLinks` doc).
+      // This sync's connect, collect and disconnect all complete inside this
+      // one call, so the simple scoped form is correct here.
+      //
+      // THE TEARDOWN IS INSIDE THE CLOSURE, deliberately — same reasoning as
+      // `oura_link.dart`'s own `_sync`: held in an outer `finally` it would run
+      // AFTER the slot had already been released, letting a queued link
+      // connect while this one was still disconnecting.
+      return await withSecondaryLinkSlot(() async {
+        try {
+          final device = BluetoothDevice.fromId(remoteId);
+          _device = device;
+          await device.connect(timeout: const Duration(seconds: 20));
+          final services = await device.discoverServices();
+          final link = GattBandLink(
+            entry: kHPlus,
+            services: services,
+            onLog: (m) => debugPrint('[hplus] $m'),
+          );
+          _link = link;
+          final missing =
+              link.missingCharacteristics(kHPlus.requiredCharacteristics);
+          if (missing.isNotEmpty) {
+            debugPrint('[hplus] ${kHPlus.label}: missing required '
+                'characteristic(s) '
+                '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
+            return false;
+          }
+          final host = BandHost(
+            adapter: kHPlusAdapter,
+            deviceId: deviceId,
+            onLog: (m) => debugPrint('[hplus] $m'),
+            onNote: _handleNote,
+            buildArchive: _buildArchiveRow,
+          );
+          _host = host;
+          final done = host.run(link);
+          // This adapter's stream has no natural end — it is a continuous
+          // notify loop — so nothing else stops it. Give the band its
+          // collection window, then end the session the same way a workout
+          // screen ends a live one: `host.stop()`.
+          unawaited(Future<void>.delayed(
+              collectFor, () => unawaited(host.stop())));
+          await done;
+          return true;
+        } finally {
+          // Drop the link and DISCONNECT before the slot is released.
+          await stop();
+        }
+      });
+    } catch (e) {
+      debugPrint('[hplus] sync failed: $e');
+      return false;
+    }
+  }
+
+  /// Drop the link, flush what the session banked, disconnect. Safe to call
+  /// when nothing is connected.
+  Future<void> stop() async {
+    _link?.close();
+    _link = null;
+    await _host?.stop();
+    _host = null;
+    final d = _device;
+    _device = null;
+    if (d != null) {
+      try {
+        await d.disconnect();
+      } catch (_) {/* already gone */}
+    }
+  }
+
+  void _handleNote(String key, Object? value) {
+    switch (key) {
+      case 'battery':
+        if (value is int) _batteryPct = value;
+      case 'firmware':
+        if (value is String) _firmwareVersion = value;
+      default:
+        debugPrint('[hplus] $key = $value');
+    }
+  }
+
+  /// Bank one frame verbatim, decoded or not (owner rulings R1-R3): the
+  /// realtime-stats fields this file does not decode, the sleep record and
+  /// the day-summary variants are all in here undecoded, banked now so a
+  /// decoder written when someone owns a unit can be run over them.
+  ArchiveRecord? _buildArchiveRow(List<int> bytes, int capturedAtMs) {
+    if (bytes.isEmpty) return null;
+    return ArchiveRecord(
+      hex: _hex(bytes),
+      // NULL, not 0. This wire has no flash-record counter — see
+      // `oura_link.dart`'s identical reasoning for why a constant here would
+      // be accidental thinning policy rather than a real absence.
+      counter: null,
+      packetType: bytes[0], // the tag byte
+      // NULL. Nothing on this wire carries a clock; every frame is stamped
+      // on arrival, not decoded from the bytes.
+      recTs: null,
+      capturedAt: capturedAtMs,
+      // ONE REASON PER TAG, so a decoder written later finds its records by
+      // name instead of re-scanning the table.
+      reason: 'hplus_evt_0x${bytes[0].toRadixString(16).padLeft(2, '0')}',
+    );
+  }
+}

--- a/lib/ble/hplus_link.dart
+++ b/lib/ble/hplus_link.dart
@@ -19,9 +19,11 @@
 // NO PAIRING KEY, EITHER. Unlike the ring and the Mi Band, this wire has no
 // auth handshake — pairing is the plain notify-class flow
 // `HrsLink.pairNotifySensor` already runs for every unauthenticated sensor —
-// so there is no secret to store, drop, or clean up on forgetting; forgetting
-// this band is the same generic `HrsLink.forgetDevice` every other
-// unauthenticated notify-class sensor already uses.
+// so there is no secret to store, drop, or clean up on forgetting. But the
+// LIVE SESSION is owned by this file's own `HPlusLink.instance`, not by
+// `HrsLink.instance`'s chest-strap session, so `HrsLink.forgetDevice` still
+// carries an explicit branch that stops `instance` here before deleting the
+// row — it is only the key-cleanup half of forgetting that this band skips.
 
 import 'dart:async';
 

--- a/lib/ble/hrs_link.dart
+++ b/lib/ble/hrs_link.dart
@@ -65,6 +65,7 @@ import 'ble_state.dart'
         withScanLock,
         acquireSecondaryLinkSlot,
         releaseSecondaryLinkSlot;
+import 'hplus_link.dart' show HPlusLink;
 import 'oura_link.dart' show OuraLink;
 
 export 'adapters/host.dart' show HrsReading;
@@ -510,6 +511,14 @@ class HrsLink {
   /// Nothing is written unless the peripheral passed the characteristic check:
   /// a row pointing at a device that cannot answer is a sensor that appears
   /// paired and never produces a beat.
+  ///
+  /// Pulled out of [pairNotifySensor] so the derivation itself — the part a
+  /// future adapter can get wrong — is reachable by a test that has no
+  /// `BluetoothDevice` to connect.
+  @visibleForTesting
+  static String? deriveTier(String? explicit, String adapterId) =>
+      explicit ?? (declaredSignals(adapterId).isEmpty ? null : 'beatToBeat');
+
   static Future<String?> pairNotifySensor(
     BandEntry entry,
     BluetoothDevice device, {
@@ -544,7 +553,7 @@ class HrsLink {
         adapterId: entry.id,
         remoteId: device.remoteId.str,
         label: label,
-        tier: tier ?? (declaredSignals(entry.id).isEmpty ? null : 'beatToBeat'),
+        tier: deriveTier(tier, entry.id),
       );
       return null;
     } catch (e) {
@@ -575,7 +584,11 @@ class HrsLink {
   /// DISPATCHES ON `adapter_id` BEFORE TOUCHING ANYTHING. An Oura row carries
   /// a secret this class knows nothing about — [OuraLink.forgetRing] drops the
   /// stored key and the row together, and calling `disarm()` on it here would
-  /// leave that key behind while looking like a complete forget.
+  /// leave that key behind while looking like a complete forget. An HPlus row
+  /// has no secret, but its live connection is [HPlusLink.instance], a
+  /// separate singleton from this class's own chest-strap session —
+  /// `disarm()` here would tear down the wrong link and leave the real one
+  /// (and its `BandHost`'s flush timer) running against a deleted device id.
   static Future<void> forgetDevice(String id) async {
     if (id == LocalDb.kPrimaryDeviceId) {
       debugPrint('[hrs] refusing to forget the primary band from here.');
@@ -586,6 +599,15 @@ class HrsLink {
         .firstOrNull;
     if (row?['adapter_id'] == kOura.id) {
       await OuraLink.forgetRing(id);
+      return;
+    }
+    if (row?['adapter_id'] == kHPlus.id) {
+      // HPlusLink.instance owns this band's live connection, not HrsLink's
+      // own chest-strap session — stopping the wrong one would leave the
+      // real link (and its BandHost's flush timer) running against a
+      // device_id that no longer exists.
+      await HPlusLink.instance.stop();
+      await LocalDb.deleteDevice(id);
       return;
     }
     // Before the row goes, not after: a live session would keep writing rows

--- a/lib/ble/hrs_link.dart
+++ b/lib/ble/hrs_link.dart
@@ -497,9 +497,15 @@ class HrsLink {
   /// that DOES need a key exchange supplies its own step to the screen and
   /// never calls this.
   ///
-  /// [tier] defaults to the strap's, and a band whose measurement quality
-  /// differs must say so rather than inherit it — the tier is what decides
-  /// precedence between two sources, so a wrong one is a silent wrong number.
+  /// [tier] defaults to null and is only worth passing explicitly when a
+  /// caller knows better than the entry's own declared signals. Left null, it
+  /// is derived from [declaredSignals]: `'beatToBeat'` for a strap that
+  /// actually declares one (today, only [kBleHrs]), null for anything that
+  /// declares none — same "NULL is a refusal, not a default" rule
+  /// `oura_link.dart` states for its own row. A band whose measurement
+  /// quality differs from that must say so rather than inherit it — the tier
+  /// is what decides precedence between two sources, so a wrong one is a
+  /// silent wrong number.
   ///
   /// Nothing is written unless the peripheral passed the characteristic check:
   /// a row pointing at a device that cannot answer is a sensor that appears
@@ -508,7 +514,7 @@ class HrsLink {
     BandEntry entry,
     BluetoothDevice device, {
     String? label,
-    String tier = 'beatToBeat',
+    String? tier,
   }) async {
     try {
       await device.connect(timeout: _connectTimeout);
@@ -538,7 +544,7 @@ class HrsLink {
         adapterId: entry.id,
         remoteId: device.remoteId.str,
         label: label,
-        tier: tier,
+        tier: tier ?? (declaredSignals(entry.id).isEmpty ? null : 'beatToBeat'),
       );
       return null;
     } catch (e) {

--- a/lib/ui2/pairing/device_picker.dart
+++ b/lib/ui2/pairing/device_picker.dart
@@ -270,6 +270,8 @@ class _DevicePickerScreenState extends State<DevicePickerScreen> {
           'The strap this app is built around. WHOOP 4 or 5.',
       'oura' => l?.devicePickerBlurbRing ??
           'Reads the ring directly — no Oura account or subscription.',
+      'hplus' => 'A generic HPlus-family HR band. Pairs and banks its '
+          'history; nothing is decoded into a number yet.',
       _ => l?.devicePickerBlurbSensor ??
           'A chest strap or armband, for beat timing during a workout.',
     };

--- a/lib/ui2/profile/devices.dart
+++ b/lib/ui2/profile/devices.dart
@@ -43,10 +43,11 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
 
 import '../../ble/adapters/_registry.dart'
-    show BandEntry, kBandRegistry, kBleHrs, kOura, declaredSignals;
+    show BandEntry, kBandRegistry, kBleHrs, kHPlus, kOura, declaredSignals;
 import '../../ble/adapters/signals.dart' show InputSignal;
 import '../../ble/hrs_link.dart' show HrsLink, HrsReading;
 import '../../ble/oura_link.dart' show OuraLink, pairOuraRing;
+import '../../ble/hplus_link.dart' show HPlusLink;
 import '../../ble/band_status_l10n.dart' show localizedBandStatus;
 import '../../ble/ble_state.dart' show BandStatus, kMaxConcurrentSecondaryLinks;
 import '../../data/db.dart' show LocalDb;
@@ -773,6 +774,7 @@ class HealthSource {
 /// the only place a user can tell two paired sensors apart at a glance.
 IconData sensorIcon(String? adapterId) => switch (adapterId) {
       'oura' => LucideIcons.circleDot,
+      'hplus' => LucideIcons.watch,
       _ => LucideIcons.heartPulse,
     };
 
@@ -950,6 +952,15 @@ final List<({BandEntry entry, String blurb, Future<String?> Function(BluetoothDe
         'the Oura app cannot be re-keyed. Reset it from the Oura app (remove/'
         'unpair the ring), then close that app before pairing here.',
     pick: pairOuraRing,
+  ),
+  (
+    entry: kHPlus,
+    blurb: 'A generic HPlus-family HR band (HPlus, Makibes F68, Zeblaze and '
+        'similar). No account, no handshake — it pairs and banks what it '
+        'sends, but nothing is decoded into a number yet.',
+    // Null: no auth step, so the plain notify-class pairing is the whole of
+    // what this band needs — same as [kBleHrs].
+    pick: null,
   ),
 ];
 
@@ -1475,7 +1486,11 @@ class _DeviceDetailState extends State<DeviceDetail> {
       // primary band's link, its restore identity and its trim cursor, none of
       // which a sensor has — pointing this at it would have unpaired the
       // WHOOP from a chest strap's page.
-      onSync: s.family == 'oura' ? () => _syncRing(c) : null,
+      onSync: s.family == 'oura'
+          ? () => _syncRing(c)
+          : s.family == 'hplus'
+              ? () => _syncHPlus(c)
+              : null,
       onForget: s.deviceId != null
           ? () => _confirmForgetSensor(c, s)
           : app == null
@@ -1501,6 +1516,24 @@ Future<void> _syncRing(BuildContext c) async {
         : (l?.devicesCouldNotReachRing ??
             'Could not reach the ring. It has to be nearby, and not connected '
                 'to another app.')),
+  ));
+}
+
+/// Connect to the band, now, because the user asked. Same "one sentence
+/// either way" shape as [_syncRing] — a sync that reached the band and one
+/// that could not are different remedies for the user.
+Future<void> _syncHPlus(BuildContext c) async {
+  final l = AppLocalizations.of(c);
+  final messenger = ScaffoldMessenger.maybeOf(c);
+  messenger?.showSnackBar(
+      SnackBar(content: Text(l?.devicesSyncing ?? 'Syncing')));
+  final ok = await HPlusLink.instance.sync();
+  if (!c.mounted) return;
+  messenger?.showSnackBar(SnackBar(
+    content: Text(ok
+        ? (l?.devicesSynced ?? 'Synced.')
+        : 'Could not reach the band. It has to be nearby, and not connected '
+            'to another app.'),
   ));
 }
 

--- a/test/adapter_signals_registry_test.dart
+++ b/test/adapter_signals_registry_test.dart
@@ -12,6 +12,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openstrap_edge/ble/adapters/_registry.dart';
 import 'package:openstrap_edge/ble/adapters/ble_hrs.dart';
+import 'package:openstrap_edge/ble/adapters/hplus.dart';
 import 'package:openstrap_edge/ble/adapters/oura.dart';
 import 'package:openstrap_edge/ble/adapters/signals.dart';
 import 'package:openstrap_edge/ble/adapters/whoop_gen4.dart';
@@ -25,6 +26,7 @@ void main() {
       'gen5': kWhoopGen4Signals,
       'ble_hrs': const BleHrsAdapter().signals,
       'oura': OuraAdapter(key: const [0]).signals,
+      'hplus': const HPlusAdapter().signals,
     };
 
     // Every registry id is covered above: a NEW adapter must extend this test,

--- a/test/adapters/hplus_adapter_test.dart
+++ b/test/adapters/hplus_adapter_test.dart
@@ -1,0 +1,126 @@
+// Replay a fixture through a [ReplayBandLink] and assert what [HPlusAdapter]
+// decodes, archives, and — just as importantly — never claims. Same shape as
+// `ble_hrs_adapter_test.dart` and `oura_adapter_test.dart`: no hardware, no
+// mocks.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ble/adapters/_registry.dart';
+import 'package:openstrap_edge/ble/adapters/adapter.dart';
+import 'package:openstrap_edge/ble/adapters/hplus.dart';
+
+/// A realtime-stats frame long enough to carry a battery byte at offset 9.
+/// Fields before and after it (steps/distance/calories/reserved/HR/active
+/// time) are filler; only the tag and the battery byte are asserted against.
+List<int> realtimeFrame({required int battery}) => <int>[
+      0x33, // tag
+      0, 0, // steps
+      0, 0, // distance
+      0, 0, 0, 0, // calories
+      battery, // battery — offset 9
+      0, // reserved
+      0, // heart rate
+      0, 0, // active time
+    ];
+
+/// Drive [HPlusAdapter] over recorded bytes and collect what it yields.
+Future<List<BandEvent>> replay(List<(int, List<int>)> arrivals) async {
+  final link = ReplayBandLink();
+  final events = <BandEvent>[];
+  final done = Completer<void>();
+  const adapter = HPlusAdapter(idleTimeout: Duration(milliseconds: 200));
+  final sub = adapter.run(link).listen(events.add, onDone: done.complete);
+  // Let the init-sequence writes go out before frames start arriving — the
+  // ReplayBandLink buffers regardless, but this mirrors real timing.
+  await Future<void>.delayed(Duration.zero);
+  for (final (sec, value) in arrivals) {
+    link.feed(kHPlusMeasureChar, value, atSec: sec);
+  }
+  await link.close();
+  await done.future;
+  await sub.cancel();
+  return events;
+}
+
+void main() {
+  test('the init sequence is written to the control characteristic, in order',
+      () async {
+    final link = ReplayBandLink();
+    const adapter = HPlusAdapter(idleTimeout: Duration(milliseconds: 200));
+    final done = Completer<void>();
+    final sub = adapter.run(link).listen((_) {}, onDone: done.complete);
+    await Future<void>.delayed(Duration.zero);
+    await link.close();
+    await done.future;
+    await sub.cancel();
+    expect(link.writes.map((w) => w.$2).toList(), <List<int>>[
+      <int>[0x4f, 0x5a],
+      <int>[0x4d],
+      <int>[0x35, 0x0a],
+      <int>[0x4f],
+    ]);
+    expect(link.writes.every((w) => w.$1 == kHPlusControlChar), isTrue);
+  });
+
+  test('a realtime-stats frame surfaces its battery byte as a BandNote',
+      () async {
+    final events =
+        await replay([(1_800_000_000, realtimeFrame(battery: 61))]);
+    final notes = events.whereType<BandNote>().toList();
+    expect(notes.where((n) => n.key == 'battery').map((n) => n.value),
+        <int>[61]);
+  });
+
+  test('0xff on the battery byte is the not-measured sentinel — no note',
+      () async {
+    final events =
+        await replay([(1_800_000_000, realtimeFrame(battery: 0xff))]);
+    expect(events.whereType<BandNote>().where((n) => n.key == 'battery'),
+        isEmpty);
+  });
+
+  test('a tag-0x18 firmware-version frame decodes its two raw bytes',
+      () async {
+    final events =
+        await replay([(1_800_000_000, <int>[0x18, 7, 2])]); // minor, major
+    final notes =
+        events.whereType<BandNote>().where((n) => n.key == 'firmware');
+    expect(notes.map((n) => n.value), <String>['2.7']);
+  });
+
+  test('a tag-0x2e firmware-version frame reads minor/major at its own offset',
+      () async {
+    final versionFrame = <int>[0x2e, 0, 0, 0, 0, 0, 0, 0, 0, 7, 2];
+    final events = await replay([(1_800_000_000, versionFrame)]);
+    final notes =
+        events.whereType<BandNote>().where((n) => n.key == 'firmware');
+    expect(notes.map((n) => n.value), <String>['2.7']);
+  });
+
+  test('every frame is archived verbatim, decoded or not', () async {
+    final events = await replay([
+      (1_800_000_000, realtimeFrame(battery: 50)),
+      (1_800_000_001, <int>[0x1a, 1, 2, 3]), // sleep record — never decoded
+    ]);
+    final raw = [
+      for (final e in events)
+        if (e is SampleBatch) ...?e.raw,
+    ];
+    expect(raw, hasLength(2));
+    expect(raw[0], Uint8List.fromList(realtimeFrame(battery: 50)));
+    expect(raw[1], Uint8List.fromList(<int>[0x1a, 1, 2, 3]));
+  });
+
+  test('nothing here declares a signal, and nothing offloads', () async {
+    expect(const HPlusAdapter().signals, isEmpty);
+    final events = await replay([(1_800_000_000, realtimeFrame(battery: 50))]);
+    expect(events.whereType<OffloadCheckpoint>(), isEmpty);
+    final samples = [
+      for (final e in events)
+        if (e is SampleBatch) ...e.samples,
+    ];
+    expect(samples, isEmpty);
+  });
+}

--- a/test/band_registry_test.dart
+++ b/test/band_registry_test.dart
@@ -10,7 +10,7 @@ import 'package:openstrap_protocol/openstrap_protocol.dart';
 void main() {
   test('ids are unique and stable — they are stamped as device_family', () {
     expect(kBandRegistry.map((e) => e.id).toList(),
-        <String>['gen4', 'gen5', 'ble_hrs', 'oura']);
+        <String>['gen4', 'gen5', 'ble_hrs', 'oura', 'hplus']);
   });
 
   test('D1 — the scan service list is exactly the two WHOOP services', () {

--- a/test/hrs_link_test.dart
+++ b/test/hrs_link_test.dart
@@ -318,4 +318,58 @@ void main() {
       await expectNoSlotLeak();
     });
   });
+
+  group('forgetDevice', () {
+    setUpAll(() {
+      sqfliteFfiInit();
+      databaseFactory = databaseFactoryFfi;
+    });
+
+    setUp(() async {
+      await LocalDb.close();
+      LocalDb.dbName = 'hrs_forget_test.db';
+      final dir = await databaseFactory.getDatabasesPath();
+      await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+    });
+
+    tearDown(() async => LocalDb.close());
+
+    test(
+        'an HPlus row goes through HPlusLink.instance, not the '
+        'chest-strap disarm', () async {
+      const id = 'hplus-11223344';
+      await LocalDb.upsertDevice(
+        id: id,
+        adapterId: kHPlus.id,
+        remoteId: 'AA:BB:CC:DD:EE:00',
+        label: 'Test Band',
+      );
+
+      // No BLE plugin is registered under `flutter test`, so this only
+      // proves the dispatch: it must reach `HPlusLink.instance.stop()`
+      // (a no-op with nothing connected) rather than `HrsLink.instance
+      // .disarm()`, and it must delete the row either way.
+      await HrsLink.forgetDevice(id);
+
+      final rows = await LocalDb.deviceRows();
+      expect(rows.where((r) => r['id'] == id), isEmpty);
+    });
+  });
+
+  // Pure derivation, no BLE plugin needed — pulled out of `pairNotifySensor`
+  // specifically so this ternary has a test that doesn't need one.
+  group('tier derivation', () {
+    test('a strap that declares beat-to-beat gets that tier by default', () {
+      expect(HrsLink.deriveTier(null, kBleHrs.id), 'beatToBeat');
+    });
+
+    test('a band that declares no signals stays null, not inherited', () {
+      expect(HrsLink.deriveTier(null, kHPlus.id), isNull);
+    });
+
+    test('an explicit tier always wins over the derivation', () {
+      expect(HrsLink.deriveTier('explicit', kHPlus.id), 'explicit');
+      expect(HrsLink.deriveTier('explicit', kBleHrs.id), 'explicit');
+    });
+  });
 }


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
adds the HPlus family (HPlus itself + rebadges like Makibes F68, Zeblaze) as a pairable band. plaintext vendor GATT service, no bonding, no key exchange — pairs, runs a short init write sequence, banks every notification raw.

experimental: no derivable signals. battery and firmware version surface as notes; heart rate/steps/etc are not decoded — the layout is vendor-inferred, not hardware-confirmed.

no protocol/ changes needed for this one.

## Summary by Sourcery

Add experimental support for pairing and synchronizing HPlus-family bands without decoding unverified health metrics.

New Features:
- Add experimental pairing and on-demand synchronization for HPlus-family bands, including Makibes F68, Zeblaze, and compatible rebrands.
- Archive all HPlus notifications as raw records while surfacing battery and firmware information as notes.
- Expose HPlus bands in device pairing and profile interfaces with manual sync support.

Bug Fixes:
- Correct sensor pairing quality tiers by deriving them from declared signals and leaving signal-less sensors unranked.

Tests:
- Add adapter, registry, pairing-tier, and HPlus forget-device coverage.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Adds experimental support for HPlus-family bands.
  - Supports Makibes F68, Zeblaze, and similar re-skins.
  - Surfaces band in the UI device picker.

- Implements on-demand connection and initialization flow.
  - Writes required init sequence to start streaming.
  - Banks all incoming notifications as raw records.

- Extracts battery and firmware version notes.
  - Avoids decoding unverified health metrics or signals.

- Fixes sensor pairing quality tier assignment.
  - Derives tier from declared signals instead of defaulting.
  - Assigns null tier to signal-less sensors.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["UI (Device Picker / Profile)"] -- "Triggers Sync" --> HPlusLink["HPlusLink"]
  HPlusLink -- "Connects & Runs" --> HPlusAdapter["HPlusAdapter"]
  HPlusAdapter -- "Writes Init Sequence" --> Band["HPlus Band"]
  Band -- "Raw Notifications" --> HPlusAdapter
  HPlusAdapter -- "Yields Notes & Raw Data" --> DB["LocalDb (Archive)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>_registry.dart</strong><dd><code>Registers HPlus GATT service and band entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/340/files#diff-92b3191852de079fb927a9209ad2e16cf950e8e551e0f515f8636e9e350edf4e">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>hplus.dart</strong><dd><code>Implements HPlusAdapter for initialization and raw archiving</code></dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/340/files#diff-80ab100cedada0edff21e3a8a8cb6e108afbace441fd84cc2f996f56fe061565">+211/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>hplus_link.dart</strong><dd><code>Implements HPlusLink for on-demand connection management</code>&nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/340/files#diff-f7ac616ff321d0063878090b89de89b05d2b445f72a0df02a2edcc4d8bbc15c5">+207/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>device_picker.dart</strong><dd><code>Adds HPlus blurb to the device picker UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/340/files#diff-01936f44e43baa4ed6113e6563a795495635194121c55976c87886c57f817ca1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>devices.dart</strong><dd><code>Surfaces HPlus in pairing list and wires manual sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/340/files#diff-e553e52550bda8f7988f04ec5fd49d57c5a36d0e774dca61d62022e97a83fcb8">+35/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>hrs_link.dart</strong><dd><code>Fixes pairing tier assignment for signal-less sensors</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/340/files#diff-62248fb98df76bd540da6dcb352073a88a0f813c14c625b00cc05970616aafe4">+11/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>adapter_signals_registry_test.dart</strong><dd><code>Updates registry test to include HPlus adapter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/340/files#diff-80fe91cb852297598cbec5fcee4d56986b78d77a5309cbcdfa31c8d3b71d900f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hplus_adapter_test.dart</strong><dd><code>Adds comprehensive tests for HPlus adapter behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/340/files#diff-c66684232136884756391a6ba6afb095ba5c4688d40d00d157503934269bfc3f">+126/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>band_registry_test.dart</strong><dd><code>Updates band registry test to expect `hplus` ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/340/files#diff-b1854a3fec47918fa17fbaa1b684889d846d730af0ec21f7cf649df08fb45bb3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for pairing and syncing HPlus-family heart-rate bands, including Makibes F68 and Zeblaze models.
  - Added device details showing battery level and firmware version.
  - Sync sessions now collect and preserve band history for later use.
  - Added HPlus-specific device identification, pairing guidance, and watch icon.

- **Bug Fixes**
  - Forgetting an HPlus device now stops its active connection before removal.
  - Concurrent sync requests are safely prevented from overlapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->