### PR TITLE
lefun ring/band: pairs and connects, reports nothing yet

### DIFF
--- a/lib/ble/adapters/_registry.dart
+++ b/lib/ble/adapters/_registry.dart
@@ -63,6 +63,13 @@ const String kOuraCommandChar = '98ed0002-a541-11e4-b6a0-0002a5d5c51b';
 /// event share this one characteristic — there is no separate data pipe.
 const String kOuraNotifyChar = '98ed0003-a541-11e4-b6a0-0002a5d5c51b';
 
+/// The Lefun-protocol family's GATT service. One shared write/notify pair
+/// covers battery, firmware info and every historical report code alike —
+/// there is no separate command channel the way Oura's ring has.
+const String kLefunService = '000018d0-0000-1000-8000-00805f9b34fb';
+const String kLefunWriteChar = '00002d01-0000-1000-8000-00805f9b34fb';
+const String kLefunNotifyChar = '00002d00-0000-1000-8000-00805f9b34fb';
+
 /// What a stored timestamp actually IS for a given band.
 ///
 /// The distinction is load-bearing and it is not cosmetic. A WHOOP record
@@ -438,12 +445,32 @@ const BandEntry kOura = BandEntry.notify(
   timeAnchor: TimeAnchor.arrival,
 );
 
+/// A Lefun-protocol OEM ring or band — the shared reference design behind a
+/// long list of storefront names, not one branded product. Plain, unencrypted
+/// GATT: no key, no nonce, no challenge/response anywhere in the envelope.
+///
+/// EXPERIMENTAL, and it stays that way: nobody on this project owns one, so
+/// not a byte of this path has met hardware (ASSUMPTIONS R6). Only the
+/// envelope and its checksum, plus the battery report, are decoded with any
+/// confidence — steps, sleep and PPG all ride the same envelope under their
+/// own report codes and have no decoder here, so `signals` is `const {}` and
+/// nothing this device writes becomes a metric.
+const BandEntry kLefun = BandEntry.notify(
+  id: 'lefun',
+  label: 'Smart ring/band (Lefun protocol)',
+  service: kLefunService,
+  characteristics: <String>[kLefunWriteChar, kLefunNotifyChar],
+  // No clock in the envelope this file decodes. See [TimeAnchor].
+  timeAnchor: TimeAnchor.arrival,
+);
+
 /// Every band this build can see. Order is match order during discovery.
 const List<BandEntry> kBandRegistry = <BandEntry>[
   kWhoopGen4,
   kWhoopGen5,
   kBleHrs,
   kOura,
+  kLefun,
 ];
 
 /// The bands the OFFLOAD ENGINE can drive, and the bands iOS provisions
@@ -500,6 +527,7 @@ const Map<String, Map<InputSignal, Duration>> kAdapterSignals =
     InputSignal.rrIntervals: Duration(seconds: 1),
   },
   'oura': <InputSignal, Duration>{},
+  'lefun': <InputSignal, Duration>{},
 };
 
 /// The signals one adapter declares, or empty for an id this build has no

--- a/lib/ble/adapters/lefun.dart
+++ b/lib/ble/adapters/lefun.dart
@@ -1,0 +1,80 @@
+// A Lefun-protocol OEM ring/band as a [BandAdapter]: no auth, one bounded
+// battery poll, bank every frame the radio hands back.
+//
+// NOTHING HERE HAS MET HARDWARE (ASSUMPTIONS R6). The envelope and the
+// battery report are the only things `protocol`'s `lefun.dart` decodes with
+// any confidence — steps, sleep and PPG all ride the same envelope under
+// their own report codes and have no decoder there, so `signals` is
+// `const {}` and every frame is archived verbatim rather than turned into a
+// value.
+//
+// A BOUNDED POLL, NOT A LIVE SESSION. Unlike a chest strap this device has no
+// per-second stream to hold a link open for — the one thing worth asking for
+// is battery, and everything else worth banking is whatever the ring pushes
+// on its own in the few seconds after that ask. So `run()` writes one
+// request, waits out [replyTimeout], and ends — the host tears the link down
+// once the stream closes, the same way `oura.dart`'s one-shot drain does.
+//
+// ponytail: no GET_ACTIVITY_DATA / GET_SLEEP_DATA / GET_PPG_DATA request
+// builders here, even though their request bodies (a single day-index or
+// PPG-type byte) are simple. Their RESPONSE layouts are not decoded by this
+// file, so requesting them would only bank more undecoded bytes for a
+// question nobody has asked yet — add them when someone verifies a response
+// shape against real hardware.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:openstrap_protocol/openstrap_protocol.dart';
+
+import '_registry.dart';
+import 'adapter.dart';
+import 'signals.dart';
+
+/// The adapter. Not const: [replyTimeout] is overridable so a test does not
+/// have to sit through the real wait.
+class LefunAdapter extends BandAdapter {
+  /// How long to hold the link open after the battery request, banking
+  /// whatever arrives on the notify characteristic in that window.
+  final Duration replyTimeout;
+
+  LefunAdapter({this.replyTimeout = const Duration(seconds: 5)});
+
+  @override
+  BandEntry get entry => kLefun;
+
+  /// NOTHING. See the module doc for why battery — the one report this file
+  /// decodes — is not a signal either: it is device state, not a
+  /// physiological reading, and it reaches the host as a [BandNote].
+  @override
+  Map<InputSignal, Duration> get signals => const {};
+
+  @override
+  Stream<BandEvent> run(BandLink link) async* {
+    final raw = <Uint8List>[];
+    int? batteryPct;
+    final sub = link.notify(kLefunNotifyChar).listen((rec) {
+      final f = parseLefunFrame(rec.$2);
+      if (f == null) return;
+      // Every frame archived verbatim, decoded or not (owner rulings R1-R3):
+      // steps, sleep and PPG all ride this same envelope with no decoder
+      // here, and the bytes are banked now so one written later can be run
+      // over them.
+      raw.add(Uint8List.fromList(rec.$2));
+      if (f.report == kLefunReportBattery) {
+        batteryPct = decodeLefunBattery(f.params) ?? batteryPct;
+      }
+    });
+    try {
+      if (!await link.write(kLefunWriteChar, buildLefunFrame(kLefunReportBattery))) {
+        link.log('lefun: battery request refused.');
+      } else {
+        await Future<void>.delayed(replyTimeout);
+      }
+      if (batteryPct case final pct?) yield BandNote('battery', pct);
+      if (raw.isNotEmpty) yield SampleBatch(const [], raw: raw);
+    } finally {
+      await sub.cancel();
+    }
+  }
+}

--- a/lib/ble/ble_state.dart
+++ b/lib/ble/ble_state.dart
@@ -1858,8 +1858,11 @@ class WriteChain {
 /// safe-trim invariant depends on (commit-then-ACK, flash trim), and making it wait
 /// behind a chest strap would turn a sensor's 12 s connect timeout into a delayed
 /// band sync — which is exactly the regression this milestone must not ship. With
-/// today's two pairable sensor kinds (kBleHrs, kOura) the cap is never reached, so
-/// this is a guard for the N-device future, not a change in behaviour.
+/// today's three pairable sensor kinds (kBleHrs, kOura, kLefun) the cap CAN be
+/// reached — a chest strap armed for a workout holds a slot for its whole
+/// duration, and a background wake syncing a ring and a Lefun device together
+/// wants both of what is left — but the mechanism is a queue, not a refusal:
+/// the caller that arrives once both slots are taken waits, it does not fail.
 const int kMaxConcurrentSecondaryLinks = 2;
 
 int _secondaryLinksInUse = 0;

--- a/lib/ble/hrs_link.dart
+++ b/lib/ble/hrs_link.dart
@@ -589,8 +589,14 @@ class HrsLink {
     if (row?['adapter_id'] == kLefun.id) {
       // No secret to drop — the envelope this device speaks has no key
       // exchange — so this is a plain stop-and-delete, same shape as Oura's
-      // forget minus the keychain half.
-      await LefunLink.instance.stop();
+      // forget minus the keychain half. GATED ON THE LIVE SESSION ACTUALLY
+      // BEING THIS ROW: `LefunLink` is a singleton over potentially several
+      // paired rows, so stopping it unconditionally would drop a DIFFERENT
+      // Lefun device's in-flight sync if one happened to be live when this
+      // one was forgotten.
+      if (LefunLink.instance.currentDeviceId == id) {
+        await LefunLink.instance.stop();
+      }
       await LocalDb.deleteDevice(id);
       return;
     }

--- a/lib/ble/hrs_link.dart
+++ b/lib/ble/hrs_link.dart
@@ -65,6 +65,7 @@ import 'ble_state.dart'
         withScanLock,
         acquireSecondaryLinkSlot,
         releaseSecondaryLinkSlot;
+import 'lefun_link.dart' show LefunLink;
 import 'oura_link.dart' show OuraLink;
 
 export 'adapters/host.dart' show HrsReading;
@@ -500,6 +501,9 @@ class HrsLink {
   /// [tier] defaults to the strap's, and a band whose measurement quality
   /// differs must say so rather than inherit it — the tier is what decides
   /// precedence between two sources, so a wrong one is a silent wrong number.
+  /// Pass null explicitly for a device that supplies no signal at all (the
+  /// same refusal `pairOuraRing` makes by never setting the column) — there is
+  /// no quality to rank on a device `BandAdapter.signals` declares nothing for.
   ///
   /// Nothing is written unless the peripheral passed the characteristic check:
   /// a row pointing at a device that cannot answer is a sensor that appears
@@ -508,7 +512,7 @@ class HrsLink {
     BandEntry entry,
     BluetoothDevice device, {
     String? label,
-    String tier = 'beatToBeat',
+    String? tier = 'beatToBeat',
   }) async {
     try {
       await device.connect(timeout: _connectTimeout);
@@ -582,9 +586,23 @@ class HrsLink {
       await OuraLink.forgetRing(id);
       return;
     }
+    if (row?['adapter_id'] == kLefun.id) {
+      // No secret to drop — the envelope this device speaks has no key
+      // exchange — so this is a plain stop-and-delete, same shape as Oura's
+      // forget minus the keychain half.
+      await LefunLink.instance.stop();
+      await LocalDb.deleteDevice(id);
+      return;
+    }
     // Before the row goes, not after: a live session would keep writing rows
-    // under an id nothing can explain any more.
-    await instance.disarm();
+    // under an id nothing can explain any more. GATED ON THE ROW BEING THE
+    // ARMED HRS SENSOR, not called unconditionally — this fallback used to run
+    // for ANY adapter without its own branch above, which would tear down a
+    // live chest-strap session while forgetting an unrelated device (e.g. a
+    // Lefun ring paired alongside one).
+    if (row?['adapter_id'] == kBleHrsAdapter.id) {
+      await instance.disarm();
+    }
     await LocalDb.deleteDevice(id);
   }
 

--- a/lib/ble/lefun_link.dart
+++ b/lib/ble/lefun_link.dart
@@ -1,0 +1,223 @@
+// The HOST for a Lefun-protocol ring/band: connect, drive [LefunAdapter] over
+// the link, bank what comes back, disconnect.
+//
+// NOTHING HERE HAS MET HARDWARE. The registry entry stays EXPERIMENTAL,
+// [LefunAdapter.signals] stays `const {}`, and nothing this file writes
+// becomes a number: its rows carry a non-null `source`, and every
+// derive/export read filters `source IS NULL`.
+//
+// THE SHAPE IS OURA'S, MINUS THE STATE OURA NEEDS AND THIS DEVICE DOES NOT.
+// There is no pairing key, no drain cursor and no time anchor to persist —
+// the envelope carries no clock and nothing here authenticates — so pairing
+// is the plain notify-class flow (`HrsLink.pairNotifySensor`) and this file
+// owns only the connect/run/disconnect a one-shot poll needs.
+//
+// NO DESTRUCTIVE COMMAND IS REACHABLE FROM HERE. This file writes nothing it
+// did not get from a builder in `protocol`'s `lefun.dart`, and that module
+// builds exactly one request (battery).
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:openstrap_protocol/openstrap_protocol.dart';
+
+import '../data/db.dart';
+import '../data/models.dart' show ArchiveRecord;
+import 'adapters/_registry.dart';
+import 'adapters/adapter.dart';
+import 'adapters/gatt_link.dart';
+import 'adapters/host.dart' show BandHost;
+import 'adapters/lefun.dart';
+import 'ble_state.dart' show withSecondaryLinkSlot;
+
+String _hex(List<int> b) =>
+    b.map((x) => x.toRadixString(16).padLeft(2, '0')).join();
+
+/// The live link to a paired Lefun-protocol device. One instance; a second
+/// concurrent ring is not a thing anyone asked for.
+class LefunLink {
+  LefunLink._();
+  static final LefunLink instance = LefunLink._();
+
+  /// The `device` row for the paired ring, or null.
+  static Future<Map<String, Object?>?> pairedRowFor(String deviceId) async {
+    for (final r in await LocalDb.deviceRows()) {
+      if (r['id'] == deviceId) return r;
+    }
+    return null;
+  }
+
+  BluetoothDevice? _device;
+
+  /// Kept only so teardown can [GattBandLink.close] it — stops a write the
+  /// adapter queued before teardown from landing on a LATER connection to the
+  /// same device.
+  GattBandLink? _link;
+
+  /// The session driving [LefunAdapter] over [_link]. See `adapters/host.dart`.
+  BandHost? _host;
+
+  bool _busy = false;
+
+  /// Connect to every paired Lefun-family device, poll battery, drain the
+  /// bounded window each one's [LefunAdapter] opens, disconnect.
+  ///
+  /// Returns false when nothing is paired or every connect failed. Multiple
+  /// paired rings are not a thing anyone asked for, but nothing here assumes
+  /// there is exactly one, unlike `OuraLink`'s single ring.
+  Future<bool> sync() {
+    if (_busy) return Future.value(false);
+    _busy = true;
+    return _sync().whenComplete(() => _busy = false);
+  }
+
+  Future<bool> _sync() async {
+    final rows = (await LocalDb.deviceRows())
+        .where((r) => r['adapter_id'] == kLefun.id)
+        .toList();
+    if (rows.isEmpty) return false;
+    var any = false;
+    for (final row in rows) {
+      if (await _syncOne(row)) any = true;
+    }
+    return any;
+  }
+
+  Future<bool> _syncOne(Map<String, Object?> row) async {
+    final deviceId = row['id'] as String?;
+    final remoteId = row['remote_id'] as String?;
+    if (deviceId == null || remoteId == null || remoteId.isEmpty) return false;
+    if (deviceId == LocalDb.kPrimaryDeviceId) {
+      // The primary band's id, permanently. A ring writing under it would
+      // interleave its seconds with the band's in one REPLACE-keyed table.
+      debugPrint('[lefun] refusing to sync: the row claims the primary '
+          'device id — re-pair it with a minted id.');
+      return false;
+    }
+    try {
+      // A cap on concurrent SECONDARY links (never the band's own connect —
+      // see ble_state.dart's kMaxConcurrentSecondaryLinks doc). Connect,
+      // drain and disconnect all complete inside this one call, so the
+      // simple scoped form is correct here.
+      //
+      // THE TEARDOWN IS INSIDE THE CLOSURE, deliberately — held in an outer
+      // `finally` it would run AFTER the slot had already been released, so
+      // the next queued link could connect while this one was still
+      // disconnecting.
+      return await withSecondaryLinkSlot(() async {
+        try {
+          final device = BluetoothDevice.fromId(remoteId);
+          _device = device;
+          await device.connect(timeout: const Duration(seconds: 20));
+          final services = await device.discoverServices();
+          final link = GattBandLink(
+            entry: kLefun,
+            services: services,
+            onLog: (m) => debugPrint('[lefun] $m'),
+          );
+          _link = link;
+          final missing =
+              link.missingCharacteristics(kLefun.requiredCharacteristics);
+          if (missing.isNotEmpty) {
+            debugPrint('[lefun] ${kLefun.label}: missing required '
+                'characteristic(s) '
+                '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
+            return false;
+          }
+          final host = BandHost(
+            adapter: LefunAdapter(),
+            deviceId: deviceId,
+            onLog: (m) => debugPrint('[lefun] $m'),
+            onNote: (key, value) => debugPrint('[lefun] $key = $value'),
+            buildArchive: _buildArchiveRow,
+          );
+          _host = host;
+          await host.run(link);
+          return true;
+        } finally {
+          // Drop the link and DISCONNECT before the slot is released.
+          await stop();
+        }
+      });
+    } catch (e) {
+      debugPrint('[lefun] sync failed: $e');
+      return false;
+    }
+  }
+
+  /// Drop the link, flush what the session can still stamp, disconnect.
+  /// Safe to call when nothing is connected.
+  Future<void> stop() async {
+    // Before the host's run subscription is cancelled: an adapter's `finally`
+    // can still write on the way out, and that write must not reach the radio.
+    _link?.close();
+    _link = null;
+    await _host?.stop();
+    _host = null;
+    final d = _device;
+    _device = null;
+    if (d != null) {
+      try {
+        await d.disconnect();
+      } catch (_) {/* already gone */}
+    }
+  }
+
+  /// Bank one frame verbatim, decoded or not (owner rulings R1-R3): steps,
+  /// sleep and PPG all ride this envelope undecoded, and the bytes are
+  /// banked now so a decoder written later can be run over them.
+  ArchiveRecord? _buildArchiveRow(List<int> bytes, int capturedAtMs) {
+    final f = parseLefunFrame(bytes);
+    if (f == null) return null;
+    return ArchiveRecord(
+      hex: _hex(bytes),
+      // NULL, not 0. This device has no flash-record counter in the envelope
+      // itself, and `counter` is what `thinRawArchiveBefore` samples on — a 0
+      // for every row would make every Lefun frame `0 % 60 == 0`, i.e.
+      // permanently exempt, which is accidental policy.
+      counter: null,
+      packetType: f.report,
+      // NULL, and it stays NULL. The envelope carries no clock.
+      recTs: null,
+      capturedAt: capturedAtMs,
+      reason: 'lefun_report_0x${f.report.toRadixString(16).padLeft(2, '0')}',
+    );
+  }
+
+  /// Replay a scripted device through the REAL [LefunAdapter] and the real
+  /// write path. The only way in: the entry point is a BLE notification and
+  /// `flutter_blue_plus` has no simulator path.
+  @visibleForTesting
+  Future<ReplayBandLink> ingestForTest(
+    String deviceId,
+    List<List<int>> Function(int writeIndex, List<int> value) reply, {
+    Duration replyTimeout = const Duration(milliseconds: 50),
+  }) async {
+    final link = ReplayBandLink();
+    final host = BandHost(
+      adapter: LefunAdapter(replyTimeout: replyTimeout),
+      deviceId: deviceId,
+      onLog: (m) => debugPrint('[lefun] $m'),
+      buildArchive: _buildArchiveRow,
+    );
+    _host = host;
+    var finished = false;
+    final done = host.run(link).whenComplete(() => finished = true);
+    var served = 0;
+    for (var spin = 0; spin < 800 && !finished; spin++) {
+      await Future<void>.delayed(Duration.zero);
+      while (served < link.writes.length) {
+        for (final f in reply(served, link.writes[served].$2)) {
+          link.feed(kLefunNotifyChar, f, atSec: 0);
+        }
+        served++;
+      }
+    }
+    await link.close();
+    await done.timeout(const Duration(seconds: 2), onTimeout: () {});
+    await host.stop();
+    _host = null;
+    return link;
+  }
+}

--- a/lib/ble/lefun_link.dart
+++ b/lib/ble/lefun_link.dart
@@ -58,6 +58,21 @@ class LefunLink {
   /// The session driving [LefunAdapter] over [_link]. See `adapters/host.dart`.
   BandHost? _host;
 
+  /// `device.id` of whichever paired row is CURRENTLY connected, or null
+  /// between syncs. This is a singleton session over potentially several
+  /// paired rows (`_sync` loops them one at a time), so a caller tearing down
+  /// one specific row — `HrsLink.forgetDevice`'s Lefun branch — must check
+  /// this before calling [stop]: stopping unconditionally would drop
+  /// whichever OTHER row's sync happened to be live at that moment.
+  ///
+  /// ponytail: not exercised by a test — reaching the race this guards
+  /// requires a genuinely concurrent forget-during-sync, which
+  /// `flutter_blue_plus` has no simulator path to construct deterministically
+  /// (the same reason `ingestForTest` below drives one session start to
+  /// finish rather than leaving it live). Add one if this ever gets a second,
+  /// non-radio way to hold a session open across an await.
+  String? get currentDeviceId => _host?.deviceId;
+
   bool _busy = false;
 
   /// Connect to every paired Lefun-family device, poll battery, drain the

--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -1727,7 +1727,7 @@ const int kAlgoVersion = 87;
 // took protocol 19d7291 → 6664854. kAlgoVersion is main's 81 — this branch
 // moves no derivation maths, which is why its own note says NO bump.
 const String kAnalyticsPin = '1fa8144a5e3b728ce91eeed6ecbc15d482933b44';
-const String kProtocolPin = '471034cb84b85edb37e72b6f6add79a2d7929294';
+const String kProtocolPin = '4284f9a2829381f4a09cdda27fa72a4bdacfa231';
 
 // Fold idempotency, the minimum-nights warm-up, and legacy-payload handling
 // all live in SleepProfilePolicy (pure, unit-tested) — see

--- a/lib/sync/background_sync.dart
+++ b/lib/sync/background_sync.dart
@@ -21,6 +21,7 @@ import '../ble/adapters/_registry.dart' show kWhoopGen4;
 import '../ble/adapters/host.dart' show BandHost;
 import '../ble/adapters/whoop_gen4.dart' show WhoopFramedAdapter;
 import '../ble/ble_engine.dart';
+import '../ble/lefun_link.dart';
 import '../ble/oura_link.dart';
 import '../compute/derivation_engine.dart';
 import '../compute/profile.dart';
@@ -223,6 +224,15 @@ Future<bool> runHeadlessSync({BandLease? lease}) async {
       await OuraLink.instance.sync();
     } catch (e) {
       debugPrint('[bgsync] oura sync skipped: $e');
+    }
+    // Same piggyback, same reasoning: LefunLink.sync() no-ops when nothing is
+    // paired and never throws, but this is still the one shared headless
+    // entry point, so a failure here must not escape and mark the WHOOP
+    // cycle as errored either.
+    try {
+      await LefunLink.instance.sync();
+    } catch (e) {
+      debugPrint('[bgsync] lefun sync skipped: $e');
     }
   }
 }

--- a/lib/ui2/pairing/device_picker.dart
+++ b/lib/ui2/pairing/device_picker.dart
@@ -270,6 +270,10 @@ class _DevicePickerScreenState extends State<DevicePickerScreen> {
           'The strap this app is built around. WHOOP 4 or 5.',
       'oura' => l?.devicePickerBlurbRing ??
           'Reads the ring directly — no Oura account or subscription.',
+      // No l10n key yet — added when this device gets one, same as every
+      // other string here started life as a fallback before its key existed.
+      'lefun' => 'A generic ring or band sold under many storefront names. '
+          'Pairs and connects; reports nothing yet.',
       _ => l?.devicePickerBlurbSensor ??
           'A chest strap or armband, for beat timing during a workout.',
     };

--- a/lib/ui2/profile/devices.dart
+++ b/lib/ui2/profile/devices.dart
@@ -43,7 +43,7 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
 
 import '../../ble/adapters/_registry.dart'
-    show BandEntry, kBandRegistry, kBleHrs, kOura, declaredSignals;
+    show BandEntry, kBandRegistry, kBleHrs, kLefun, kOura, declaredSignals;
 import '../../ble/adapters/signals.dart' show InputSignal;
 import '../../ble/hrs_link.dart' show HrsLink, HrsReading;
 import '../../ble/oura_link.dart' show OuraLink, pairOuraRing;
@@ -772,7 +772,7 @@ class HealthSource {
 /// The glyph for a paired sensor. A ring is not a chest strap and the row is
 /// the only place a user can tell two paired sensors apart at a glance.
 IconData sensorIcon(String? adapterId) => switch (adapterId) {
-      'oura' => LucideIcons.circleDot,
+      'oura' || 'lefun' => LucideIcons.circleDot,
       _ => LucideIcons.heartPulse,
     };
 
@@ -950,6 +950,21 @@ final List<({BandEntry entry, String blurb, Future<String?> Function(BluetoothDe
         'the Oura app cannot be re-keyed. Reset it from the Oura app (remove/'
         'unpair the ring), then close that app before pairing here.',
     pick: pairOuraRing,
+  ),
+  (
+    entry: kLefun,
+    blurb: 'A generic Bluetooth ring or band from the family sold under many '
+        'storefront names. Pairs and connects, but reports nothing yet — '
+        'nobody on this project has held one to verify what its numbers mean.',
+    // No key, no handshake — plain notify-class pairing, with no measurement
+    // tier: this device declares no signal at all (`LefunAdapter.signals` is
+    // `const {}`), so there is no quality to rank it against another source.
+    pick: (device) => HrsLink.pairNotifySensor(
+      kLefun,
+      device,
+      label: cleanDeviceLabel(device.platformName),
+      tier: null,
+    ),
   ),
 ];
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -857,10 +857,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -946,8 +946,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "471034cb84b85edb37e72b6f6add79a2d7929294"
-      resolved-ref: "471034cb84b85edb37e72b6f6add79a2d7929294"
+      ref: "4284f9a2829381f4a09cdda27fa72a4bdacfa231"
+      resolved-ref: "4284f9a2829381f4a09cdda27fa72a4bdacfa231"
       url: "https://github.com/OpenStrap/protocol.git"
     source: git
     version: "1.0.0"
@@ -1376,26 +1376,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.16"
   timezone:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -127,23 +127,16 @@ dependencies:
       # in lib/compute/derivation_engine.dart, which moves together with this
       # ref and pubspec.lock (the pin-equality test fails a partial repin).
       #
-      # REPIN: protocol main @ 471034c, the #42 (audit/consolidated-fixes)
-      # merge — 6 commits on top of 6664854: decodeFrame's short-packet
-      # dispatch now tries the v2 realtime-HR parser before falling back to
-      # v1 (rev-2 packets were being misdecoded); R10 live dispatch no longer
-      # drops hr==0 (off-wrist) records to a bare data_record and now carries
-      # ts_epoch like the other realtime_hr branches; the copy-pasted LE
-      # (sec, subsec) byte packing used by 5 command builders and the
-      # hand-rolled _pow10/gen5 u16/i16/u32 readers were deduped; and #36
-      # lands raw R11 frame decoding (`R11Raw`/`decodeR11Raw`, meaning
-      # unconfirmed — see live.dart).
+      # REPIN (this branch): protocol `lefun-protocol` @ 4284f9a, 2 commits on
+      # top of 471034c (everything above). Adds the Lefun band's own wire
+      # module this branch's `lib/ble/adapters/lefun.dart` calls:
+      # `buildLefunFrame`/`parseLefunFrame`, `decodeLefunBattery`, and
+      # `kLefunReportBattery` — a bounded envelope codec plus battery decode,
+      # nothing else. No decoded physiological field (owner ruling: nobody on
+      # this project owns the hardware).
       #
-      # NO kAlgoVersion bump: every changed decoder here is on the live
-      # realtime path (decodeFrame's `realtime_hr`/`realtime_small`, R11) —
-      # live high-rate streams are never persisted (see invariant #1), so no
-      # stored day_result number moves. R11's meaning is still unconfirmed
-      # and edge does not read it.
-      ref: 471034cb84b85edb37e72b6f6add79a2d7929294
+      # NO kAlgoVersion bump: nothing here feeds a stored metric.
+      ref: 4284f9a2829381f4a09cdda27fa72a4bdacfa231
   openstrap_analytics:
     git:
       url: https://github.com/OpenStrap/analytics.git

--- a/test/adapter_signals_registry_test.dart
+++ b/test/adapter_signals_registry_test.dart
@@ -12,6 +12,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openstrap_edge/ble/adapters/_registry.dart';
 import 'package:openstrap_edge/ble/adapters/ble_hrs.dart';
+import 'package:openstrap_edge/ble/adapters/lefun.dart';
 import 'package:openstrap_edge/ble/adapters/oura.dart';
 import 'package:openstrap_edge/ble/adapters/signals.dart';
 import 'package:openstrap_edge/ble/adapters/whoop_gen4.dart';
@@ -25,6 +26,7 @@ void main() {
       'gen5': kWhoopGen4Signals,
       'ble_hrs': const BleHrsAdapter().signals,
       'oura': OuraAdapter(key: const [0]).signals,
+      'lefun': LefunAdapter().signals,
     };
 
     // Every registry id is covered above: a NEW adapter must extend this test,

--- a/test/adapters/lefun_adapter_test.dart
+++ b/test/adapters/lefun_adapter_test.dart
@@ -1,0 +1,96 @@
+// The mandatory adapter test (MULTIBAND_PLAN §3.3.3): replay a fixture
+// through a [ReplayBandLink]. `LefunAdapter.signals` is `const {}`, so there
+// is no declared signal to assert appears — the shape this test proves
+// instead is the one this adapter actually makes: one bounded battery
+// request, then bank whatever the notify characteristic hands back.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ble/adapters/_registry.dart';
+import 'package:openstrap_edge/ble/adapters/adapter.dart';
+import 'package:openstrap_edge/ble/adapters/lefun.dart';
+import 'package:openstrap_protocol/openstrap_protocol.dart';
+
+Future<List<BandEvent>> replay(
+  List<int> Function(List<int> writeArgs)? reply, {
+  Duration replyTimeout = const Duration(milliseconds: 20),
+}) async {
+  final link = ReplayBandLink();
+  final events = <BandEvent>[];
+  final done = Completer<void>();
+  final adapter = LefunAdapter(replyTimeout: replyTimeout);
+  final sub = adapter.run(link).listen(events.add, onDone: done.complete);
+  // Wait for the write to land before answering it — a fixed delay would
+  // race the adapter's own write.
+  while (link.writes.isEmpty) {
+    await Future<void>.delayed(Duration.zero);
+  }
+  if (reply != null) {
+    link.feed(kLefunNotifyChar, reply(link.writes.single.$2), atSec: 0);
+  }
+  await done.future;
+  await sub.cancel();
+  return events;
+}
+
+void main() {
+  test('declares no signal at all', () {
+    expect(LefunAdapter().signals, isEmpty);
+  });
+
+  test('writes exactly one battery request, then ends the stream', () async {
+    final link = ReplayBandLink();
+    final done = Completer<void>();
+    final sub = LefunAdapter(replyTimeout: const Duration(milliseconds: 5))
+        .run(link)
+        .listen((_) {}, onDone: done.complete);
+    await done.future;
+    await sub.cancel();
+    expect(link.writes, hasLength(1));
+    expect(link.writes.single.$1, kLefunWriteChar);
+    expect(link.writes.single.$2, buildLefunFrame(kLefunReportBattery));
+  });
+
+  test('a battery reply becomes a BandNote and an archived frame', () async {
+    final events = await replay((_) => const [0x5A, 0x05, 0x03, 0x57, 0xFB]);
+    final notes = events.whereType<BandNote>().toList();
+    expect(notes, hasLength(1));
+    expect(notes.single.key, 'battery');
+    expect(notes.single.value, 87);
+
+    final batches = events.whereType<SampleBatch>().toList();
+    expect(batches, hasLength(1));
+    expect(batches.single.samples, isEmpty);
+    expect(batches.single.raw, hasLength(1));
+    expect(batches.single.raw!.single,
+        const [0x5A, 0x05, 0x03, 0x57, 0xFB]);
+  });
+
+  test('a corrupted frame is dropped, not archived', () async {
+    // Same bytes as above with the checksum flipped.
+    final events = await replay((_) => const [0x5A, 0x05, 0x03, 0x57, 0x00]);
+    expect(events.whereType<BandNote>(), isEmpty);
+    expect(events.whereType<SampleBatch>(), isEmpty);
+  });
+
+  test('nothing arriving yields nothing, not an empty archive', () async {
+    final events = await replay(null);
+    expect(events, isEmpty);
+  });
+
+  test('a refused write ends the session without waiting out the timeout',
+      () async {
+    final link = ReplayBandLink()..writeSucceeds = false;
+    final events = <BandEvent>[];
+    final done = Completer<void>();
+    final sw = Stopwatch()..start();
+    final sub = LefunAdapter(replyTimeout: const Duration(seconds: 30))
+        .run(link)
+        .listen(events.add, onDone: done.complete);
+    await done.future;
+    await sub.cancel();
+    expect(sw.elapsed, lessThan(const Duration(seconds: 1)));
+    expect(events, isEmpty);
+  });
+}

--- a/test/band_registry_test.dart
+++ b/test/band_registry_test.dart
@@ -10,7 +10,7 @@ import 'package:openstrap_protocol/openstrap_protocol.dart';
 void main() {
   test('ids are unique and stable — they are stamped as device_family', () {
     expect(kBandRegistry.map((e) => e.id).toList(),
-        <String>['gen4', 'gen5', 'ble_hrs', 'oura']);
+        <String>['gen4', 'gen5', 'ble_hrs', 'oura', 'lefun']);
   });
 
   test('D1 — the scan service list is exactly the two WHOOP services', () {

--- a/test/lefun_link_test.dart
+++ b/test/lefun_link_test.dart
@@ -1,0 +1,108 @@
+// The Lefun HOST: banks archive rows and gates forget/sync against a live
+// session, the two things only a host (not the adapter) can get wrong.
+//
+// NOTHING HERE HAS MET HARDWARE. `lefun_adapter_test.dart` already proves the
+// adapter's own frame/session behaviour via `ReplayBandLink`; this file exists
+// for `_buildArchiveRow`'s counter/rec_ts invariants, `_syncOne`'s primary-id
+// refusal, and `HrsLink.forgetDevice`'s kLefun branch.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ble/adapters/_registry.dart';
+import 'package:openstrap_edge/ble/hrs_link.dart';
+import 'package:openstrap_edge/ble/lefun_link.dart';
+import 'package:openstrap_edge/data/db.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+const String _deviceId = 'lefun-0a1b2c3d';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    await LocalDb.close();
+    LocalDb.dbName = 'lefun_link_test.db';
+    final dir = await databaseFactory.getDatabasesPath();
+    await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+  });
+
+  tearDown(() async => LocalDb.close());
+
+  test('a battery reply is banked with counter and rec_ts both null',
+      () async {
+    // NULL, not 0 / not a decoded second — this envelope has no flash-record
+    // counter and no clock, and a 0 would make every row `0 % 60 == 0` (i.e.
+    // permanently exempt from raw-archive thinning), which is accidental
+    // policy, not a decode.
+    //
+    // A real device-to-host battery reply (marker 0x5A, report 0x03, value
+    // 87 = 0x57, checksum verified) — `buildLefunFrame` builds the other
+    // direction (host-to-device, marker 0xAB) and would fail to parse here.
+    await LefunLink.instance.ingestForTest(
+      _deviceId,
+      (i, v) => const [
+        [0x5A, 0x05, 0x03, 0x57, 0xFB]
+      ],
+    );
+    final db = await LocalDb.instance;
+    final rows = await db.query('raw_archive', orderBy: 'captured_at, hex');
+    expect(rows, hasLength(1));
+    expect(rows.single['counter'], isNull);
+    expect(rows.single['rec_ts'], isNull);
+    expect(rows.single['reason'], 'lefun_report_0x03');
+  });
+
+  test('nothing paired means nothing to sync', () async {
+    expect(await LefunLink.instance.sync(), isFalse);
+  });
+
+  test('a row claiming the primary device id is refused, not synced',
+      () async {
+    // This must return before ever touching BLE — a real connect attempt in
+    // a plugin-less test isolate is the failure mode this test would catch.
+    await LocalDb.upsertDevice(
+      id: LocalDb.kPrimaryDeviceId,
+      adapterId: kLefun.id,
+      remoteId: 'AA:BB:CC:DD:EE:FF',
+      label: 'Ring',
+    );
+    expect(await LefunLink.instance.sync(), isFalse);
+  });
+
+  group('forgetDevice', () {
+    test('drops the device row when no session is live for it', () async {
+      await LocalDb.upsertDevice(
+        id: _deviceId,
+        adapterId: kLefun.id,
+        remoteId: 'AA:BB:CC:DD:EE:FF',
+        label: 'Ring',
+      );
+      await HrsLink.forgetDevice(_deviceId);
+      final rows = await LocalDb.deviceRows();
+      expect(rows.where((r) => r['id'] == _deviceId), isEmpty);
+    });
+
+    test('a device id nothing paired is a harmless no-op', () async {
+      await HrsLink.forgetDevice('lefun-never-paired');
+      final rows = await LocalDb.deviceRows();
+      expect(rows.where((r) => r['id'] == 'lefun-never-paired'), isEmpty);
+    });
+
+    test('currentDeviceId is null once a session has finished', () async {
+      // `forgetDevice`'s kLefun branch only calls `stop()` when
+      // `currentDeviceId` matches the row being forgotten — proving the
+      // getter clears after a session is what keeps a later, unrelated
+      // forget from stopping a session that already ended.
+      await LefunLink.instance.ingestForTest(
+        _deviceId,
+        (i, v) => const [
+          [0x5A, 0x05, 0x03, 0x57, 0xFB]
+        ],
+      );
+      expect(LefunLink.instance.currentDeviceId, isNull);
+    });
+  });
+}


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
adds the lefun-protocol family (a bunch of ~$10 storefront rings/bands sharing one reference design) as a pairable device. plain notify-class pairing, one battery poll, everything else it sends gets archived raw. no signals declared, nothing derived — same shape as the oura/hrs entries.

needs the openstrap/protocol lefun-protocol PR merged and the git pin in pubspec.yaml bumped before this can merge (using a local pubspec_overrides.yaml for now).

## Summary by Sourcery

Add experimental Lefun device support with battery polling and raw frame archiving, and ensure unrelated device removal leaves active HRS sessions running.

New Features:
- Add experimental Lefun ring and band support for pairing, foreground synchronization, and background synchronization.
- Archive validated Lefun protocol frames as raw data while exposing battery status without deriving physiological metrics.

Bug Fixes:
- Prevent forgetting an unrelated device from disarming an active chest-strap session.

Enhancements:
- Add Lefun device discovery, pairing metadata, registry entries, icons, and bounded secondary-link synchronization.

Build:
- Update the pinned OpenStrap protocol dependency to include Lefun frame and battery support.

Tests:
- Add coverage for Lefun adapter behavior, raw archiving, registry integration, and synchronization safeguards.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add experimental Lefun ring and band support.
  - Integrates Lefun devices into the pairing UI and background sync flows.
  - Uses a bounded poll connection with plain notify-class pairing.

- Archive raw Lefun frames without deriving metrics.
  - Polls battery status but abstains from exposing any physiological signals.
  - Saves undecoded bytes to the raw archive with null timestamps.

- Fix chest-strap disarm bug during device removal.
  - Prevents forgetting an unrelated device from stopping an active HRS session.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  DevicePicker["Device Picker"] -- "Pairs" --> LefunLink["Lefun Link"]
  BackgroundSync["Background Sync"] -- "Triggers" --> LefunLink
  LefunLink -- "Drives" --> LefunAdapter["Lefun Adapter"]
  LefunAdapter -- "Banks raw frames" --> LocalDb["Local DB"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>_registry.dart</strong><dd><code>Add Lefun GATT service and registry entries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/341/files#diff-92b3191852de079fb927a9209ad2e16cf950e8e551e0f515f8636e9e350edf4e">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lefun.dart</strong><dd><code>Implement LefunAdapter for bounded battery polling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/341/files#diff-e574bed98c86c389d0dbf630d19d76f5b3b62a40fdf13beeea3ea73b2334b1f8">+80/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lefun_link.dart</strong><dd><code>Implement LefunLink host for connection and archiving</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/341/files#diff-5b5f4c3a1e8c537e55118c50a89f58c1606a53c4337c137e62f914ed5a636fe4">+223/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>background_sync.dart</strong><dd><code>Add Lefun sync to headless background sync flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/341/files#diff-16ac57f05bd5fda34d2e44e6b163a9053f857df64e384dd6b6ec95170d07dab9">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>device_picker.dart</strong><dd><code>Add UI blurb for Lefun devices in picker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/341/files#diff-01936f44e43baa4ed6113e6563a795495635194121c55976c87886c57f817ca1">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>devices.dart</strong><dd><code>Add Lefun to sensor pairing options and icons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/341/files#diff-e553e52550bda8f7988f04ec5fd49d57c5a36d0e774dca61d62022e97a83fcb8">+17/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>hrs_link.dart</strong><dd><code>Fix HRS disarm bug and allow null tier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/341/files#diff-62248fb98df76bd540da6dcb352073a88a0f813c14c625b00cc05970616aafe4">+21/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>adapter_signals_registry_test.dart</strong><dd><code>Add Lefun to adapter signals registry test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/341/files#diff-80fe91cb852297598cbec5fcee4d56986b78d77a5309cbcdfa31c8d3b71d900f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lefun_adapter_test.dart</strong><dd><code>Add tests for LefunAdapter behavior and frames</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/341/files#diff-e1e7250d5ea06542063aa6d225d4e64df8b5073fde7b70562f688c2b8600b28b">+96/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>band_registry_test.dart</strong><dd><code>Update band registry test to include Lefun</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/341/files#diff-b1854a3fec47918fa17fbaa1b684889d846d730af0ec21f7cf649df08fb45bb3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for pairing and connecting to Lefun rings and bands.
  - Added one-time battery status retrieval and raw device data archiving.
  - Included Lefun devices in background synchronization.
  - Added Lefun device identification and pairing guidance in the interface.

- **Bug Fixes**
  - Forgetting a device now stops only the matching Lefun connection.
  - Forgetting unrelated devices no longer interrupts an active sensor session.

- **Documentation**
  - Clarified secondary sensor connection limits and queued connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->