### PR TITLE
dt78/dt92/dt66: pairs-only support

### DIFF
--- a/lib/ble/adapters/_registry.dart
+++ b/lib/ble/adapters/_registry.dart
@@ -63,6 +63,18 @@ const String kOuraCommandChar = '98ed0002-a541-11e4-b6a0-0002a5d5c51b';
 /// event share this one characteristic — there is no separate data pipe.
 const String kOuraNotifyChar = '98ed0003-a541-11e4-b6a0-0002a5d5c51b';
 
+/// The DT78/DT92/DT66 family's service — a Nordic UART Service instance, and
+/// NOT a fingerprint: this exact triple is reused by unrelated gadgets (see
+/// `kDt78`'s own doc comment below).
+const String kDt78Service = '6e400001-b5a3-f393-e0a9-e50e24dcca9e';
+
+/// Host to watch, write-without-response in both reference clients.
+const String kDt78WriteChar = '6e400002-b5a3-f393-e0a9-e50e24dcca9e';
+
+/// Watch to host, notify. Every reply and every unprompted push share this
+/// one characteristic.
+const String kDt78NotifyChar = '6e400003-b5a3-f393-e0a9-e50e24dcca9e';
+
 /// What a stored timestamp actually IS for a given band.
 ///
 /// The distinction is load-bearing and it is not cosmetic. A WHOOP record
@@ -438,12 +450,39 @@ const BandEntry kOura = BandEntry.notify(
   timeAnchor: TimeAnchor.arrival,
 );
 
+/// DT78 / DT92 / DT66 and the wider tail of WearFit-2.0-compatible OEM clones
+/// that share this exact service — one Nordic UART instance, no envelope, no
+/// checksum, no auth (`dt78.dart`'s own header has the worked byte examples).
+///
+/// The service/characteristic UUIDs are the generic Nordic UART reference
+/// triple, reused by large numbers of unrelated gadgets across many
+/// unaffiliated device families — so unlike gen4's `nameMatcher` there is no
+/// reliable advertised name to key on across resellers. The scan matches on
+/// service only; the picker surfaces a hit by its advertised name and lets
+/// the user confirm.
+///
+/// [TimeAnchor.arrival]: nothing in either reference client reads this
+/// watch's clock back, so there is no measured origin to anchor a reading to.
+///
+/// EXPERIMENTAL: nobody on this project owns one (ASSUMPTIONS R6). `signals`
+/// is `const {}` and `kDerivableSources` never gets this id — heart rate,
+/// SpO2, blood pressure, steps and sleep are all readable at fixed opcodes
+/// and none of it is decoded.
+const BandEntry kDt78 = BandEntry.notify(
+  id: 'dt78',
+  label: 'DT78 / DT92 / DT66',
+  service: kDt78Service,
+  characteristics: <String>[kDt78WriteChar, kDt78NotifyChar],
+  timeAnchor: TimeAnchor.arrival,
+);
+
 /// Every band this build can see. Order is match order during discovery.
 const List<BandEntry> kBandRegistry = <BandEntry>[
   kWhoopGen4,
   kWhoopGen5,
   kBleHrs,
   kOura,
+  kDt78,
 ];
 
 /// The bands the OFFLOAD ENGINE can drive, and the bands iOS provisions
@@ -471,10 +510,11 @@ BandEntry bandEntryFor(BandProfile wire) =>
 /// `signals` getter is a plain literal with no computed dependency, so this
 /// maps straight to the declared signals instead of a constructed instance —
 /// KEPT IN SYNC BY HAND with `whoop_gen4.dart`'s `kWhoopGen4Signals`,
-/// `ble_hrs.dart`'s `BleHrsAdapter.signals` and `oura.dart`'s
-/// `OuraAdapter.signals`, since importing those three back into this file
-/// (each of which already imports THIS file for its `BandEntry`) would be a
-/// needless import cycle for three lines of data.
+/// `ble_hrs.dart`'s `BleHrsAdapter.signals`, `oura.dart`'s
+/// `OuraAdapter.signals` and `dt78.dart`'s `Dt78Adapter.signals`, since
+/// importing those back into this file (each of which already imports THIS
+/// file for its `BandEntry`) would be a needless import cycle for a few
+/// lines of data.
 ///
 /// gen5 reuses gen4's map: `kWhoopGen5`'s own doc comment states "same inner
 /// payload layout as gen4 — only the envelope differs", so gen4's declared
@@ -500,6 +540,7 @@ const Map<String, Map<InputSignal, Duration>> kAdapterSignals =
     InputSignal.rrIntervals: Duration(seconds: 1),
   },
   'oura': <InputSignal, Duration>{},
+  'dt78': <InputSignal, Duration>{},
 };
 
 /// The signals one adapter declares, or empty for an id this build has no

--- a/lib/ble/adapters/dt78.dart
+++ b/lib/ble/adapters/dt78.dart
@@ -92,25 +92,29 @@ class _Dt78Reader {
         _buf.removeAt(0);
         continue;
       }
+      if (_buf.length < 4) break; // the marker byte has not arrived yet
+      if (_buf[3] != 0xFF) {
+        // The length happened to land on something that is not really a
+        // frame boundary. Checked as soon as the marker byte itself is
+        // available — NOT after waiting for the full `total` span, which
+        // `len` alone can claim is up to 258 bytes long. Waiting that long
+        // to find out this was noise would sit on a real frame arriving
+        // right behind it for however long the rest of that false span
+        // takes to fill, which on a 20-second sync window can be forever.
+        // Drop only the false preamble's start byte and resync from there.
+        _buf.removeAt(0);
+        continue;
+      }
       final total = 3 + len;
       if (_buf.length < total) break; // waiting on the rest of this frame
-      if (_buf[3] == 0xFF) {
-        final frame = Uint8List.fromList(_buf.sublist(0, total));
-        _buf.removeRange(0, total);
-        out.add(Dt78Frame(
-          frame[4],
-          frame[5],
-          frame.sublist(6),
-          frame,
-        ));
-      } else {
-        // The length happened to land on something that is not really a
-        // frame boundary. Drop only the false preamble's start byte, NOT the
-        // whole `total`-byte window — a real frame can be hiding anywhere
-        // inside it, and discarding the lot would eat it along with the
-        // noise. The loop resumes scanning from the next candidate.
-        _buf.removeAt(0);
-      }
+      final frame = Uint8List.fromList(_buf.sublist(0, total));
+      _buf.removeRange(0, total);
+      out.add(Dt78Frame(
+        frame[4],
+        frame[5],
+        frame.sublist(6),
+        frame,
+      ));
     }
     return out;
   }

--- a/lib/ble/adapters/dt78.dart
+++ b/lib/ble/adapters/dt78.dart
@@ -94,19 +94,23 @@ class _Dt78Reader {
       }
       final total = 3 + len;
       if (_buf.length < total) break; // waiting on the rest of this frame
-      final frame = Uint8List.fromList(_buf.sublist(0, total));
-      _buf.removeRange(0, total);
-      if (frame[3] == 0xFF) {
+      if (_buf[3] == 0xFF) {
+        final frame = Uint8List.fromList(_buf.sublist(0, total));
+        _buf.removeRange(0, total);
         out.add(Dt78Frame(
           frame[4],
           frame[5],
           frame.sublist(6),
           frame,
         ));
+      } else {
+        // The length happened to land on something that is not really a
+        // frame boundary. Drop only the false preamble's start byte, NOT the
+        // whole `total`-byte window — a real frame can be hiding anywhere
+        // inside it, and discarding the lot would eat it along with the
+        // noise. The loop resumes scanning from the next candidate.
+        _buf.removeAt(0);
       }
-      // else: the length happened to land on something that is not really a
-      // frame boundary — dropped, and the loop resumes scanning from
-      // whatever preamble candidate is left in the buffer.
     }
     return out;
   }
@@ -154,11 +158,21 @@ class Dt78Adapter extends BandAdapter {
       // One poll each, fire-and-forget — a refused write just means that
       // one reply never arrives, not a reason to end the session. Device
       // info and battery first (matching both reference clients' own
-      // connect-time behaviour), then the health bundle and steps.
-      await link.write(kDt78WriteChar, buildDt78Poll(0x92, 0x80));
-      await link.write(kDt78WriteChar, buildDt78Poll(0x91, 0x80));
-      await link.write(kDt78WriteChar, buildDt78Poll(0x32, 0x01));
-      await link.write(kDt78WriteChar, buildDt78Poll(0x51, 0x80));
+      // connect-time behaviour), then the health bundle and steps. Each
+      // write is its own try/catch so a thrown refusal cannot abort the
+      // remaining polls or the notify loop below.
+      for (final poll in <List<int>>[
+        buildDt78Poll(0x92, 0x80),
+        buildDt78Poll(0x91, 0x80),
+        buildDt78Poll(0x32, 0x01),
+        buildDt78Poll(0x51, 0x80),
+      ]) {
+        try {
+          await link.write(kDt78WriteChar, poll);
+        } catch (_) {
+          // A refused/thrown poll costs one reply, never the session.
+        }
+      }
 
       await for (final f in frames.stream) {
         switch (f.cmd) {

--- a/lib/ble/adapters/dt78.dart
+++ b/lib/ble/adapters/dt78.dart
@@ -1,0 +1,198 @@
+// DT78 / DT92 / DT66 and the wider tail of WearFit-2.0-compatible OEM clones,
+// as a [BandAdapter].
+//
+// NOTHING HERE HAS MET HARDWARE. Nobody on this project owns one of these
+// watches, so only the envelope itself and the two report codes with a real
+// worked byte example — battery and device info — are read at all, and
+// neither becomes anything more than a [BandNote]. Every frame this watch
+// sends — the health bundle, steps, sleep, the two connect-event pushes — is
+// banked to `raw_archive` verbatim and none of it is decoded. It ships
+// EXPERIMENTAL (ASSUMPTIONS R6), `signals` is `const {}`, and it is excluded
+// from `kDerivableSources`: nothing here can become a number until someone
+// has held one of these to cross-check a decode against.
+//
+// NO HANDSHAKE. There is no pairing key, no nonce, no challenge/response and
+// no bonding requirement anywhere in this protocol — the whole of what a
+// working client does after service discovery is request an MTU and enable
+// notifications, both of which happen above this seam. This file's [run]
+// starts polling the moment it is subscribed.
+//
+// THE FRAME, transcribed from the format's own worked examples:
+//
+//   AB 00 [len] FF [cmd] [mode] [args...]
+//
+// `len` is a u8 counting every byte from the `FF` marker to the end of the
+// frame inclusive — the only integrity signal this format has, since there is
+// no checksum or CRC anywhere in it. Nothing states that one GATT
+// notification carries exactly one frame, so [_Dt78Reader] buffers across
+// notifications and only emits once a declared length has actually arrived.
+//
+// WRITE TYPE. Both reference clients write host->watch without response
+// (Android sets `WRITE_TYPE_NO_RESPONSE` explicitly), while this repo's
+// shared link write is with-response by construction (`gatt_link.dart`) —
+// that is what triggers WHOOP's bonding, and it is untested here against a
+// real DT78 characteristic that may not expose the with-response property.
+// Left as-is rather than widening the shared link for one unverified band;
+// worth checking against real hardware before this ships past EXPERIMENTAL.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import '_registry.dart';
+import 'adapter.dart';
+import 'signals.dart';
+
+/// One parsed frame off the notify characteristic.
+class Dt78Frame {
+  final int cmd;
+  final int mode;
+
+  /// Bytes after the mode byte — empty for a bare poll's reply header alone.
+  final List<int> args;
+
+  /// The whole frame verbatim, preamble included — what `raw_archive` gets.
+  final Uint8List raw;
+
+  const Dt78Frame(this.cmd, this.mode, this.args, this.raw);
+}
+
+/// Build one bare host->watch poll: `AB 00 03 FF [cmd] [mode]`. Every request
+/// this adapter sends is exactly this shape — none carries an argument.
+Uint8List buildDt78Poll(int cmd, int mode) =>
+    Uint8List.fromList(<int>[0xAB, 0x00, 3, 0xFF, cmd, mode]);
+
+/// Buffers an accumulating notify byte stream into complete [Dt78Frame]s.
+///
+/// Hand-rolled rather than reusing a shared reassembler: there is no other
+/// length-prefixed-with-no-checksum format in this codebase to share one
+/// with, and the whole of what this needs is "wait for `len` more bytes,
+/// then hand back one frame".
+class _Dt78Reader {
+  final List<int> _buf = <int>[];
+
+  /// Feed newly-arrived bytes; returns every frame that is now complete.
+  List<Dt78Frame> feed(List<int> chunk) {
+    _buf.addAll(chunk);
+    final out = <Dt78Frame>[];
+    while (true) {
+      final start = _findPreamble();
+      if (start == null) {
+        // Nothing but noise buffered. Bounded so a stream that never
+        // resyncs cannot grow this forever.
+        if (_buf.length > 512) _buf.clear();
+        break;
+      }
+      if (start > 0) _buf.removeRange(0, start);
+      if (_buf.length < 3) break; // the length byte has not arrived yet
+      final len = _buf[2];
+      if (len < 3) {
+        // No real frame is shorter than `FF, cmd, mode` — this is not a
+        // length byte, it is a stray 0xAB/0x00 pair. Drop it and keep
+        // scanning.
+        _buf.removeAt(0);
+        continue;
+      }
+      final total = 3 + len;
+      if (_buf.length < total) break; // waiting on the rest of this frame
+      final frame = Uint8List.fromList(_buf.sublist(0, total));
+      _buf.removeRange(0, total);
+      if (frame[3] == 0xFF) {
+        out.add(Dt78Frame(
+          frame[4],
+          frame[5],
+          frame.sublist(6),
+          frame,
+        ));
+      }
+      // else: the length happened to land on something that is not really a
+      // frame boundary — dropped, and the loop resumes scanning from
+      // whatever preamble candidate is left in the buffer.
+    }
+    return out;
+  }
+
+  int? _findPreamble() {
+    for (var i = 0; i + 1 < _buf.length; i++) {
+      if (_buf[i] == 0xAB && _buf[i + 1] == 0x00) return i;
+    }
+    return null;
+  }
+}
+
+/// The adapter. Const, and it holds no session state — everything a session
+/// needs lives inside [run].
+class Dt78Adapter extends BandAdapter {
+  const Dt78Adapter();
+
+  @override
+  BandEntry get entry => kDt78;
+
+  /// NOTHING. The watch plainly emits heart rate, SpO2, blood pressure, steps
+  /// and sleep, and none of it is declared here: `0x31`/`0x32` are single- or
+  /// two-byte values with one worked example each and zero real captures to
+  /// check a decode against, and `0x51`/`0x52` are the source doc's own
+  /// best-effort guesses on undetermined byte widths. A declared-but-absent
+  /// signal is worse than a missing one (see [BandAdapter.signals]), so
+  /// nothing is claimed until a decoder exists and a real capture has met it.
+  @override
+  Map<InputSignal, Duration> get signals => const {};
+
+  @override
+  Stream<BandEvent> run(BandLink link) async* {
+    final reader = _Dt78Reader();
+    final frames = StreamController<Dt78Frame>();
+    final sub = link.notify(kDt78NotifyChar).listen(
+          (rec) {
+            for (final f in reader.feed(rec.$2)) {
+              frames.add(f);
+            }
+          },
+          onDone: frames.close,
+          onError: (Object _) => frames.close(),
+        );
+    try {
+      // One poll each, fire-and-forget — a refused write just means that
+      // one reply never arrives, not a reason to end the session. Device
+      // info and battery first (matching both reference clients' own
+      // connect-time behaviour), then the health bundle and steps.
+      await link.write(kDt78WriteChar, buildDt78Poll(0x92, 0x80));
+      await link.write(kDt78WriteChar, buildDt78Poll(0x91, 0x80));
+      await link.write(kDt78WriteChar, buildDt78Poll(0x32, 0x01));
+      await link.write(kDt78WriteChar, buildDt78Poll(0x51, 0x80));
+
+      await for (final f in frames.stream) {
+        switch (f.cmd) {
+          case 0x91:
+            // `[charging?, level]` per the format's own worked example
+            // (`AB 00 05 FF 91 80 00 50` → level 0x50 = 80). Close enough to
+            // bank as a note; never a health signal.
+            if (f.args.length >= 2) yield BandNote('battery', f.args[1]);
+            break;
+          case 0x92:
+            yield BandNote('device_info', f.args);
+            break;
+          case 0x20:
+          case 0x87:
+            // Watch-initiated connect pushes ("connection" / "connection
+            // response"). Nothing replies to these; logged so they are
+            // visible rather than silently dropped.
+            link.log('dt78: connect event 0x${f.cmd.toRadixString(16)}');
+            break;
+        }
+        // Every frame, decoded or not — the health bundle, steps, sleep and
+        // anything else this watch ever sends lives here undecoded, so a
+        // decoder written when someone owns one of these can be run over it.
+        yield SampleBatch(const [], raw: <Uint8List>[f.raw]);
+      }
+    } finally {
+      await sub.cancel();
+      await frames.close();
+    }
+    // No OffloadCheckpoint, ever. There is no trim-on-ack or fetch-by-range
+    // in this protocol — the watch is only ever polled, never told to
+    // forget anything.
+  }
+}
+
+/// The single instance. Const, so it costs nothing to reference.
+const Dt78Adapter kDt78Adapter = Dt78Adapter();

--- a/lib/ble/dt78_link.dart
+++ b/lib/ble/dt78_link.dart
@@ -42,6 +42,13 @@ class Dt78Link {
   BandHost? _host;
   bool _busy = false;
 
+  /// Whether a sync is already in flight. Read this BEFORE calling [sync] to
+  /// tell "already syncing" apart from "could not reach the watch" — both
+  /// collapse to the same `false` return from [sync] itself, which is the
+  /// right answer for the "did this session write anything" question but the
+  /// wrong one for the snack bar, where "already running" is not a failure.
+  bool get busy => _busy;
+
   /// How long one sync session listens before tearing down. There is no
   /// drain to finish and no cursor to exhaust — the watch just answers the
   /// startup polls and whatever else it sends unprompted — so this is a
@@ -78,9 +85,22 @@ class Dt78Link {
       // A cap on concurrent SECONDARY links (never the primary band's own
       // connect — see ble_state.dart's kMaxConcurrentSecondaryLinks doc).
       return await withSecondaryLinkSlot(() async {
+        final device = BluetoothDevice.fromId(remoteId);
         try {
-          final device = BluetoothDevice.fromId(remoteId);
           await device.connect(timeout: const Duration(seconds: 20));
+        } catch (e) {
+          debugPrint('[dt78] connect failed: $e');
+          return false;
+        }
+        // From here on the watch IS connected, so every exit — a thrown
+        // service discovery, a missing characteristic, a run() that throws,
+        // or the plain success path — must disconnect it. One `finally`
+        // covering the whole of that, rather than the two separate
+        // `disconnect()` call sites the two failure arms used to each need
+        // to remember on their own, which is exactly the shape that leaves
+        // the watch connected the day a THIRD failure arm is added and
+        // forgets to.
+        try {
           final services = await device.discoverServices();
           final link = GattBandLink(
             entry: kDt78,
@@ -94,7 +114,6 @@ class Dt78Link {
             debugPrint('[dt78] ${kDt78.label}: missing required '
                 'characteristic(s) '
                 '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
-            await device.disconnect().catchError((_) {});
             return false;
           }
           final host = BandHost(
@@ -103,19 +122,16 @@ class Dt78Link {
             onLog: (m) => debugPrint('[dt78] $m'),
           );
           _host = host;
-          final done = host.run(link);
-          try {
-            await done.timeout(_listenWindow, onTimeout: () {});
-          } finally {
-            await stop();
-            try {
-              await device.disconnect();
-            } catch (_) {/* already gone */}
-          }
+          await host.run(link).timeout(_listenWindow, onTimeout: () {});
           return true;
         } catch (e) {
-          debugPrint('[dt78] connect failed: $e');
+          debugPrint('[dt78] sync failed: $e');
           return false;
+        } finally {
+          await stop();
+          try {
+            await device.disconnect();
+          } catch (_) {/* already gone */}
         }
       });
     } catch (e) {

--- a/lib/ble/dt78_link.dart
+++ b/lib/ble/dt78_link.dart
@@ -1,0 +1,135 @@
+// The HOST for a paired DT78/DT92/DT66-family band: connect to its stored
+// remote id, drive [Dt78Adapter] over the link, bank what comes back,
+// disconnect.
+//
+// NOTHING HERE HAS MET HARDWARE (ASSUMPTIONS R6). The registry entry stays
+// EXPERIMENTAL, `Dt78Adapter.signals` stays `const {}`, and nothing this file
+// writes becomes a number — every row it commits carries a non-null `source`.
+//
+// THIN COUSIN OF `pinetime_link.dart`. There is no drain cursor and no time
+// anchor to hold — the four startup polls are fire-and-forget and nothing
+// here waits on a reply — so this is the same one-shot `sync()` shape:
+// connect, listen for whatever the watch sends over one flush window, tear
+// down.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+import '../data/db.dart';
+import 'adapters/_registry.dart';
+import 'adapters/dt78.dart';
+import 'adapters/gatt_link.dart';
+import 'adapters/host.dart' show BandHost;
+import 'ble_state.dart' show withSecondaryLinkSlot;
+
+/// The live link to a paired DT78/DT92/DT66-family band. One instance; a
+/// second concurrent unit is not a thing anyone asked for.
+class Dt78Link {
+  Dt78Link._();
+  static final Dt78Link instance = Dt78Link._();
+
+  /// The `device` row for the paired band, or null.
+  static Future<Map<String, Object?>?> pairedRow() async {
+    for (final r in await LocalDb.deviceRows()) {
+      if (r['adapter_id'] == kDt78.id) return r;
+    }
+    return null;
+  }
+
+  GattBandLink? _link;
+  BandHost? _host;
+  bool _busy = false;
+
+  /// How long one sync session listens before tearing down. There is no
+  /// drain to finish and no cursor to exhaust — the watch just answers the
+  /// startup polls and whatever else it sends unprompted — so this is a
+  /// plain window, not a completion signal.
+  static const Duration _listenWindow = Duration(seconds: 20);
+
+  /// Connect, listen for [_listenWindow], disconnect.
+  ///
+  /// Returns false when nothing is paired or the connect failed. Never
+  /// throws. SERIALISED: a second call while one is in flight is a no-op
+  /// rather than a second radio session over the same peripheral.
+  Future<bool> sync() {
+    if (_busy) return Future.value(false);
+    _busy = true;
+    return _sync().whenComplete(() => _busy = false);
+  }
+
+  Future<bool> _sync() async {
+    final row = await pairedRow();
+    if (row == null) return false;
+    final deviceId = row['id'] as String?;
+    final remoteId = row['remote_id'] as String?;
+    if (deviceId == null || remoteId == null || remoteId.isEmpty) return false;
+    if (deviceId == LocalDb.kPrimaryDeviceId) {
+      // The primary band's id, permanently. This watch writing under it
+      // would interleave its (undecoded, sample-less) rows with the band's
+      // own.
+      debugPrint('[dt78] refusing to sync: the row claims the primary '
+          'device id — re-pair it with a minted id.');
+      return false;
+    }
+
+    try {
+      // A cap on concurrent SECONDARY links (never the primary band's own
+      // connect — see ble_state.dart's kMaxConcurrentSecondaryLinks doc).
+      return await withSecondaryLinkSlot(() async {
+        try {
+          final device = BluetoothDevice.fromId(remoteId);
+          await device.connect(timeout: const Duration(seconds: 20));
+          final services = await device.discoverServices();
+          final link = GattBandLink(
+            entry: kDt78,
+            services: services,
+            onLog: (m) => debugPrint('[dt78] $m'),
+          );
+          _link = link;
+          final missing =
+              link.missingCharacteristics(kDt78.requiredCharacteristics);
+          if (missing.isNotEmpty) {
+            debugPrint('[dt78] ${kDt78.label}: missing required '
+                'characteristic(s) '
+                '${missing.map((u) => u.substring(0, 8)).join(", ")}.');
+            await device.disconnect().catchError((_) {});
+            return false;
+          }
+          final host = BandHost(
+            adapter: const Dt78Adapter(),
+            deviceId: deviceId,
+            onLog: (m) => debugPrint('[dt78] $m'),
+          );
+          _host = host;
+          final done = host.run(link);
+          try {
+            await done.timeout(_listenWindow, onTimeout: () {});
+          } finally {
+            await stop();
+            try {
+              await device.disconnect();
+            } catch (_) {/* already gone */}
+          }
+          return true;
+        } catch (e) {
+          debugPrint('[dt78] connect failed: $e');
+          return false;
+        }
+      });
+    } catch (e) {
+      debugPrint('[dt78] sync failed: $e');
+      return false;
+    }
+  }
+
+  /// Drop the link, flush what has been buffered. Safe when nothing is
+  /// connected.
+  Future<void> stop() async {
+    _link?.close();
+    _link = null;
+    await _host?.stop();
+    _host = null;
+  }
+}

--- a/lib/ble/dt78_link.dart
+++ b/lib/ble/dt78_link.dart
@@ -67,21 +67,27 @@ class Dt78Link {
   }
 
   Future<bool> _sync() async {
-    final row = await pairedRow();
-    if (row == null) return false;
-    final deviceId = row['id'] as String?;
-    final remoteId = row['remote_id'] as String?;
-    if (deviceId == null || remoteId == null || remoteId.isEmpty) return false;
-    if (deviceId == LocalDb.kPrimaryDeviceId) {
-      // The primary band's id, permanently. This watch writing under it
-      // would interleave its (undecoded, sample-less) rows with the band's
-      // own.
-      debugPrint('[dt78] refusing to sync: the row claims the primary '
-          'device id — re-pair it with a minted id.');
-      return false;
-    }
-
+    // The WHOLE body is inside this try now, `pairedRow()` included — a
+    // `LocalDb.deviceRows()` failure used to escape uncaught, breaking
+    // `sync()`'s no-throw contract and leaving the manual caller's "Syncing"
+    // snackbar never replaced with a result. Same fix as `pinetime_link.dart`.
     try {
+      final row = await pairedRow();
+      if (row == null) return false;
+      final deviceId = row['id'] as String?;
+      final remoteId = row['remote_id'] as String?;
+      if (deviceId == null || remoteId == null || remoteId.isEmpty) {
+        return false;
+      }
+      if (deviceId == LocalDb.kPrimaryDeviceId) {
+        // The primary band's id, permanently. This watch writing under it
+        // would interleave its (undecoded, sample-less) rows with the band's
+        // own.
+        debugPrint('[dt78] refusing to sync: the row claims the primary '
+            'device id — re-pair it with a minted id.');
+        return false;
+      }
+
       // A cap on concurrent SECONDARY links (never the primary band's own
       // connect — see ble_state.dart's kMaxConcurrentSecondaryLinks doc).
       return await withSecondaryLinkSlot(() async {

--- a/lib/ui2/pairing/device_picker.dart
+++ b/lib/ui2/pairing/device_picker.dart
@@ -270,6 +270,11 @@ class _DevicePickerScreenState extends State<DevicePickerScreen> {
           'The strap this app is built around. WHOOP 4 or 5.',
       'oura' => l?.devicePickerBlurbRing ??
           'Reads the ring directly — no Oura account or subscription.',
+      // No dedicated l10n key for this one — it is the same "pairs and
+      // banks, nothing decoded yet" sentence `kPairableSensors` already
+      // carries for it, English-only like every other category blurb until
+      // it earns one.
+      'dt78' => 'Pairs and banks its raw data — nothing is decoded yet.',
       _ => l?.devicePickerBlurbSensor ??
           'A chest strap or armband, for beat timing during a workout.',
     };

--- a/lib/ui2/profile/devices.dart
+++ b/lib/ui2/profile/devices.dart
@@ -1525,6 +1525,13 @@ Future<void> _syncRing(BuildContext c) async {
 Future<void> _syncDt78(BuildContext c) async {
   final l = AppLocalizations.of(c);
   final messenger = ScaffoldMessenger.maybeOf(c);
+  // Checked BEFORE calling sync(), which answers `false` for "already
+  // syncing" and "could not reach the watch" alike — a real distinction the
+  // snack bar should not blur into one failure sentence.
+  if (Dt78Link.instance.busy) {
+    messenger?.showSnackBar(const SnackBar(content: Text('Already syncing.')));
+    return;
+  }
   // `devicesSyncing`/`devicesSynced` are genuinely generic ("Syncing"/
   // "Synced."), unlike `devicesSyncingTheRing`/`devicesCouldNotReachRing`,
   // which name the ring by copy — reusing those here would show the wrong

--- a/lib/ui2/profile/devices.dart
+++ b/lib/ui2/profile/devices.dart
@@ -45,6 +45,7 @@ import 'package:provider/provider.dart';
 import '../../ble/adapters/_registry.dart'
     show BandEntry, kBandRegistry, kBleHrs, kDt78, kOura, declaredSignals;
 import '../../ble/adapters/signals.dart' show InputSignal;
+import '../../ble/dt78_link.dart' show Dt78Link;
 import '../../ble/hrs_link.dart' show HrsLink, HrsReading;
 import '../../ble/oura_link.dart' show OuraLink, pairOuraRing;
 import '../../ble/band_status_l10n.dart' show localizedBandStatus;
@@ -773,6 +774,7 @@ class HealthSource {
 /// the only place a user can tell two paired sensors apart at a glance.
 IconData sensorIcon(String? adapterId) => switch (adapterId) {
       'oura' => LucideIcons.circleDot,
+      'dt78' => LucideIcons.watch,
       _ => LucideIcons.heartPulse,
     };
 
@@ -1484,7 +1486,11 @@ class _DeviceDetailState extends State<DeviceDetail> {
       // primary band's link, its restore identity and its trim cursor, none of
       // which a sensor has — pointing this at it would have unpaired the
       // WHOOP from a chest strap's page.
-      onSync: s.family == 'oura' ? () => _syncRing(c) : null,
+      onSync: s.family == 'oura'
+          ? () => _syncRing(c)
+          : s.family == 'dt78'
+              ? () => _syncDt78(c)
+              : null,
       onForget: s.deviceId != null
           ? () => _confirmForgetSensor(c, s)
           : app == null
@@ -1510,6 +1516,29 @@ Future<void> _syncRing(BuildContext c) async {
         : (l?.devicesCouldNotReachRing ??
             'Could not reach the ring. It has to be nearby, and not connected '
                 'to another app.')),
+  ));
+}
+
+/// Connect and bank the watch's raw bytes, now, because the user asked. Same
+/// shape as [_syncRing] — a separate family behind a separate link, same
+/// reason a sync that did nothing needs to say so.
+Future<void> _syncDt78(BuildContext c) async {
+  final l = AppLocalizations.of(c);
+  final messenger = ScaffoldMessenger.maybeOf(c);
+  // `devicesSyncing`/`devicesSynced` are genuinely generic ("Syncing"/
+  // "Synced."), unlike `devicesSyncingTheRing`/`devicesCouldNotReachRing`,
+  // which name the ring by copy — reusing those here would show the wrong
+  // device in the snack bar, so the failure sentence stays untranslated
+  // rather than borrowing one that says the wrong thing.
+  messenger?.showSnackBar(
+      SnackBar(content: Text(l?.devicesSyncing ?? 'Syncing')));
+  final ok = await Dt78Link.instance.sync();
+  if (!c.mounted) return;
+  messenger?.showSnackBar(SnackBar(
+    content: Text(ok
+        ? (l?.devicesSynced ?? 'Synced.')
+        : 'Could not reach the watch. It has to be nearby, and not connected '
+            'to another app.'),
   ));
 }
 

--- a/lib/ui2/profile/devices.dart
+++ b/lib/ui2/profile/devices.dart
@@ -43,7 +43,7 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
 
 import '../../ble/adapters/_registry.dart'
-    show BandEntry, kBandRegistry, kBleHrs, kOura, declaredSignals;
+    show BandEntry, kBandRegistry, kBleHrs, kDt78, kOura, declaredSignals;
 import '../../ble/adapters/signals.dart' show InputSignal;
 import '../../ble/hrs_link.dart' show HrsLink, HrsReading;
 import '../../ble/oura_link.dart' show OuraLink, pairOuraRing;
@@ -950,6 +950,15 @@ final List<({BandEntry entry, String blurb, Future<String?> Function(BluetoothDe
         'the Oura app cannot be re-keyed. Reset it from the Oura app (remove/'
         'unpair the ring), then close that app before pairing here.',
     pick: pairOuraRing,
+  ),
+  (
+    entry: kDt78,
+    blurb: 'Pairs and banks its raw data in the background, but does not '
+        'derive anything from it yet — nobody on this project owns one to '
+        'verify its numbers against.',
+    // Null means the plain notify-class pairing, which is the whole of what
+    // this watch needs — no auth, no key.
+    pick: null,
   ),
 ];
 

--- a/test/adapter_signals_registry_test.dart
+++ b/test/adapter_signals_registry_test.dart
@@ -12,6 +12,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openstrap_edge/ble/adapters/_registry.dart';
 import 'package:openstrap_edge/ble/adapters/ble_hrs.dart';
+import 'package:openstrap_edge/ble/adapters/dt78.dart';
 import 'package:openstrap_edge/ble/adapters/oura.dart';
 import 'package:openstrap_edge/ble/adapters/signals.dart';
 import 'package:openstrap_edge/ble/adapters/whoop_gen4.dart';
@@ -25,6 +26,7 @@ void main() {
       'gen5': kWhoopGen4Signals,
       'ble_hrs': const BleHrsAdapter().signals,
       'oura': OuraAdapter(key: const [0]).signals,
+      'dt78': const Dt78Adapter().signals,
     };
 
     // Every registry id is covered above: a NEW adapter must extend this test,

--- a/test/adapters/dt78_adapter_test.dart
+++ b/test/adapters/dt78_adapter_test.dart
@@ -132,6 +132,22 @@ void main() {
         hasLength(1));
   });
 
+  test('a false preamble claiming a huge length is rejected on the marker '
+      'byte alone, without waiting for that whole span to arrive', () async {
+    // `len=0xFF` claims a 258-byte frame this notification never delivers.
+    // Waiting for that span before checking `buf[3]` would leave the real
+    // battery frame arriving right behind it stuck for however long 258
+    // bytes takes to fill — on a 20 s window, potentially forever. The
+    // marker is wrong (0x77, not 0xFF) and must be caught on the FOUR bytes
+    // already in hand.
+    final buf = <int>[0xAB, 0x00, 0xFF, 0x77, ...kBatteryReply];
+    final events = await replay(
+      (link) => link.feed(kDt78NotifyChar, buf, atSec: 1),
+    );
+    expect(events.whereType<BandNote>().where((n) => n.key == 'battery'),
+        hasLength(1));
+  });
+
   test('never emits an OffloadCheckpoint — this protocol has no trim-on-ack',
       () async {
     final events = await replay(

--- a/test/adapters/dt78_adapter_test.dart
+++ b/test/adapters/dt78_adapter_test.dart
@@ -1,0 +1,131 @@
+// The mandatory adapter test (MULTIBAND_PLAN §3.3.3), adapted for a band that
+// declares NO signals at all: instead of "every declared signal arrives",
+// this pins the two things that matter for a raw-bank-only adapter — every
+// frame reaches `raw_archive` and nothing here is ever mistaken for a decoded
+// health value.
+//
+// No hardware, no mocks: a [ReplayBandLink] fed the format's own worked
+// examples byte-for-byte.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ble/adapters/_registry.dart';
+import 'package:openstrap_edge/ble/adapters/adapter.dart';
+import 'package:openstrap_edge/ble/adapters/dt78.dart';
+
+/// `AB 00 05 FF 91 80 00 50` — the format's own battery worked example:
+/// level 0x50 = 80.
+const List<int> kBatteryReply = <int>[0xAB, 0x00, 0x05, 0xFF, 0x91, 0x80, 0x00, 0x50];
+
+/// Drive [Dt78Adapter] over recorded bytes and collect what it yields.
+Future<List<BandEvent>> replay(
+  void Function(ReplayBandLink link) feed,
+) async {
+  final link = ReplayBandLink();
+  final events = <BandEvent>[];
+  final done = Completer<void>();
+  final sub = kDt78Adapter.run(link).listen(events.add, onDone: done.complete);
+  // Let the four startup polls actually go out before feeding replies —
+  // otherwise a poll's own write is not yet in `link.writes` when a test
+  // wants to assert against it.
+  await Future<void>.delayed(Duration.zero);
+  feed(link);
+  await link.close();
+  await done.future;
+  await sub.cancel();
+  return events;
+}
+
+void main() {
+  test('declares no signals — every frame is a bank, never a measurement',
+      () {
+    expect(kDt78Adapter.signals, isEmpty);
+    expect(kDt78Adapter.entry.isFramed, isFalse);
+  });
+
+  test('polls device info, battery, the health bundle and steps on start',
+      () async {
+    final link = ReplayBandLink();
+    final done = Completer<void>();
+    final sub = kDt78Adapter.run(link).listen((_) {}, onDone: done.complete);
+    await Future<void>.delayed(Duration.zero);
+    await link.close();
+    await done.future;
+    await sub.cancel();
+
+    // Compared as two parallel lists rather than a `List` of records: a
+    // record's own `==` falls back to `List`'s IDENTITY equality for a
+    // field that is itself a `List`, which `equals()`'s deep comparison does
+    // not reach through — plain nested lists get the deep comparison this
+    // needs.
+    expect(link.writes.map((w) => w.$1).toList(),
+        List.filled(4, kDt78WriteChar));
+    expect(link.writes.map((w) => w.$2.toList()).toList(), <List<int>>[
+      <int>[0xAB, 0x00, 3, 0xFF, 0x92, 0x80],
+      <int>[0xAB, 0x00, 3, 0xFF, 0x91, 0x80],
+      <int>[0xAB, 0x00, 3, 0xFF, 0x32, 0x01],
+      <int>[0xAB, 0x00, 3, 0xFF, 0x51, 0x80],
+    ]);
+  });
+
+  test('a battery reply becomes a note; the frame is still archived',
+      () async {
+    final events = await replay(
+      (link) => link.feed(kDt78NotifyChar, kBatteryReply, atSec: 1_800_000_000),
+    );
+    final notes = events.whereType<BandNote>().toList();
+    expect(notes.where((n) => n.key == 'battery').single.value, 80);
+
+    final batches = events.whereType<SampleBatch>().toList();
+    expect(batches.any((b) => b.raw != null && b.raw!.single.length == 8),
+        isTrue,
+        reason: 'the raw frame is banked whether or not it was decoded');
+    // No signal was declared, so nothing here is ever a decoded sample.
+    expect(batches.every((b) => b.samples.isEmpty), isTrue);
+  });
+
+  test('a frame split across two notifications is still reassembled',
+      () async {
+    final events = await replay((link) {
+      link.feed(kDt78NotifyChar, kBatteryReply.sublist(0, 4), atSec: 1);
+      link.feed(kDt78NotifyChar, kBatteryReply.sublist(4), atSec: 1);
+    });
+    expect(events.whereType<BandNote>().where((n) => n.key == 'battery'),
+        hasLength(1));
+  });
+
+  test('an unrecognised command is archived, never dropped', () async {
+    final unknown = <int>[0xAB, 0x00, 0x03, 0xFF, 0x77, 0x80];
+    final events = await replay(
+      (link) => link.feed(kDt78NotifyChar, unknown, atSec: 1),
+    );
+    final batches = events.whereType<SampleBatch>().toList();
+    expect(batches.any((b) => b.raw?.single.length == unknown.length), isTrue);
+  });
+
+  test('a too-short length byte is dropped as noise, not a crash', () async {
+    // `len=2` claims a frame with no mode byte — shorter than any real
+    // frame (`FF, cmd, mode` is the floor) — followed by a real battery
+    // reply. Must resync onto the real frame rather than throw.
+    final stray = <int>[0xAB, 0x00, 0x02, 0xFF, 0x99];
+    final events = await replay(
+      (link) => link.feed(
+          kDt78NotifyChar, <int>[...stray, ...kBatteryReply], atSec: 1),
+    );
+    expect(events.whereType<BandNote>().where((n) => n.key == 'battery'),
+        hasLength(1));
+  });
+
+  test('never emits an OffloadCheckpoint — this protocol has no trim-on-ack',
+      () async {
+    final events = await replay(
+      (link) => link.feed(kDt78NotifyChar, kBatteryReply, atSec: 1),
+    );
+    expect(events.whereType<OffloadCheckpoint>(), isEmpty);
+  });
+
+  test('buildDt78Poll matches the format\'s own frame layout', () {
+    expect(buildDt78Poll(0x91, 0x80), <int>[0xAB, 0x00, 3, 0xFF, 0x91, 0x80]);
+  });
+}

--- a/test/adapters/dt78_adapter_test.dart
+++ b/test/adapters/dt78_adapter_test.dart
@@ -117,6 +117,21 @@ void main() {
         hasLength(1));
   });
 
+  test('a false preamble drops only its own start byte, never a real frame '
+      'hiding inside its claimed length', () async {
+    // `AB 00 03 AB 00 ...` — a false preamble (buf[3]=0xAB, not 0xFF) whose
+    // claimed 6-byte span swallows a REAL preamble sitting at its own index
+    // 3-4. Removing the whole 6-byte span (the bug) deletes that real
+    // preamble along with the noise; removing only the first byte (the fix)
+    // leaves it for the next scan to find.
+    final buf = <int>[0xAB, 0x00, 0x03, ...kBatteryReply];
+    final events = await replay(
+      (link) => link.feed(kDt78NotifyChar, buf, atSec: 1),
+    );
+    expect(events.whereType<BandNote>().where((n) => n.key == 'battery'),
+        hasLength(1));
+  });
+
   test('never emits an OffloadCheckpoint — this protocol has no trim-on-ack',
       () async {
     final events = await replay(

--- a/test/band_registry_test.dart
+++ b/test/band_registry_test.dart
@@ -10,7 +10,7 @@ import 'package:openstrap_protocol/openstrap_protocol.dart';
 void main() {
   test('ids are unique and stable — they are stamped as device_family', () {
     expect(kBandRegistry.map((e) => e.id).toList(),
-        <String>['gen4', 'gen5', 'ble_hrs', 'oura']);
+        <String>['gen4', 'gen5', 'ble_hrs', 'oura', 'dt78']);
   });
 
   test('D1 — the scan service list is exactly the two WHOOP services', () {

--- a/test/dt78_link_test.dart
+++ b/test/dt78_link_test.dart
@@ -1,0 +1,60 @@
+// The DT78/DT92/DT66/wearfit-2.0-clone HOST wrapper: DB-only tests, the same
+// surface `casio_link_test.dart` and `pinetime_link_test.dart` cover for
+// their own hosts — no radio touched, because every path here that matters
+// returns before `sync()` reaches BLE.
+//
+// This file exists for what only the host can get wrong: refusing to sync
+// with nothing paired, refusing to write under the primary band's device id,
+// and serialising concurrent sync() calls through `busy`.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ble/adapters/_registry.dart';
+import 'package:openstrap_edge/ble/dt78_link.dart';
+import 'package:openstrap_edge/data/db.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    await LocalDb.close();
+    LocalDb.dbName = 'dt78_link_test.db';
+    final dir = await databaseFactory.getDatabasesPath();
+    await databaseFactory.deleteDatabase(p.join(dir, LocalDb.dbName));
+  });
+
+  tearDown(() async => LocalDb.close());
+
+  test('nothing paired means nothing to sync', () async {
+    expect(await Dt78Link.pairedRow(), isNull);
+    expect(await Dt78Link.instance.sync(), isFalse);
+  });
+
+  test('refuses to sync a row that claims the primary device id', () async {
+    await LocalDb.upsertDevice(
+      id: LocalDb.kPrimaryDeviceId,
+      adapterId: kDt78.id,
+      remoteId: 'AA:BB:CC:DD:EE:01',
+      label: 'DT78',
+    );
+    // The guard fires before any connect attempt, so this is safe without a
+    // real BLE stack behind it.
+    expect(await Dt78Link.instance.sync(), isFalse);
+  });
+
+  test('busy serialises a second concurrent sync() to a no-op', () async {
+    // Nothing paired, so the first call resolves fast — but `busy` is set
+    // synchronously before that resolution, and a call made while it is
+    // still in flight must collapse to `false` rather than starting a
+    // second radio session.
+    final first = Dt78Link.instance.sync();
+    expect(Dt78Link.instance.busy, isTrue);
+    expect(await Dt78Link.instance.sync(), isFalse);
+    expect(await first, isFalse);
+    expect(Dt78Link.instance.busy, isFalse);
+  });
+}


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
pairs and connects a DT78/DT92/DT66 (and other WearFit 2.0 clones sold under a pile of storefront names). same Nordic UART service the whole family shares. subscribes, sends the four harmless startup polls (device info, battery, health bundle, steps), banks every frame verbatim including the reassembled multi-notification ones. nothing decoded, no signals declared, EXPERIMENTAL like the other pairs-only sensors.

adds a Sync button on the paired band's detail screen (connect, drain the flush window, disconnect) — same shape as the ring's.

no protocol/ changes needed, no BLE framing lives there for this one.

## Summary by Sourcery

Enable experimental pairing and manual raw-data synchronization for the DT78 family of WearFit 2.0-compatible devices.

New Features:
- Add experimental pairing support for DT78, DT92, DT66, and compatible WearFit 2.0 devices.
- Provide manual synchronization from the paired device details screen.
- Archive incoming device frames as raw data while exposing battery level and device information as notes.

Enhancements:
- Register the DT78 family with its Nordic UART service and no declared health signals.
- Handle fragmented and noisy notifications while preserving complete raw frames for later decoding.

Tests:
- Add adapter, registry, raw-frame reassembly, polling, note extraction, and synchronization lifecycle coverage.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds experimental pairing for DT78-family watches.

- Enables manual sync from device details UI.

- Banks raw data frames without decoding metrics.

- Extracts battery and device info as notes.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["Device Details UI"] -- "Manual Sync" --> Link["Dt78Link"]
  Link -- "Connect & Poll" --> Adapter["Dt78Adapter"]
  Adapter -- "Bank Raw Frames" --> DB["raw_archive"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>_registry.dart</strong><dd><code>Registers DT78 service UUIDs and band entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/343/files#diff-92b3191852de079fb927a9209ad2e16cf950e8e551e0f515f8636e9e350edf4e">+45/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>dt78.dart</strong><dd><code>Implements DT78 adapter for raw frame banking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/343/files#diff-80ce30cfe5269beb8ca102d59358b2296aa7beb85d85ac11c527cbd536cb5ac3">+198/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dt78_link.dart</strong><dd><code>Manages BLE connection lifecycle for DT78 watches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/343/files#diff-690305e5ed76d2f4ac548b9ac5ecd51f2d1cc6f94da9fec03cbb020951cd5315">+135/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>device_picker.dart</strong><dd><code>Adds DT78 description to the device picker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/343/files#diff-01936f44e43baa4ed6113e6563a795495635194121c55976c87886c57f817ca1">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>devices.dart</strong><dd><code>Wires DT78 sync button and pairing UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/343/files#diff-e553e52550bda8f7988f04ec5fd49d57c5a36d0e774dca61d62022e97a83fcb8">+40/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>adapter_signals_registry_test.dart</strong><dd><code>Adds DT78 to adapter signals registry test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/343/files#diff-80fe91cb852297598cbec5fcee4d56986b78d77a5309cbcdfa31c8d3b71d900f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dt78_adapter_test.dart</strong><dd><code>Tests DT78 polling, parsing, and raw banking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/343/files#diff-c26ee841150122024678723931f56f41c13cd814e92d16eae9dfe7fa3e393a6b">+131/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>band_registry_test.dart</strong><dd><code>Adds DT78 to band registry ID test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/OpenStrap/edge/pull/343/files#diff-b1854a3fec47918fa17fbaa1b684889d846d730af0ec21f7cf649df08fb45bb3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental pairing support for DT78, DT92, and DT66 WearFit-compatible watches.
  * Added watch discovery, connection, synchronization, and disconnect handling.
  * Added a dedicated watch icon and pairing status description.
  * Synchronization retrieves battery and device information and archives incoming watch data.
  * Added polling for health and step data.

* **Limitations**
  * Health and activity data are archived but not yet decoded into derived metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->