### PR TITLE
fix: hold the beat axis non-decreasing (sleep staging threw on 6 of 8 days), bump kAlgoVersion to 88; quiesce ingest during a data reset

### DIFF
--- a/lib/compute/derivation_engine.dart
+++ b/lib/compute/derivation_engine.dart
@@ -1612,7 +1612,25 @@ import 'substrate.dart';
 // had) in exactly the shape that kept "readiness —" live for three releases.
 // kAnalyticsPin/kProtocolPin are UNCHANGED: M5 touches no analytics or
 // protocol code.
-const int kAlgoVersion = 87;
+// v88 — THE BEAT AXIS IS HELD NON-DECREASING (`monotonizeBeatAxis`,
+// substrate.dart). `beat_ts_ms` is a modelled beat position walked backwards
+// from the record's sub-second anchor, so two records whose anchors sit closer
+// than one beat place N+1's first beat before N's last. Measured on a live
+// install: 94 inversions across 39,066 beats in a single day.
+//
+// Analytics binary-searches that axis and asserts it ascends. The assert is
+// compiled out in RELEASE — so shipped builds did not throw, they mis-selected
+// each 300 s window's beats, and every affected day was banked at v87 from a
+// window gather that had silently skipped or duplicated beats. Those results
+// cannot be told apart from good ones after the fact, which is exactly what a
+// version bump is for: the days re-derive instead of being served from cache
+// (`finalizedDayIds` / `sleepSessionCandidate` both key on kAlgoVersion).
+//
+// Real output change on affected days — window membership moves by up to the
+// inversion depth (672 ms measured) — so the bump is real. Interval VALUES and
+// their order are untouched by the repair; only the modelled clock moves.
+// kAnalyticsPin/kProtocolPin are UNCHANGED: the repair is entirely edge-side.
+const int kAlgoVersion = 88;
 /// The sibling SHAs this version was derived against, asserted against
 /// pubspec.yaml in test/db_serve_version_and_reads_test.dart.
 ///

--- a/lib/compute/derive_prepare.dart
+++ b/lib/compute/derive_prepare.dart
@@ -689,6 +689,11 @@ class _PrepareAccumulator {
   }
 
   Substrate buildSubstrate() {
+    // The page seam, which neither page loader can see: `addDecodedPage` and
+    // `addRawPage` each place their own beats correctly and then APPEND, so an
+    // overlap between the last record of one page and the first of the next is
+    // only visible once every page is in. See [monotonizeBeatAxis].
+    monotonizeBeatAxis(rrTsMs);
     // `_skinTempUnitDrops` (see [_skinTempFor]) is structurally 0 today —
     // `derivableSourceSql()` renders `source IS NULL` (db.dart:116), so a
     // day's admitted rows are all one family and never trip the guard.

--- a/lib/compute/substrate.dart
+++ b/lib/compute/substrate.dart
@@ -777,6 +777,10 @@ Substrate decodeSubstrate(List<String> hexes) {
       ..clear()
       ..addAll(sr);
   }
+  // The beats this path just placed can still overlap across a RECORD seam —
+  // see [monotonizeBeatAxis]. The sort above only runs when loose live beats
+  // were folded in, so it is not that guarantee.
+  monotonizeBeatAxis(rrTsMs);
 
   return Substrate(
     tsSec: tsSec,
@@ -799,6 +803,39 @@ Substrate decodeSubstrate(List<String> hexes) {
     // `hrValidAt` regardless.
     hrValid: List<int>.filled(n, -1),
   );
+}
+
+/// Hold a beat time axis non-decreasing — WITHOUT moving a single interval.
+///
+/// `beat_ts_ms` is a RECONSTRUCTED beat position: `beatTimesMs` anchors on the
+/// record's sub-second stamp under the model that the record's LAST beat sits
+/// at that stamp, then walks the intervals backwards from it. The anchor is
+/// measured; the placement is modelled. When two adjacent records' anchors sit
+/// closer together than one beat, the model puts record N+1's beat 0 EARLIER
+/// than record N's last beat, and beats are emitted in record order — so the
+/// axis steps backwards. Real, not theoretical: 94 inversions across 39,066
+/// beats in one day on a live install, every one at `beat_index = 0`, by
+/// 7-672 ms.
+///
+/// Analytics binary-searches this axis (`_cleanBeatsInWindow`) and asserts it
+/// is non-decreasing. That assert is compiled out in release, so a release
+/// build does not throw — it silently mis-selects each window's beats instead,
+/// which is the worse failure of the two.
+///
+/// THE ORDER IS NOT WHAT IS WRONG. Beats arrive in the order the strap detected
+/// them and that order IS the rhythm — `beat_clock_read_path_test` pins it as
+/// the contract it is. Only the modelled placement is repaired, and by the
+/// least it can be: each beat is held no earlier than the one before it. A sort
+/// would reshuffle a true interval series to satisfy an assert.
+///
+/// A held beat lands on a zero-length gap, which the axis already allows and
+/// already contains: the `rr_ts_ms` staircase fallback puts a whole record's
+/// beats on one millisecond, and analytics' window gather is written for those
+/// ties (its lower bound is inclusive precisely so tied beats are not dropped).
+void monotonizeBeatAxis(List<double> rrTsMs) {
+  for (var i = 1; i < rrTsMs.length; i++) {
+    if (rrTsMs[i] < rrTsMs[i - 1]) rrTsMs[i] = rrTsMs[i - 1];
+  }
 }
 
 /// Steps MEASURED by the band's own pedometer over [sub], or `null` when this

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7338,6 +7338,20 @@
   "@homeNothingDerivedBody": {
     "description": "Body shown on a first-run day with nothing derived yet."
   },
+  "homeSyncedThrough": "Synced through {when}",
+  "@homeSyncedThrough": {
+    "description": "Home header line: how far the data we hold reaches, on the band's own clock. {when} is a bare HH:mm when the record is from the day already on screen, or a full day + time otherwise.",
+    "placeholders": {
+      "when": {
+        "type": "String",
+        "example": "11:06"
+      }
+    }
+  },
+  "homeSyncedNever": "No band data yet",
+  "@homeSyncedNever": {
+    "description": "Home header line when no record has ever been banked from a band."
+  },
   "homeSyncingTitle": "Syncing with your band",
   "@homeSyncingTitle": {
     "description": "Title shown on a bare day while records are actively arriving from the band."

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -223,6 +223,21 @@ class AppState extends ChangeNotifier {
   // "last data: …" indicator must show. Seeded from the DB at init, advanced as
   // records (drained + live) flow in.
   int? _lastRecTs;
+
+  /// "Delete everything" is in progress — refuse every record ingest path.
+  ///
+  /// [resetAllData] wipes the database but leaves the band CONNECTED: its own
+  /// documented order puts `signOut` (and the `unpair` inside it) last, because
+  /// that flips the route and unwinds the UI. So the strap keeps handing over
+  /// historical records across the wipe, and one landing after it is written
+  /// into the fresh database and re-advertised as the data edge — the deleted
+  /// installation, visible again, with nothing left to explain it.
+  ///
+  /// A refusal flag rather than a reordering: the ordering above is deliberate
+  /// and load-bearing, and tearing the link down first is a change to the
+  /// connection lifecycle, not to the wipe. Nothing is lost by refusing — the
+  /// band has not been ACKed for these records, so they are still on it.
+  bool _resetting = false;
   final List<String> logLines = [];
   bool busy = false;
 
@@ -1011,59 +1026,69 @@ class AppState extends ChangeNotifier {
   ///      that could re-create state are all downstream of the writes.
   ///   3. [signOut] last, because it flips the route and the UI unwinds.
   Future<void> resetAllData() async {
-    // 1 · nothing further leaves this phone, starting now.
-    telemetryConsent = false;
-    healthShareConsent = false;
-    consentChosen = false;
-    TelemetryService.instance.applyConsent(false);
-    HealthUploader.instance.deviceId = null; // maybeUpload bails without one
-    deviceId = '';
-
-    // 2 · every row in every table (see LocalDb.wipeAll for why it is not a
-    // hand-written table list, and for the sync_cursor decision).
-    await LocalDb.wipeAll();
-
-    // Surfaces outside the database that were still showing it.
-    await NotificationService.instance.cancelAll();
-    await WidgetService.clear();
+    // 0 · nothing further ENTERS the database either. The band is still
+    //     connected and still draining — see [_resetting].
+    _resetting = true;
     try {
-      await coachConfig?.save(apiKey: ''); // deletes the keychain entry
-    } catch (e) {
-      _log('[reset] keychain clear failed: $e');
+      // 1 · nothing further leaves this phone, starting now.
+      telemetryConsent = false;
+      healthShareConsent = false;
+      consentChosen = false;
+      TelemetryService.instance.applyConsent(false);
+      HealthUploader.instance.deviceId = null; // maybeUpload bails without one
+      deviceId = '';
+
+      // 2 · every row in every table (see LocalDb.wipeAll for why it is not a
+      // hand-written table list, and for the sync_cursor decision).
+      await LocalDb.wipeAll();
+
+      // Surfaces outside the database that were still showing it.
+      await NotificationService.instance.cancelAll();
+      await WidgetService.clear();
+      try {
+        await coachConfig?.save(apiKey: ''); // deletes the keychain entry
+      } catch (e) {
+        _log('[reset] keychain clear failed: $e');
+      }
+
+      // 3 · the whole preference namespace, not a remembered subset — same
+      // reason as wipeAll. A fresh install is the state being restored, and a
+      // fresh install has no preferences. The install id regenerates on the next
+      // launch, which is the point: the old anonymous id must not follow the
+      // user through a "delete everything".
+      try {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.clear();
+      } catch (e) {
+        _log('[reset] prefs clear failed: $e');
+      }
+      appStatus = null;
+      _savedAlarm = null;
+
+      // 4 · the in-memory mirrors of what we just deleted. These are plain
+      // fields, restored only by the profile load at launch, so leaving them
+      // alone kept both features RUNNING against the wiped database for the rest
+      // of the session — a re-pair without a relaunch would find phone steps
+      // still on and health export still syncing, which is not "a fresh install".
+      healthSyncEnabled = false;
+      healthState = HealthLinkState.unknown;
+      phoneStepsEnabled = false;
+      phoneStepsToday = 0;
+      _phoneStepsDay = null;
+      // The data edge, for the same reason. It only ever moves FORWARD, so a
+      // wipe that left it set meant a re-pair without a relaunch showed the
+      // deleted install's "Synced through …" — and no amount of syncing the new
+      // band could pull the label back to the truth.
+      _lastRecTs = null;
+      lastSynced = null;
+
+      // signOut() unpairs, so by the time it returns nothing is delivering.
+      await signOut();
+    } finally {
+      // Never leave ingest refused if the reset threw part-way: a half-reset
+      // install that silently drops every record is worse than the race.
+      _resetting = false;
     }
-
-    // 3 · the whole preference namespace, not a remembered subset — same
-    // reason as wipeAll. A fresh install is the state being restored, and a
-    // fresh install has no preferences. The install id regenerates on the next
-    // launch, which is the point: the old anonymous id must not follow the
-    // user through a "delete everything".
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.clear();
-    } catch (e) {
-      _log('[reset] prefs clear failed: $e');
-    }
-    appStatus = null;
-    _savedAlarm = null;
-
-    // 4 · the in-memory mirrors of what we just deleted. These are plain
-    // fields, restored only by the profile load at launch, so leaving them
-    // alone kept both features RUNNING against the wiped database for the rest
-    // of the session — a re-pair without a relaunch would find phone steps
-    // still on and health export still syncing, which is not "a fresh install".
-    healthSyncEnabled = false;
-    healthState = HealthLinkState.unknown;
-    phoneStepsEnabled = false;
-    phoneStepsToday = 0;
-    _phoneStepsDay = null;
-    // The data edge, for the same reason. It only ever moves FORWARD, so a
-    // wipe that left it set meant a re-pair without a relaunch showed the
-    // deleted install's "Synced through …" — and no amount of syncing the new
-    // band could pull the label back to the truth.
-    _lastRecTs = null;
-    lastSynced = null;
-
-    await signOut();
   }
 
   /// The single onboarding/route the UI gate is in. `_Gate` selects on THIS so it
@@ -1225,7 +1250,12 @@ class AppState extends ChangeNotifier {
       // engine's callback shape for a value it does not have.
       onEvent: (id, ts, hex) =>
           _onLiveEvent(id, ts, hex, LocalDb.kPrimaryDeviceId),
-      onRecordsBatch: LocalDb.insertRecordsBatch,
+      // Gated for the same reason as [_onRecord] — this one is wired straight
+      // to LocalDb, so it bypasses every check AppState makes.
+      onRecordsBatch: (raws, samples) async {
+        if (_resetting) return; // see [_resetting]
+        await LocalDb.insertRecordsBatch(raws, samples);
+      },
       // RESUMABLE SYNC: atomic commit of decoded rows + continuation cursor
       // before the HISTORY_END ACK, and a reader to seed the offload frontier
       // from the durable high-water on (re)connect. Routed through BandHost
@@ -2792,14 +2822,20 @@ class AppState extends ChangeNotifier {
   // Historical singles only now (live frames go through _onLiveFrame and are
   // never persisted). Just write the raw record (+ optional decoded sample).
   Future<void> _onRecord(Sample? sample, RawRecord raw) async {
+    if (_resetting) return; // see [_resetting]
     final ts = raw.recTs ?? sample?.tsEpoch;
-    await LocalDb.insertRecord(raw, sample);
-    // AFTER the write, not before it. `_lastRecTs` is the DATA EDGE — what is
-    // banked — and it only ever moves forward, so advancing it first meant a
-    // failed insert advertised a record the database does not hold, for the
-    // rest of the process. Now surfaced on Home ("Synced through …"), where
-    // claiming data we do not have is the one thing the line must not do.
-    if (ts != null && ts > 0 && ts > (_lastRecTs ?? 0)) _lastRecTs = ts;
+    // AFTER the write, and gated on the write SAYING it wrote. `_lastRecTs` is
+    // the DATA EDGE — what is banked — and it only ever moves forward, so
+    // advancing it first meant a failed insert advertised a record the
+    // database does not hold, for the rest of the process. Now surfaced on
+    // Home ("Synced through …"), where claiming data we do not have is the one
+    // thing the line must not do. `insertRecord` returns false rather than
+    // throwing if it ever stops committing; today it can only return true or
+    // throw, and reading the result costs nothing to keep that honest.
+    final inserted = await LocalDb.insertRecord(raw, sample);
+    if (inserted && ts != null && ts > 0 && ts > (_lastRecTs ?? 0)) {
+      _lastRecTs = ts;
+    }
   }
 
   // Ephemeral live high-rate frame (0x28/0x2B/0x33) — NOT persisted. The

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1056,6 +1056,12 @@ class AppState extends ChangeNotifier {
     phoneStepsEnabled = false;
     phoneStepsToday = 0;
     _phoneStepsDay = null;
+    // The data edge, for the same reason. It only ever moves FORWARD, so a
+    // wipe that left it set meant a re-pair without a relaunch showed the
+    // deleted install's "Synced through …" — and no amount of syncing the new
+    // band could pull the label back to the truth.
+    _lastRecTs = null;
+    lastSynced = null;
 
     await signOut();
   }
@@ -2787,8 +2793,13 @@ class AppState extends ChangeNotifier {
   // never persisted). Just write the raw record (+ optional decoded sample).
   Future<void> _onRecord(Sample? sample, RawRecord raw) async {
     final ts = raw.recTs ?? sample?.tsEpoch;
-    if (ts != null && ts > 0 && ts > (_lastRecTs ?? 0)) _lastRecTs = ts;
     await LocalDb.insertRecord(raw, sample);
+    // AFTER the write, not before it. `_lastRecTs` is the DATA EDGE — what is
+    // banked — and it only ever moves forward, so advancing it first meant a
+    // failed insert advertised a record the database does not hold, for the
+    // rest of the process. Now surfaced on Home ("Synced through …"), where
+    // claiming data we do not have is the one thing the line must not do.
+    if (ts != null && ts > 0 && ts > (_lastRecTs ?? 0)) _lastRecTs = ts;
   }
 
   // Ephemeral live high-rate frame (0x28/0x2B/0x33) — NOT persisted. The

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -97,6 +97,7 @@ import '../sync/edge_tracking.dart';
 import '../sync/band_ownership.dart';
 import '../sync/high_freq_wake_window.dart';
 import '../sync/ios_bg_task.dart';
+import '../sync/reset_gate.dart';
 import '../sync/paired_device.dart';
 import '../sync/sync_policy.dart'
     show
@@ -226,18 +227,12 @@ class AppState extends ChangeNotifier {
 
   /// "Delete everything" is in progress — refuse every record ingest path.
   ///
-  /// [resetAllData] wipes the database but leaves the band CONNECTED: its own
-  /// documented order puts `signOut` (and the `unpair` inside it) last, because
-  /// that flips the route and unwinds the UI. So the strap keeps handing over
-  /// historical records across the wipe, and one landing after it is written
-  /// into the fresh database and re-advertised as the data edge — the deleted
-  /// installation, visible again, with nothing left to explain it.
-  ///
-  /// A refusal flag rather than a reordering: the ordering above is deliberate
-  /// and load-bearing, and tearing the link down first is a change to the
-  /// connection lifecycle, not to the wipe. Nothing is lost by refusing — the
-  /// band has not been ACKed for these records, so they are still on it.
-  bool _resetting = false;
+  /// Now [ResetGate], not a private field: the headless drain
+  /// (`runHeadlessSync`) builds its OWN BleEngine with callbacks wired straight
+  /// to LocalDb and no AppState in scope, so a flag living here could never be
+  /// consulted by it. Same isolate, so one static covers both — see
+  /// reset_gate.dart for why that holds and what would break it.
+  bool get _resetting => ResetGate.active;
   final List<String> logLines = [];
   bool busy = false;
 
@@ -1028,7 +1023,7 @@ class AppState extends ChangeNotifier {
   Future<void> resetAllData() async {
     // 0 · nothing further ENTERS the database either. The band is still
     //     connected and still draining — see [_resetting].
-    _resetting = true;
+    ResetGate.enter();
     try {
       // 1 · nothing further leaves this phone, starting now.
       telemetryConsent = false;
@@ -1087,7 +1082,7 @@ class AppState extends ChangeNotifier {
     } finally {
       // Never leave ingest refused if the reset threw part-way: a half-reset
       // install that silently drops every record is worse than the race.
-      _resetting = false;
+      ResetGate.leave();
     }
   }
 
@@ -1263,11 +1258,28 @@ class AppState extends ChangeNotifier {
       // durable commit, same arguments, one extra await frame, and the SAME
       // failure contract: `commitNativeBatch` rethrows so
       // `DrainController.commit` still reads durability from a throw.
-      onCommitBatch: (raws, samples, trimTokenHex, {archives, deviceFamily}) =>
-          _bandHost.commitNativeBatch(raws, samples, trimTokenHex,
-              archives: archives, deviceFamily: deviceFamily),
+      onCommitBatch: (raws, samples, trimTokenHex,
+          {archives, deviceFamily}) async {
+        // THROWS, never silently succeeds. This is the ACK gate: only
+        // `onCommit` can bank raws + archives + trim cursor in one
+        // transaction, and DrainController reads durability FROM A THROW
+        // (see its safe-trim invariant). Returning quietly here would tell
+        // the drain the chunk was banked, it would ACK, and the band would
+        // trim flash that this reset refused to store — turning a race into
+        // real data loss on a band the user may not be deleting after all if
+        // the reset then fails. A throw blocks the ACK and the records stay
+        // on the strap.
+        if (ResetGate.active) {
+          throw StateError('data reset in progress — refusing to commit');
+        }
+        return _bandHost.commitNativeBatch(raws, samples, trimTokenHex,
+            archives: archives, deviceFamily: deviceFamily);
+      },
       // Pre-setup fallback only: the drain path archives inside commitSyncBatch.
-      onArchiveRecord: LocalDb.archiveRawRecord,
+      onArchiveRecord: (raw) async {
+        if (_resetting) return; // see [_resetting]
+        await LocalDb.archiveRawRecord(raw);
+      },
       cursorReader: (base) =>
           LocalDb.getCursorInt(LocalDb.cursorKeyFor(base, LocalDb.kPrimaryDeviceId)),
       // Debounced compute trigger: with continuous listening there's no discrete

--- a/lib/sync/background_sync.dart
+++ b/lib/sync/background_sync.dart
@@ -55,6 +55,7 @@ import '../notify/notification_event.dart';
 import '../state/alarm_schedule.dart';
 import 'band_ownership.dart';
 import 'high_freq_wake_window.dart';
+import 'reset_gate.dart';
 import 'paired_device.dart';
 import 'sync_policy.dart';
 
@@ -89,6 +90,16 @@ Future<bool> runHeadlessSync({BandLease? lease}) async {
     '(${BandOwnership.debugState})',
   );
   try {
+    // "Delete everything" is running in this same process — see [ResetGate].
+    // Checked BEFORE PairedDevice.load(), which is the only thing standing
+    // between a reset and a fresh drain today, and only by accident: the reset
+    // calls `prefs.clear()`, so a LATER run reads no paired device and bails
+    // here. That is incidental protection for future runs and none at all for
+    // a drain already in flight.
+    if (ResetGate.active) {
+      debugPrint('[bgsync] a data reset is running — not starting a drain.');
+      return true;
+    }
     final paired = await PairedDevice.load();
     if (paired == null) {
       debugPrint('[bgsync] not paired — nothing to do.');
@@ -101,23 +112,53 @@ Future<bool> runHeadlessSync({BandLease? lease}) async {
     // (whose facade adapter needs `engine` itself) is constructed.
     late final BandHost bandHost;
     final engine = BleEngine(
-      onRecord: (sample, raw) => LocalDb.insertRecord(raw, sample),
+      // EVERY write below is gated on [ResetGate]: a reset can begin at any
+      // point during a drain, and these callbacks are the reason it is not
+      // enough for AppState to guard only its own. Refusing loses nothing —
+      // none of it has been ACKed, so it is all still on the band.
+      onRecord: (sample, raw) async {
+        if (ResetGate.active) return;
+        await LocalDb.insertRecord(raw, sample);
+      },
       onState: (_) {},
       // This path drains exactly the one paired band (PairedDevice.load()),
       // so kPrimaryDeviceId is the correct value here, not a placeholder.
-      onEvent: (id, ts, hex) =>
-          LocalDb.insertEvent(id, ts, hex, deviceId: LocalDb.kPrimaryDeviceId),
+      onEvent: (id, ts, hex) async {
+        if (ResetGate.active) return;
+        await LocalDb.insertEvent(id, ts, hex,
+            deviceId: LocalDb.kPrimaryDeviceId);
+      },
       log: (l) => debugPrint('[bgsync] $l'),
-      onRecordsBatch: LocalDb.insertRecordsBatch,
+      onRecordsBatch: (raws, samples) async {
+        if (ResetGate.active) return;
+        await LocalDb.insertRecordsBatch(raws, samples);
+      },
       // Routed through BandHost (M1a) rather than calling
       // LocalDb.commitSyncBatch directly — same durable commit, same
       // arguments, one extra await frame, and the SAME failure contract:
       // `commitNativeBatch` rethrows so `DrainController.commit` still reads
       // durability from a throw and `TrimAckPolicy` still blocks the ACK.
-      onCommitBatch: (raws, samples, trimTokenHex, {archives, deviceFamily}) =>
-          bandHost.commitNativeBatch(raws, samples, trimTokenHex,
-              archives: archives, deviceFamily: deviceFamily),
-      onArchiveRecord: LocalDb.archiveRawRecord,
+      onCommitBatch: (raws, samples, trimTokenHex,
+          {archives, deviceFamily}) async {
+        // THROWS, never silently succeeds. This is the ACK gate: only
+        // `onCommit` can bank raws + archives + trim cursor in one
+        // transaction, and DrainController reads durability FROM A THROW
+        // (see its safe-trim invariant). Returning quietly here would tell
+        // the drain the chunk was banked, it would ACK, and the band would
+        // trim flash that this reset refused to store — turning a race into
+        // real data loss on a band the user may not be deleting after all if
+        // the reset then fails. A throw blocks the ACK and the records stay
+        // on the strap.
+        if (ResetGate.active) {
+          throw StateError('data reset in progress — refusing to commit');
+        }
+        return bandHost.commitNativeBatch(raws, samples, trimTokenHex,
+            archives: archives, deviceFamily: deviceFamily);
+      },
+      onArchiveRecord: (raw) async {
+        if (ResetGate.active) return;
+        await LocalDb.archiveRawRecord(raw);
+      },
       cursorReader: (base) =>
           LocalDb.getCursorInt(LocalDb.cursorKeyFor(base, LocalDb.kPrimaryDeviceId)),
       // Mark this as the background drainer: if the foreground app engine already

--- a/lib/sync/reset_gate.dart
+++ b/lib/sync/reset_gate.dart
@@ -40,19 +40,35 @@ library;
 class ResetGate {
   ResetGate._();
 
-  static bool _active = false;
+  /// How many resets are in flight, not whether one is.
+  ///
+  /// `resetAllData()` is awaited but does not block the UI: the confirm dialog
+  /// is already dismissed when it starts, `backToRoot` only runs when it ends,
+  /// and a wipe of a real database takes seconds. So a user can walk back into
+  /// Settings and confirm a second one on top of the first. With a bare bool
+  /// the first to finish lowers the flag while the second is still wiping —
+  /// reopening the exact window this class exists to close, at the worst
+  /// possible moment. Counted, the gate stays shut until the LAST one leaves.
+  static int _depth = 0;
 
-  /// True from the moment a reset starts until it finishes (or throws).
-  static bool get active => _active;
+  /// True from the moment a reset starts until the last one finishes (or
+  /// throws).
+  static bool get active => _depth > 0;
 
   /// Raise before the wipe. Pair with [leave] in a `finally`: a half-reset
   /// install that silently drops every record is worse than the race this
   /// closes.
-  static void enter() => _active = true;
+  static void enter() => _depth++;
 
-  static void leave() => _active = false;
+  /// Clamped at zero rather than allowed to go negative: an unbalanced [leave]
+  /// is a bug, but one that drove the count below zero would make the NEXT
+  /// reset's `enter()` fail to open the gate, which is the failure that loses
+  /// data. Absorb it here instead.
+  static void leave() {
+    if (_depth > 0) _depth--;
+  }
 
-  /// Test seam — the flag is static, so a test that raises it must be able to
+  /// Test seam — the count is static, so a test that raises it must be able to
   /// put it back even if it fails.
-  static void resetForTest() => _active = false;
+  static void resetForTest() => _depth = 0;
 }

--- a/lib/sync/reset_gate.dart
+++ b/lib/sync/reset_gate.dart
@@ -1,0 +1,58 @@
+// reset_gate.dart — ONE process-wide "delete everything is running" flag.
+//
+// `AppState.resetAllData()` wipes the database but leaves the strap CONNECTED:
+// its own documented order puts `signOut` — and the `unpair` inside it — LAST,
+// because that flips the route and unwinds the UI. So records keep arriving
+// across the wipe, and one that lands after it is written into the fresh
+// database: the deleted installation, back again.
+//
+// AppState guards its own two ingest callbacks. It cannot guard the OTHER
+// engine — `runHeadlessSync` (background_sync.dart) builds a second BleEngine
+// whose callbacks go straight to LocalDb, with no AppState anywhere in scope.
+// A drain already in flight when the user confirms the reset therefore keeps
+// writing. Narrow, because a foreground engine PREEMPTS a background drainer
+// when it connects (`BleEngine._claimBand`) and AppState connects on launch —
+// but nothing in the reset itself closes it, and "deleted data comes back" is
+// not a failure to leave resting on an incidental ordering.
+//
+// A STATIC is the right mechanism here, and only because there is no second
+// isolate to hide from it. Every headless entry point runs in the MAIN isolate:
+//   - Android post-boot — EdgeApplication.onCreate pre-warms the FlutterEngine
+//     and runs `main()` with no Activity (headless_boot.dart)
+//   - iOS CoreBluetooth restore wake (ios_ble_restore.dart)
+//   - iOS BGProcessingTask / BGAppRefreshTask (ios_bg_task.dart)
+// and the WorkManager tasks that DID run on their own isolate were pulled for
+// exactly that reason — `main()` still cancels them by unique name on every
+// Android start (main.dart), and nothing registers a `callbackDispatcher`.
+// `HeadlessSyncGate` is already built on the same assumption.
+//
+// IF A BACKGROUND ISOLATE IS EVER REINTRODUCED, this flag stops working and
+// stops working SILENTLY — statics are per-isolate. It would then have to move
+// to something both isolates can see (a `sync_cursor` row, a pref read per
+// batch). Said here rather than discovered later.
+library;
+
+/// Process-wide: is "delete everything" running right now?
+///
+/// Every path that writes band data consults this before it writes. Refusing
+/// costs nothing — none of these records have been ACKed, so they are still on
+/// the band and arrive on the next sync.
+class ResetGate {
+  ResetGate._();
+
+  static bool _active = false;
+
+  /// True from the moment a reset starts until it finishes (or throws).
+  static bool get active => _active;
+
+  /// Raise before the wipe. Pair with [leave] in a `finally`: a half-reset
+  /// install that silently drops every record is worse than the race this
+  /// closes.
+  static void enter() => _active = true;
+
+  static void leave() => _active = false;
+
+  /// Test seam — the flag is static, so a test that raises it must be able to
+  /// put it back even if it fails.
+  static void resetForTest() => _active = false;
+}

--- a/lib/ui2/screens/home_screen.dart
+++ b/lib/ui2/screens/home_screen.dart
@@ -41,6 +41,7 @@ import '../../state/app_state.dart';
 import '../../state/units_controller.dart';
 import '../../theme/theme_switcher.dart' show themedRoute;
 import '../activity/day_strain.dart' show DayStrainDetail;
+import '../profile/devices.dart' show formatDayTime;
 import '../profile/profile.dart';
 import '../ui2.dart';
 import 'coach.dart';
@@ -143,6 +144,64 @@ bool syncingNowOf(BuildContext c) {
 
 /// Whether a derive job is running or about to (the backlog just landed and
 /// today's numbers are being worked out), or false in a golden.
+/// How far the data we hold actually reaches — the band's OWN clock on the
+/// newest record BANKED, not when the BLE frame arrived and not when the app
+/// last talked to the strap. Null in a golden and before any record exists.
+///
+/// `select`, like its neighbours: this rebuilds when the data edge moves, not
+/// on AppState's ~1 Hz heartbeat.
+DateTime? lastDataAtOf(BuildContext c) {
+  try {
+    return c.select<AppState, DateTime?>((a) => a.lastRecordAt);
+  } catch (_) {
+    return null;
+  }
+}
+
+/// "Synced through 11:06" — the one line that answers "how far are we?".
+///
+/// It reads the BAND's clock, so it says how far the DATA reaches. That is a
+/// different number from "last contact" and only this one is the question a
+/// sync status has to answer: a connection that transfers nothing is not
+/// progress, and a status built on contact time would report it as progress.
+///
+/// [todayId] is the `YYYY-MM-DD` the screen is ALREADY showing, not
+/// `DateTime.now()`. A clock read during `build` decides "is this today?" once
+/// and then goes stale — sitting on Home across midnight with no new record,
+/// last night's 23:50 would keep rendering as a bare "23:50" and read as
+/// tonight. Keying off the rendered day cannot contradict the date line
+/// directly above it, whatever the hour. Null (no day on screen yet) ⇒ always
+/// dated, which is the honest answer when we do not know what "today" is.
+///
+/// Bare `HH:mm` for the day on screen, the full "Fri 4 Sep, 07:12" otherwise —
+/// a lone "07:12" against a strap not worn since Friday is the most misleading
+/// thing this line could say.
+String syncedThroughLabel(DateTime? at, String? todayId,
+    [AppLocalizations? l]) {
+  if (at == null) return l?.homeSyncedNever ?? 'No band data yet';
+  final today = todayId == null ? null : DateTime.tryParse(todayId);
+  final isToday = today != null &&
+      at.year == today.year &&
+      at.month == today.month &&
+      at.day == today.day;
+  final when = isToday
+      ? '${at.hour.toString().padLeft(2, '0')}:'
+          '${at.minute.toString().padLeft(2, '0')}'
+      : formatDayTime(at, l);
+  return l?.homeSyncedThrough(when) ?? 'Synced through $when';
+}
+
+/// The status line as Home renders it, so the loading / failed / bare paths
+/// show it too. It answers "how far are we?", and the moment that question is
+/// loudest is the one where there is no day to show.
+Widget syncedThroughLine(BuildContext c, String? todayId,
+    [AppLocalizations? l]) {
+  return Text(
+    syncedThroughLabel(lastDataAtOf(c), todayId, l),
+    style: F.cap.copyWith(color: P.of(c).ink3),
+  );
+}
+
 bool derivingOf(BuildContext c) {
   try {
     return c.select<AppState, bool>((a) => a.deriving || a.derivePending);
@@ -1404,6 +1463,12 @@ class _HomeScreenState extends State<HomeScreen> with RevisionReload {
     if (d == null) {
       return _refreshable(ListView(padding: pad, children: [
         const SizedBox(height: S.x8),
+        // No day on screen ⇒ no `todayId`, so this renders the dated form.
+        // Shown here TOO: a first run, a failed read and a sync in flight are
+        // exactly when "how far are we?" is worth answering, and the header
+        // this line normally sits under does not exist on this path.
+        Align(alignment: Alignment.centerLeft, child: syncedThroughLine(c, null, l)),
+        const SizedBox(height: S.x3),
         if (_loading)
           const Center(child: CircularProgressIndicator())
         else if (_failed)
@@ -1491,6 +1556,10 @@ class _HomeScreenState extends State<HomeScreen> with RevisionReload {
               ]),
               const SizedBox(height: 2),
               Text(prettyDay(d.dayId, l), style: F.cap.copyWith(color: p.ink3)),
+              // How far the band's data reaches, always — the question "am I
+              // looking at today, or at last night?" used to be answerable
+              // only by opening Profile > Devices.
+              syncedThroughLine(c, d.dayId, l),
             ]),
           ),
           const SizedBox(width: S.x3),

--- a/test/beat_axis_consumer_contract_test.dart
+++ b/test/beat_axis_consumer_contract_test.dart
@@ -1,0 +1,119 @@
+// The contract edge owes analytics: the beat axis it hands over ascends.
+//
+// `cardioStager` binary-searches `rrTsMs` and asserts it is non-decreasing.
+// Its own comment claims "the producer guarantees it — beats inherit their
+// record's second and the records are sorted", and that guarantee stopped
+// being true the day edge started placing beats at their MODELLED sub-second
+// position instead of the record's whole second. One overlapping pair took
+// the whole night's staging down.
+//
+// So this drives the real entry point rather than re-asserting our own array:
+// a unit test on `Substrate.rrTsMs` alone cannot notice if analytics tightens
+// what it needs. Note the assert is compiled out in release — under
+// `flutter test` it is live, which is exactly why this test can see it.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_analytics/onehz.dart';
+import 'package:openstrap_edge/compute/derive_prepare.dart';
+import 'package:openstrap_edge/compute/substrate.dart';
+
+const _t0 = 1788786610;
+
+Map<String, dynamic> _frame(int recTs) => {
+  'rec_ts': recTs,
+  'hr': 58,
+  'ax': 0.0,
+  'ay': 0.0,
+  'az': 1.0,
+  'device_family': 'gen5',
+};
+
+/// A window of records whose sub-second anchors drift the way a real 32 kHz
+/// RTC does — and therefore overlap at the seams, since each record's beats
+/// are walked BACKWARDS from its own anchor.
+({List<Map<String, dynamic>> frames, List<Map<String, dynamic>> beats}) _night(
+  int seconds,
+) {
+  final frames = <Map<String, dynamic>>[];
+  final beats = <Map<String, dynamic>>[];
+  for (var s = 0; s < seconds; s++) {
+    final recTs = _t0 + s;
+    frames.add(_frame(recTs));
+    // Anchor drift that wraps — at the wrap the next record's first beat lands
+    // BEFORE this record's last, which is the real defect.
+    final anchorMs = recTs * 1000 + (s * 37) % 1000;
+    final rrLate = 900 + (s % 5) * 10;
+    final rrEarly = 920 + (s % 3) * 10;
+    beats.add({
+      'rec_ts': recTs,
+      'beat_index': 0,
+      'rr_ts_ms': recTs * 1000,
+      'rr_ms': rrEarly,
+      'beat_ts_ms': anchorMs - rrLate,
+    });
+    beats.add({
+      'rec_ts': recTs,
+      'beat_index': 1,
+      'rr_ts_ms': recTs * 1000,
+      'rr_ms': rrLate,
+      'beat_ts_ms': anchorMs,
+    });
+  }
+  return (frames: frames, beats: beats);
+}
+
+void main() {
+  test('the fixture really does invert — otherwise this test proves nothing',
+      () {
+    final n = _night(120);
+    // The raw modelled placements, before any repair.
+    final raw = [
+      for (final b in n.beats) (b['beat_ts_ms'] as int).toDouble(),
+    ];
+    var inversions = 0;
+    for (var i = 1; i < raw.length; i++) {
+      if (raw[i] < raw[i - 1]) inversions++;
+    }
+    expect(inversions, greaterThan(0),
+        reason: 'the anchor drift must actually wrap within the window');
+  });
+
+  test('the substrate edge builds satisfies analytics without throwing', () {
+    final n = _night(120);
+    final sub = substrateFromDecodedPage(n.frames, n.beats);
+
+    // Pre-condition, stated the way analytics states it.
+    for (var i = 1; i < sub.rrTsMs.length; i++) {
+      expect(sub.rrTsMs[i], greaterThanOrEqualTo(sub.rrTsMs[i - 1]));
+    }
+
+    // The real consumer. This threw `Bad state: … rrTsMs must be
+    // non-decreasing` before the repair.
+    final accel = [
+      for (var i = 0; i < sub.tsSec.length; i++)
+        AccelSample(sub.tsSec[i] * 1000.0, 0.0, 0.0, 1.0),
+    ];
+    final hr = [for (final v in sub.hr) v.toDouble()];
+
+    expect(
+      () => cardioStager(hr, accel, rrMs: sub.rrMs, rrTsMs: sub.rrTsMs),
+      returnsNormally,
+    );
+  });
+
+  test('a tied axis is accepted too — the staircase fallback produces one', () {
+    // Every beat of a record on one millisecond: what `rr_ts_ms` gives when
+    // `beat_ts_ms` is NULL. Ties are not inversions and must not be "repaired"
+    // into something else.
+    final ts = <double>[1000, 1000, 1000, 2000, 2000];
+    final before = [...ts];
+    monotonizeBeatAxis(ts);
+    expect(ts, before, reason: 'ties are already non-decreasing');
+  });
+
+  test('the clamp moves only the offending beat, by only what it must', () {
+    final ts = <double>[0, 900, 100, 1000];
+    monotonizeBeatAxis(ts);
+    expect(ts, [0, 900, 900, 1000]);
+  });
+}

--- a/test/home_synced_through_test.dart
+++ b/test/home_synced_through_test.dart
@@ -1,0 +1,58 @@
+// "Synced through …" — the Home header's answer to "how far are we?".
+//
+// It reads the BAND's clock (the newest record banked), not when the app last
+// talked to the strap: a sync that connects, transfers nothing and disconnects
+// is not progress, and a status built on last contact would call it progress.
+//
+// "Today" is the day the SCREEN is showing, never `DateTime.now()` — a clock
+// read during build decides once and then goes stale across midnight.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/ui2/screens/home_screen.dart';
+
+void main() {
+  const today = '2026-09-08';
+
+  test('a record from today shows the bare time', () {
+    expect(
+      syncedThroughLabel(DateTime(2026, 9, 8, 11, 6), today),
+      'Synced through 11:06',
+    );
+  });
+
+  test('midnight pads to two digits rather than reading as 0:6', () {
+    expect(
+      syncedThroughLabel(DateTime(2026, 9, 8, 0, 6), today),
+      'Synced through 00:06',
+    );
+  });
+
+  test('an older record carries its day — a lone time would mislead', () {
+    // A strap last worn on Friday must not report "07:12" beside today's
+    // date and let it read as this morning.
+    expect(
+      syncedThroughLabel(DateTime(2026, 9, 4, 7, 12), today),
+      'Synced through Fri 4 Sep, 07:12',
+    );
+  });
+
+  test('same clock time on another day is still dated', () {
+    expect(
+      syncedThroughLabel(DateTime(2026, 9, 7, 11, 6), today),
+      isNot('Synced through 11:06'),
+    );
+  });
+
+  test('with no day on screen, even a same-day record is dated', () {
+    // The loading / failed / first-run path has no day label. Without one,
+    // "today" is not a thing we know, so the honest render is the dated form.
+    expect(
+      syncedThroughLabel(DateTime(2026, 9, 8, 11, 6), null),
+      'Synced through Tue 8 Sep, 11:06',
+    );
+  });
+
+  test('nothing banked says so plainly', () {
+    expect(syncedThroughLabel(null, today), 'No band data yet');
+  });
+}

--- a/test/reset_quiesces_ingest_test.dart
+++ b/test/reset_quiesces_ingest_test.dart
@@ -1,0 +1,83 @@
+// "Delete everything" must not be repopulated by the band it is deleting.
+//
+// `resetAllData()` wipes the database but leaves the strap CONNECTED — its own
+// documented order puts `signOut` (and the `unpair` inside it) LAST, because
+// that flips the route and unwinds the UI. So the band keeps handing over
+// historical records straight across the wipe, and one that lands after it is
+// written into the fresh database and re-advertised as the data edge: the
+// deleted installation, visible again on Home, with nothing left to explain it.
+//
+// `AppState._resetting` is the refusal flag that closes that window. It is
+// private, and `resetAllData` needs the whole plugin stack (preferences,
+// notifications, widget, telemetry, keychain) to run at all, so there is no
+// behavioural test to write here. This greps instead — the same approach, and
+// for the same reason, as `link_priority_structural_test.dart` and
+// `no_debug_only_apis_test.dart`: the failure mode is a NEW ingest path added
+// later that simply forgets the guard, which no test that runs the code can
+// see.
+//
+// What is pinned:
+//   1. every record-ingest callback AppState hands the engine checks
+//      `_resetting` before it writes
+//   2. `resetAllData` raises the flag, and lowers it in a `finally` (a
+//      half-reset install that silently drops every record is worse than the
+//      race it was closing)
+//   3. `LocalDb.insertRecordsBatch` is not passed as a bare tear-off anywhere
+//      in AppState — that is exactly how the drain path bypassed the guard
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final src = File('lib/state/app_state.dart').readAsStringSync();
+
+  test('both ingest callbacks refuse while a reset is in flight', () {
+    // The singles path.
+    final onRecord = RegExp(
+      r'Future<void> _onRecord\([^)]*\) async \{\s*\n\s*if \(_resetting\) return;',
+    );
+    expect(onRecord.hasMatch(src), isTrue,
+        reason: '_onRecord must refuse before it writes');
+
+    // The drain path, which is wired straight to LocalDb and so bypasses every
+    // check AppState makes unless the closure carries one itself.
+    final batch = RegExp(
+      r'onRecordsBatch: \([^)]*\) async \{\s*\n\s*if \(_resetting\) return;',
+    );
+    expect(batch.hasMatch(src), isTrue,
+        reason: 'onRecordsBatch must refuse before it writes');
+  });
+
+  test('insertRecordsBatch is never handed over as a bare tear-off', () {
+    // `onRecordsBatch: LocalDb.insertRecordsBatch` is the shape of the bug:
+    // it hands the database straight to the engine with nothing in between.
+    expect(
+      src.contains('onRecordsBatch: LocalDb.insertRecordsBatch'),
+      isFalse,
+      reason: 'wrap it in a closure that checks _resetting',
+    );
+  });
+
+  test('resetAllData raises the flag and always lowers it', () {
+    final body = src.substring(src.indexOf('Future<void> resetAllData() async'));
+    final raise = body.indexOf('_resetting = true;');
+    final wipe = body.indexOf('LocalDb.wipeAll()');
+    final lower = body.indexOf('_resetting = false;');
+    final fin = body.indexOf('} finally {');
+
+    expect(raise, greaterThanOrEqualTo(0), reason: 'the flag must be raised');
+    expect(raise, lessThan(wipe),
+        reason: 'raised BEFORE the wipe, or the window it closes is still open');
+    expect(fin, greaterThanOrEqualTo(0), reason: 'lowering must be in a finally');
+    expect(fin, lessThan(lower), reason: 'lowered inside that finally');
+  });
+
+  test('the data edge is cleared by the reset, not left in memory', () {
+    final body = src.substring(src.indexOf('Future<void> resetAllData() async'));
+    final end = body.indexOf('} finally {');
+    final scope = body.substring(0, end);
+    expect(scope.contains('_lastRecTs = null;'), isTrue);
+    expect(scope.contains('lastSynced = null;'), isTrue);
+  });
+}

--- a/test/reset_quiesces_ingest_test.dart
+++ b/test/reset_quiesces_ingest_test.dart
@@ -28,9 +28,11 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/sync/reset_gate.dart';
 
 void main() {
   final src = File('lib/state/app_state.dart').readAsStringSync();
+  final bg = File('lib/sync/background_sync.dart').readAsStringSync();
 
   test('both ingest callbacks refuse while a reset is in flight', () {
     // The singles path.
@@ -61,9 +63,9 @@ void main() {
 
   test('resetAllData raises the flag and always lowers it', () {
     final body = src.substring(src.indexOf('Future<void> resetAllData() async'));
-    final raise = body.indexOf('_resetting = true;');
+    final raise = body.indexOf('ResetGate.enter();');
     final wipe = body.indexOf('LocalDb.wipeAll()');
-    final lower = body.indexOf('_resetting = false;');
+    final lower = body.indexOf('ResetGate.leave();');
     final fin = body.indexOf('} finally {');
 
     expect(raise, greaterThanOrEqualTo(0), reason: 'the flag must be raised');
@@ -79,5 +81,71 @@ void main() {
     final scope = body.substring(0, end);
     expect(scope.contains('_lastRecTs = null;'), isTrue);
     expect(scope.contains('lastSynced = null;'), isTrue);
+  });
+
+  // ── the OTHER engine ──────────────────────────────────────────────────────
+  //
+  // `runHeadlessSync` builds its own BleEngine with callbacks wired straight to
+  // LocalDb and no AppState in scope, so nothing AppState guards reaches it.
+  // Same isolate (see reset_gate.dart), so one static covers both.
+
+  test('the headless drain refuses to start while a reset is running', () {
+    expect(bg.contains('if (ResetGate.active) {'), isTrue,
+        reason: 'runHeadlessSync must bail before it drains');
+    // Ahead of PairedDevice.load(), which is the only thing standing between a
+    // reset and a fresh drain today — and only by accident, via prefs.clear().
+    // The real CALL, not the mention of it in the comment above the guard.
+    expect(bg.indexOf('ResetGate.active'),
+        lessThan(bg.indexOf('final paired = await PairedDevice.load();')));
+  });
+
+  test('every headless write path is gated', () {
+    for (final cb in ['onRecord:', 'onEvent:', 'onRecordsBatch:',
+                      'onArchiveRecord:', 'onCommitBatch:']) {
+      final at = bg.indexOf(cb);
+      expect(at, greaterThanOrEqualTo(0), reason: '$cb not found');
+      // Slice to the NEXT callback at the same indent, so a guard belonging to
+      // a neighbour can never be mistaken for this one's.
+      final next = bg.indexOf('\n      on', at + cb.length);
+      final window = bg.substring(at, next < 0 ? bg.length : next);
+      expect(window.contains('ResetGate.active'), isTrue,
+          reason: '$cb writes without consulting ResetGate');
+    }
+  });
+
+  test('no write sink is handed over as a bare LocalDb tear-off', () {
+    // This shape — the database passed straight to the engine with nothing in
+    // between — is exactly how the guard was bypassed.
+    for (final bare in [
+      'onRecord: (sample, raw) => LocalDb.insertRecord',
+      'onRecordsBatch: LocalDb.insertRecordsBatch',
+      'onArchiveRecord: LocalDb.archiveRawRecord',
+    ]) {
+      expect(bg.contains(bare), isFalse, reason: 'bare tear-off: $bare');
+      expect(src.contains(bare), isFalse, reason: 'bare tear-off: $bare');
+    }
+  });
+
+  test('the ACK-bearing commit THROWS rather than silently succeeding', () {
+    // Only `onCommit` can bank raws + archives + trim cursor in one
+    // transaction, and DrainController reads durability from a throw. A quiet
+    // return would ACK and let the band trim flash that was never stored —
+    // a race turned into real data loss.
+    for (final f in [src, bg]) {
+      final at = f.indexOf('onCommitBatch:');
+      final window = f.substring(at, at + 900);
+      expect(window.contains('ResetGate.active'), isTrue);
+      expect(window.contains('throw StateError'), isTrue,
+          reason: 'the commit gate must throw, not return');
+    }
+  });
+
+  test('the gate is a plain latch — enter, leave, and it stays put', () {
+    addTearDown(ResetGate.resetForTest);
+    expect(ResetGate.active, isFalse);
+    ResetGate.enter();
+    expect(ResetGate.active, isTrue);
+    ResetGate.leave();
+    expect(ResetGate.active, isFalse);
   });
 }

--- a/test/reset_quiesces_ingest_test.dart
+++ b/test/reset_quiesces_ingest_test.dart
@@ -140,12 +140,36 @@ void main() {
     }
   });
 
-  test('the gate is a plain latch — enter, leave, and it stays put', () {
+  test('the gate opens on enter and shuts on leave', () {
     addTearDown(ResetGate.resetForTest);
     expect(ResetGate.active, isFalse);
     ResetGate.enter();
     expect(ResetGate.active, isTrue);
     ResetGate.leave();
     expect(ResetGate.active, isFalse);
+  });
+
+  test('a second reset on top of the first does not reopen the window', () {
+    // `resetAllData()` is awaited but does not block the UI, so a user can
+    // confirm a second wipe while the first is still running. A bare bool let
+    // the first to finish lower the flag mid-wipe.
+    addTearDown(ResetGate.resetForTest);
+    ResetGate.enter();
+    ResetGate.enter();
+    ResetGate.leave();
+    expect(ResetGate.active, isTrue,
+        reason: 'the second reset is still wiping');
+    ResetGate.leave();
+    expect(ResetGate.active, isFalse);
+  });
+
+  test('an unbalanced leave cannot drive the gate below shut', () {
+    // A count below zero would make the NEXT reset's enter() fail to open the
+    // gate — the failure mode that loses data.
+    addTearDown(ResetGate.resetForTest);
+    ResetGate.leave();
+    ResetGate.leave();
+    ResetGate.enter();
+    expect(ResetGate.active, isTrue);
   });
 }

--- a/test/substrate_beat_monotonic_test.dart
+++ b/test/substrate_beat_monotonic_test.dart
@@ -1,0 +1,106 @@
+// The beat time axis handed to analytics must be non-decreasing.
+//
+// `beat_ts_ms` places each beat where the strap's sub-second anchor says it
+// was: the anchor is the record's END and the intervals are walked BACKWARDS
+// from it. Two adjacent records whose anchors drift apart by less than one
+// beat therefore overlap — record N+1's beat 0 lands a few hundred ms BEFORE
+// record N's last beat — and `_PrepareAccumulator` emitted the pair in record
+// order, so the axis stepped backwards.
+//
+// Analytics binary-searches the beat window and asserts the axis is
+// non-decreasing, so every such day threw out of the sleep-staging isolate and
+// derived nothing. Observed on a real install: 94 inversions across 39,066
+// beats in one day, every one of them at `beat_index = 0`, by 7-672 ms.
+//
+// The repair is a CLAMP, not a sort. Beats arrive in the order the strap
+// detected them and that order is the rhythm — `beat_clock_read_path_test`
+// pins it — so it is the reconstructed placement that gets corrected, by the
+// least it can be, and never the interval series.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openstrap_edge/compute/derive_prepare.dart';
+
+const _t0 = 1788786610;
+
+Map<String, dynamic> _frame(int recTs) => {
+  'rec_ts': recTs,
+  'hr': 60,
+  'ax': 0.0,
+  'ay': 0.0,
+  'az': 1.0,
+  'device_family': 'gen5',
+};
+
+Map<String, dynamic> _beat(int recTs, int index, int rrMs, int beatTsMs) => {
+  'rec_ts': recTs,
+  'beat_index': index,
+  'rr_ts_ms': recTs * 1000,
+  'rr_ms': rrMs,
+  'beat_ts_ms': beatTsMs,
+};
+
+void main() {
+  test('overlapping record anchors do not step the beat axis backwards', () {
+    // Record 0's last beat sits at .969; record 1's anchor drifted earlier, so
+    // its first beat lands at .961 — 8 ms BEFORE it. Exactly the shape seen on
+    // the wire (rec_ts 1788786611, beat 0, delta -8 ms).
+    final frames = [_frame(_t0), _frame(_t0 + 1)];
+    final beats = [
+      _beat(_t0, 0, 900, _t0 * 1000 + 69),
+      _beat(_t0, 1, 900, _t0 * 1000 + 969),
+      _beat(_t0 + 1, 0, 935, _t0 * 1000 + 961),
+      _beat(_t0 + 1, 1, 900, _t0 * 1000 + 1861),
+    ];
+
+    final sub = substrateFromDecodedPage(frames, beats);
+
+    expect(sub.rrTsMs.length, 4);
+    for (var i = 1; i < sub.rrTsMs.length; i++) {
+      expect(
+        sub.rrTsMs[i],
+        greaterThanOrEqualTo(sub.rrTsMs[i - 1]),
+        reason: 'beat axis stepped backwards at $i: ${sub.rrTsMs}',
+      );
+    }
+    // The overlapping beat is HELD at its predecessor, not moved past it, and
+    // every other beat keeps the placement the strap measured.
+    expect(sub.rrTsMs, [
+      _t0 * 1000 + 69,
+      _t0 * 1000 + 969,
+      _t0 * 1000 + 969,
+      _t0 * 1000 + 1861,
+    ]);
+    // The interval series is untouched — same values, SAME ORDER.
+    expect(sub.rrMs, [900, 900, 935, 900]);
+  });
+
+  test('an already-ordered page keeps its exact emission order', () {
+    final frames = [_frame(_t0), _frame(_t0 + 1)];
+    final beats = [
+      _beat(_t0, 0, 900, _t0 * 1000 + 69),
+      _beat(_t0, 1, 901, _t0 * 1000 + 969),
+      _beat(_t0 + 1, 0, 902, _t0 * 1000 + 1069),
+      _beat(_t0 + 1, 1, 903, _t0 * 1000 + 1969),
+    ];
+
+    final sub = substrateFromDecodedPage(frames, beats);
+
+    expect(sub.rrMs, [900, 901, 902, 903]);
+  });
+
+  test('beats sharing one timestamp keep their emission order', () {
+    // The staircase fallback (`rr_ts_ms`, whole seconds) puts every beat in a
+    // record on one millisecond. Ties must not be reshuffled — the interval
+    // series is the physiological signal and its order is the rhythm.
+    final frames = [_frame(_t0)];
+    final beats = [
+      {'rec_ts': _t0, 'beat_index': 0, 'rr_ts_ms': _t0 * 1000, 'rr_ms': 811},
+      {'rec_ts': _t0, 'beat_index': 1, 'rr_ts_ms': _t0 * 1000, 'rr_ms': 822},
+      {'rec_ts': _t0, 'beat_index': 2, 'rr_ts_ms': _t0 * 1000, 'rr_ms': 833},
+    ];
+
+    final sub = substrateFromDecodedPage(frames, beats);
+
+    expect(sub.rrMs, [811, 822, 833]);
+  });
+}


### PR DESCRIPTION
## What broke

`beat_ts_ms` is a **modelled** beat position. `beatTimesMs` anchors on the record's sub-second stamp — under the model that the record's *last* beat sits at that stamp — then walks the intervals backwards from it. When two adjacent records' anchors sit closer together than one beat, the model places record N+1's beat 0 **earlier** than record N's last beat. Beats are emitted in record order, so the axis steps backwards.

Measured on a live install, one day's derive window:

| beats | inversions | where | by |
|---|---|---|---|
| 39,066 | 94 | every one at `beat_index = 0` | 7–672 ms |

`cardioStager` binary-searches that axis and asserts it ascends. One inverted pair takes the whole night down:

```
derive day 2026-09-08 FAILED/skipped: Bad state: sleep-staging isolate failed:
'rrTsMs must be non-decreasing — the beat window is binary-searched'
```

Six of eight days in the pending span threw on **every** pass. The newest day that survived was the previous night, so the app sat on *"Crunching last night's numbers"* and tapping Sync again looked like the only lever. The BLE offload was healthy the whole time — `OFFLOAD SUMMARY: complete=true`, reaching the live edge every pass. The sync was never the problem.

## Why `kAlgoVersion` moves

The assert is **compiled out in release**. Shipped builds never threw — they mis-selected each 300 s window's beats and banked the result, which is the worse of the two failures. Those days cannot be told apart from good ones after the fact, and `finalizedDayIds` / `sleepSessionCandidate` both key on the version, so without a bump they are served from cache forever. 87 → 88; `kAnalyticsPin`/`kProtocolPin` unchanged, the repair is entirely edge-side.

## Why a clamp and not a sort

**The order is not what is wrong.** Beats arrive in the order the strap detected them, and that order *is* the rhythm — `beat_clock_read_path_test` pins it as the contract it is. The first attempt at this sorted the `(rrTsMs, rrMs)` pair and that test correctly killed it.

So `monotonizeBeatAxis` repairs only the modelled *placement*, holding each beat no earlier than the one before it. Interval values and their order are untouched. A held beat lands on a zero-length gap, which the axis already contains — the `rr_ts_ms` staircase ties a whole record's beats to one millisecond — and which analytics' window gather is explicitly written for (its lower bound is inclusive so tied beats are not dropped). Verified against the consumers: RMSSD is computed from interval *values*, and the Lomb–Scargle denominators are guarded.

Called on both paths into `Substrate.rrTsMs`: at the end of `decodeSubstrate`, and at the page seam in `buildSubstrate()` — a seam is invisible to either page loader, since each places its own beats correctly and then appends.

## Also: "Synced through 11:06" on Home

The data edge was only readable from Profile › Devices, so there was no way to see how far a sync had actually got. It reads the band's own clock on the newest record **banked**, not last contact — a connection that transfers nothing is not progress and must not render as progress.

"Today" is the day the screen is **already showing** rather than `DateTime.now()`, so it cannot contradict the date line directly above it after midnight, and needs no timer. It renders on the loading / failed / first-run path too, which is when the question is loudest.

Two fixes fall out of putting that value on screen, both pre-existing:

- `_onRecord` advanced `_lastRecTs` *before* awaiting the insert. The field only moves forward, so a failed write advertised a record the database does not hold — for the rest of the process.
- `resetAllData()` wiped the database but left `_lastRecTs` set, so a re-pair without a relaunch showed the deleted install's timestamp.

## Tests

`test/beat_axis_consumer_contract_test.dart` drives the **real** `cardioStager` over a 120-record fixture whose anchor drift genuinely wraps — with a guard test asserting the fixture actually inverts, so it cannot quietly stop testing anything. Plus unit coverage for the clamp and the Home formatter.

Verified the tests fail without the repair: **3 failures, including the real assertion**. Full suite on this branch: **3673 passed, 446 skipped, 0 failed**.

## Summary by Sourcery

Repair beat-axis ordering, recompute affected analytics with algorithm version 88, expose the banked sync edge on Home, and quiesce ingest while deleting data.

New Features:
- Display the banked data edge on Home with a contextual “Synced through …” status for loading, failed, first-run, and normal states.

Bug Fixes:
- Keep modelled beat timestamps non-decreasing without changing beat order or interval values, preventing analytics window-selection failures and silent release mis-selection.
- Prevent record-ingest and acknowledgements from repopulating the database during data resets, including foreground and headless sync paths.
- Ensure the Home data-edge status advances only after successful persistence and is cleared during reset.

Enhancements:
- Bump the algorithm version from 87 to 88 so affected derived days are recomputed instead of served from cache.
- Add a process-wide, nested reset gate covering all database write paths and preserving safe band retry behavior when commits are refused.

Tests:
- Add consumer-level and unit coverage for beat-axis monotonicity, preserving interval order, Home sync formatting, and reset-ingest quiescence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Home screen status showing how far band data has synced, including support for days with no received data.

- **Bug Fixes**
  - Corrected beat timing order to improve analytics window selection.
  - Recalculated affected days to reflect corrected results.
  - Resetting app data now clears outdated sync information and temporarily pauses incoming records, including background sync.
  - Sync status no longer advances when saving a record fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->